### PR TITLE
Add Claude Code session ingestion and computed model pricing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 node_modules/
 .deno/
+.env

--- a/README.md
+++ b/README.md
@@ -15,7 +15,9 @@ Open `http://localhost:5273`. The API reads
 
 Set `OPENCODE_DB_PATH` to use a different database or `PORT` to change the API
 port. If the API port changes during development, update the proxy target in
-`vite.config.ts` as well.
+`vite.config.ts` as well. `CLAUDE_CODE_PROJECT_PATH` must point to one Claude
+Code project directory containing its session JSONL files. Local development
+loads this value from the ignored `.env` file.
 
 ## Production Build
 

--- a/deno.json
+++ b/deno.json
@@ -28,10 +28,10 @@
   },
   "tasks": {
     "dev": "deno run -A npm:concurrently@10.0.3 --kill-others-on-fail --names api,web 'deno task dev:server' 'deno task dev:client'",
-    "dev:server": "deno run --allow-env=HOME,OPENCODE_DB_PATH,PORT --allow-read --allow-net --watch=src/server,src/shared src/server/main.ts",
+    "dev:server": "deno run --env-file=.env --allow-env=HOME,OPENCODE_DB_PATH,CLAUDE_CODE_PROJECT_PATH,PORT --allow-read --allow-net --watch=src/server,src/shared src/server/main.ts",
     "dev:client": "deno run -A npm:vite@8.1.4",
     "build": "deno run -A npm:vite@8.1.4 build",
-    "start": "deno run --allow-env=HOME,OPENCODE_DB_PATH,PORT --allow-read --allow-net src/server/main.ts",
+    "start": "deno run --env-file=.env --allow-env=HOME,OPENCODE_DB_PATH,CLAUDE_CODE_PROJECT_PATH,PORT --allow-read --allow-net src/server/main.ts",
     "check": "deno check src/server/main.ts src/client/main.tsx vite.config.ts",
     "test": "deno test --allow-env --allow-read --allow-write"
   }

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -81,11 +81,12 @@ tokens.reasoning
 cost
 ```
 
-Frugal Tokens currently derives:
+Frugal Tokens currently derives these internal fields, displayed as New input
+and Total activity:
 
 ```text
-fresh prompt = input + reported cache write
-processed = input + cache read + cache write + output + reasoning
+freshPrompt (New input) = input + reported cache write
+processed (Total activity) = input + cache read + cache write + output + reasoning
 ```
 
 Interpret these as reported billing categories, not globally unique text.
@@ -141,6 +142,80 @@ commands, and tool outputs should be treated as sensitive user data.
 - Reference fixture: `ses_0b8d314b5ffeBwIBzZmNhmoVCi` (3 turns, 5 calls,
   `$0.4861795` reported)
 - Subagent fixture: `ses_0b155ab5affer9adyuA3Gg2Br8`
+
+## Claude Code
+
+### Source
+
+- Format: JSONL transcripts and optional JSON metadata
+- Frugal Tokens path: required `CLAUDE_CODE_PROJECT_PATH` environment variable
+- Normal default: `~/.claude/projects/<encoded-cwd>`
+- Version observed: Claude Code 2.1.202
+- Access: read-only
+
+Each top-level `<session-id>.jsonl` is a session. Use the latest timestamp in
+the transcript for session activity and ordering; copied-file modification
+times are not authoritative. Assistant records sharing a `message.id` are
+streaming fragments of one model call: merge their distinct content blocks and
+count their usage once. Keeping only the last fragment can lose text or tool
+activity.
+
+A turn starts at a human or typed prompt, an SDK prompt, a rendered `❯ ...`
+command prompt, or the initial prompt in a sidechain transcript. Metadata and
+intermediate local-command records, including `isMeta`, `<command-name>`,
+`<local-command-stdout>`, and command caveats, do not start turns. Tool-result
+user records remain in the current turn. SDK sessions are regular sessions,
+not subagents.
+
+Assistant content blocks map `text`, `thinking`, and `tool_use` to call
+activity. A later user `tool_result` block supplies completion/error status.
+Agent results expose an `agentId`, which links to
+`<session-id>/subagents/agent-<agentId>.jsonl`; the matching `.meta.json`
+provides the description and parent tool-use ID.
+
+Model identity is recorded per call. Commands such as `/model` can therefore
+produce sessions containing calls from multiple models. If Claude provides no
+generated title, use the first genuine prompt as the display-title fallback.
+
+Claude usage maps as follows:
+
+| Claude Code field | Frugal Tokens field |
+|---|---|
+| `input_tokens` | `uncachedInput` |
+| `cache_read_input_tokens` | `cacheRead` |
+| `cache_creation_input_tokens` | `cacheWrite` |
+| input plus cache creation | `freshPrompt` |
+| `output_tokens` | `output` |
+
+Current normalized-model gaps:
+
+- Thinking is included in Claude's output tokens, so `reasoning` remains zero;
+  `hasReasoning` still reflects the presence of a thinking content block.
+- Transcripts do not report dollar cost, so `reportedCost` remains absent.
+- Server-side web search/fetch billing units, turn duration, branch changes,
+  and structured tool payloads are not represented in the current shared
+  schema.
+
+The normalized model preserves aggregate, 5-minute, and 1-hour cache writes.
+Repositories do not compute prices. A separate pricing enrichment layer applies
+versioned model rate cards and emits `computedCost`; it leaves that field absent
+for unknown models or aggregate-only cache writes that cannot be classified by
+TTL. Reported and computed costs remain separate values.
+
+The bundled xAI Grok 4.5 rate card uses $2/M uncached input tokens, $0.50/M
+cache-read tokens, and $6/M output or reasoning tokens. OpenCode-reported cost
+remains available alongside the computed value for comparison.
+
+Bundled GPT rate cards currently cover the short-context tiers for the GPT 5.6
+Sol/Terra/Luna family, GPT 5.5 and 5.5 Pro, and GPT 5.4, Mini, Nano, and Pro.
+Calls with 272k or more input-side tokens remain unpriced until long-context
+pricing is implemented. A model without a published cache-write rate also
+remains unpriced when its source reports cache-write tokens.
+
+Pricing thresholds and model rates apply per model call. Session computed cost
+is the sum of its individually priced calls, never a price applied to aggregate
+session tokens. If any call cannot be priced, the session computed total remains
+absent rather than presenting a partial total.
 
 ## Adding A Harness
 

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -32,6 +32,12 @@ function TokenValue({ value }: { value: number }) {
   return <span title={integer.format(value)}>{compact.format(value)}</span>;
 }
 
+function cacheHitRate(tokens: SessionDetail["tokens"]) {
+  const input = tokens.uncachedInput + tokens.cacheRead +
+    (tokens.cacheWrite ?? 0);
+  return input === 0 ? undefined : tokens.cacheRead / input;
+}
+
 function duration(startedAt?: number, completedAt?: number) {
   if (startedAt === undefined || completedAt === undefined) return undefined;
   const milliseconds = completedAt - startedAt;
@@ -84,17 +90,23 @@ function SessionBreakdown({
                 {session.userTurns} {session.userTurns === 1 ? "turn" : "turns"}
               </span>
               <span>{session.modelCalls} calls</span>
-              <span>{dollars.format(session.reportedCost)}</span>
+              <span>
+                {session.reportedCost === undefined
+                  ? "-"
+                  : dollars.format(session.reportedCost)}
+              </span>
             </div>
           </div>
         )
         : (
           <div className="definition-note">
-            <strong>Fresh prompt</strong>{" "}
+            <strong>New input</strong>{" "}
             is uncached input plus reported cache writes.{" "}
-            <strong>Processed tokens</strong>{" "}
-            include fresh prompt, cache reads, output, and reasoning. A dash
-            means no cache write was reported.
+            <strong>Total activity</strong>{" "}
+            includes new input, cache reads, output, and reasoning. A dash means
+            no cache write was reported. <strong>Computed cost</strong>{" "}
+            uses the bundled rate card; a dash means pricing is unavailable or
+            the source token categories are incomplete.
           </div>
         )}
       {session.turns.map((turn) => (
@@ -117,13 +129,14 @@ function SessionBreakdown({
                       <th>Started</th>
                       <th>Activity</th>
                       <th>Model</th>
-                      <th>Fresh prompt</th>
+                      <th>New input</th>
                       <th>Cache read</th>
                       <th>Reported write</th>
                       <th>Output</th>
                       <th>Reasoning</th>
-                      <th>Processed</th>
+                      <th>Total activity</th>
                       <th>Cost</th>
+                      <th>Computed cost</th>
                     </tr>
                   </thead>
                   <tbody>
@@ -184,11 +197,20 @@ function SessionBreakdown({
                             <td>
                               <TokenValue value={call.tokens.processed} />
                             </td>
-                            <td>{dollars.format(call.reportedCost)}</td>
+                            <td>
+                              {call.reportedCost === undefined
+                                ? "-"
+                                : dollars.format(call.reportedCost)}
+                            </td>
+                            <td>
+                              {call.computedCost === undefined
+                                ? "-"
+                                : dollars.format(call.computedCost)}
+                            </td>
                           </tr>
                           {expanded && (
                             <tr className="activity-detail-row">
-                              <td colSpan={11}>
+                              <td colSpan={12}>
                                 <div className="activity-detail">
                                   <div className="activity-meta">
                                     <span className="activity-label">
@@ -329,7 +351,7 @@ function SessionBreakdown({
 }
 
 export function SessionsPage() {
-  const { page } = route.useSearch();
+  const { page, harness } = route.useSearch();
   const navigate = route.useNavigate();
   const [data, setData] = useState<SessionListResponse>();
   const [expandedID, setExpandedID] = useState<string>();
@@ -340,21 +362,22 @@ export function SessionsPage() {
     let active = true;
     setData(undefined);
     setError(undefined);
-    getSessions(page).then((result) => active && setData(result)).catch(
-      (reason) => {
-        if (active) {
-          setError(
-            reason instanceof Error
-              ? reason.message
-              : "Unable to load sessions",
-          );
-        }
-      },
-    );
+    getSessions(page, harness).then((result) => active && setData(result))
+      .catch(
+        (reason) => {
+          if (active) {
+            setError(
+              reason instanceof Error
+                ? reason.message
+                : "Unable to load sessions",
+            );
+          }
+        },
+      );
     return () => {
       active = false;
     };
-  }, [page]);
+  }, [page, harness]);
 
   async function toggleSession(id: string) {
     if (expandedID === id) {
@@ -364,7 +387,9 @@ export function SessionsPage() {
     setExpandedID(id);
     if (details[id]) return;
     try {
-      const detail = await getSession(id);
+      const summary = data?.items.find((session) => session.id === id);
+      if (!summary) return;
+      const detail = await getSession(id, summary.harness);
       setDetails((current) => ({ ...current, [id]: detail }));
     } catch (reason) {
       setExpandedID(undefined);
@@ -392,11 +417,30 @@ export function SessionsPage() {
             <h2>Recent sessions</h2>
             <p>Ordered by latest activity</p>
           </div>
-          {data && (
-            <span className="session-count">
-              {integer.format(data.pagination.totalItems)} sessions
-            </span>
-          )}
+          <div className="session-filters">
+            {data && (
+              <span className="session-count">
+                {integer.format(data.pagination.totalItems)} sessions
+              </span>
+            )}
+            <label>
+              <span>Harness</span>
+              <select
+                value={harness}
+                onChange={(event) =>
+                  navigate({
+                    search: {
+                      page: 1,
+                      harness: event.target.value as typeof harness,
+                    },
+                  })}
+              >
+                <option value="all">All</option>
+                <option value="claude-code">Claude Code</option>
+                <option value="opencode">OpenCode</option>
+              </select>
+            </label>
+          </div>
         </div>
         {error && <div className="error">{error}</div>}
         {!data && !error && (
@@ -412,9 +456,14 @@ export function SessionsPage() {
                     <th>Provider / model</th>
                     <th>Turns</th>
                     <th>Calls</th>
-                    <th>Fresh prompt</th>
-                    <th>Processed</th>
+                    <th>New input</th>
+                    <th title="Cache reads divided by all input-side tokens">
+                      Cache hit
+                    </th>
+                    <th>Generated</th>
+                    <th>Total activity</th>
                     <th>Reported cost</th>
+                    <th>Computed cost</th>
                     <th aria-label="Expand" />
                   </tr>
                 </thead>
@@ -431,6 +480,11 @@ export function SessionsPage() {
                         >
                           <td>
                             <strong>{session.title}</strong>
+                            <small className="activity-label">
+                              {session.harness === "claude-code"
+                                ? "CLAUDE CODE"
+                                : "OPENCODE"}
+                            </small>
                             <small className="session-id" title={session.id}>
                               {session.id}
                             </small>
@@ -450,9 +504,29 @@ export function SessionsPage() {
                             <TokenValue value={session.tokens.freshPrompt} />
                           </td>
                           <td>
+                            {cacheHitRate(session.tokens) === undefined
+                              ? "-"
+                              : `${(cacheHitRate(session.tokens)! * 100).toFixed(1)}%`}
+                          </td>
+                          <td>
+                            <TokenValue
+                              value={session.tokens.output +
+                                session.tokens.reasoning}
+                            />
+                          </td>
+                          <td>
                             <TokenValue value={session.tokens.processed} />
                           </td>
-                          <td>{dollars.format(session.reportedCost)}</td>
+                          <td>
+                            {session.reportedCost === undefined
+                              ? "-"
+                              : dollars.format(session.reportedCost)}
+                          </td>
+                          <td>
+                            {session.computedCost === undefined
+                              ? "-"
+                              : dollars.format(session.computedCost)}
+                          </td>
                           <td className="chevron">{expanded ? "−" : "+"}</td>
                         </tr>
                         {expanded && (
@@ -460,7 +534,7 @@ export function SessionsPage() {
                             className="detail-row"
                             key={`${session.id}-detail`}
                           >
-                            <td colSpan={8}>
+                            <td colSpan={11}>
                               {details[session.id]
                                 ? (
                                   <SessionBreakdown
@@ -485,7 +559,8 @@ export function SessionsPage() {
               <button
                 type="button"
                 disabled={page <= 1}
-                onClick={() => navigate({ search: { page: page - 1 } })}
+                onClick={() =>
+                  navigate({ search: { page: page - 1, harness } })}
               >
                 Previous
               </button>
@@ -493,7 +568,8 @@ export function SessionsPage() {
               <button
                 type="button"
                 disabled={page >= data.pagination.totalPages}
-                onClick={() => navigate({ search: { page: page + 1 } })}
+                onClick={() =>
+                  navigate({ search: { page: page + 1, harness } })}
               >
                 Next
               </button>

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -6,17 +6,21 @@ import {
 async function getJson(path: string) {
   const response = await fetch(path);
   if (!response.ok) throw new Error(`Request failed (${response.status})`);
+  const contentType = response.headers.get("content-type");
+  if (!contentType?.includes("application/json")) {
+    throw new Error(`API returned ${contentType ?? "unknown content"} for ${path}`);
+  }
   return response.json();
 }
 
-export async function getSessions(page: number) {
+export async function getSessions(page: number, harness: string) {
   return sessionListResponseSchema.parse(
-    await getJson(`/api/sessions?page=${page}&pageSize=10`),
+    await getJson(`/api/sessions?page=${page}&pageSize=10&harness=${harness}`),
   );
 }
 
-export async function getSession(id: string) {
+export async function getSession(id: string, harness: string) {
   return sessionDetailSchema.parse(
-    await getJson(`/api/sessions/${encodeURIComponent(id)}`),
+    await getJson(`/api/sessions/${encodeURIComponent(id)}?harness=${harness}`),
   );
 }

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -16,6 +16,7 @@ const indexRoute = createRoute({
   path: "/",
   validateSearch: z.object({
     page: z.coerce.number().int().positive().catch(1),
+    harness: z.enum(["all", "opencode", "claude-code"]).catch("all"),
   }),
   component: SessionsPage,
 });

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -88,6 +88,28 @@ h1 {
   border: 1px solid #aab9a7;
   padding: 6px 9px;
 }
+.session-filters {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+.session-filters label {
+  display: grid;
+  gap: 4px;
+  color: #767970;
+  font-family: "SFMono-Regular", Consolas, monospace;
+  font-size: 10px;
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+.session-filters select {
+  border: 1px solid #aab9a7;
+  border-radius: 0;
+  background: #fffdf8;
+  color: #263126;
+  padding: 6px 28px 6px 9px;
+  font: 12px "SFMono-Regular", Consolas, monospace;
+}
 .session-table-wrap,
 .call-table-wrap {
   overflow-x: auto;

--- a/src/server/claudeCodeRepository.ts
+++ b/src/server/claudeCodeRepository.ts
@@ -1,0 +1,377 @@
+import { z } from "zod";
+import {
+  type ModelCall,
+  sessionDetailSchema,
+  sessionListResponseSchema,
+  type SessionSummary,
+  type TokenUsage,
+} from "../shared/sessionSchemas.ts";
+
+const contentBlockSchema = z.object({
+  type: z.string(),
+  text: z.string().optional(),
+  thinking: z.string().optional(),
+  id: z.string().optional(),
+  name: z.string().optional(),
+  tool_use_id: z.string().optional(),
+  is_error: z.boolean().optional(),
+}).passthrough();
+
+const recordSchema = z.object({
+  type: z.string(),
+  uuid: z.string().optional(),
+  timestamp: z.string().optional(),
+  aiTitle: z.string().optional(),
+  isMeta: z.boolean().optional(),
+  isSidechain: z.boolean().optional(),
+  promptSource: z.string().optional(),
+  origin: z.object({ kind: z.string().optional() }).passthrough().optional(),
+  message: z.object({
+    id: z.string().optional(),
+    role: z.string().optional(),
+    model: z.string().optional(),
+    stop_reason: z.string().nullable().optional(),
+    content: z.union([z.string(), z.array(contentBlockSchema)]).optional(),
+    usage: z.object({
+      input_tokens: z.number().int().nonnegative().default(0),
+      cache_read_input_tokens: z.number().int().nonnegative().default(0),
+      cache_creation_input_tokens: z.number().int().nonnegative().default(0),
+      output_tokens: z.number().int().nonnegative().default(0),
+      cache_creation: z.object({
+        ephemeral_5m_input_tokens: z.number().int().nonnegative().default(0),
+        ephemeral_1h_input_tokens: z.number().int().nonnegative().default(0),
+      }).optional(),
+    }).optional(),
+  }).passthrough().optional(),
+  toolUseResult: z.object({
+    agentId: z.string().optional(),
+  }).passthrough().optional(),
+}).passthrough();
+
+type Record = z.infer<typeof recordSchema>;
+type IndexEntry = { summary?: string; firstPrompt?: string };
+
+const emptyTokens = (): TokenUsage => ({
+  uncachedInput: 0,
+  cacheRead: 0,
+  cacheWrite: undefined,
+  cacheWrite5m: undefined,
+  cacheWrite1h: undefined,
+  freshPrompt: 0,
+  output: 0,
+  reasoning: 0,
+  processed: 0,
+});
+
+function addTokens(total: TokenUsage, usage: TokenUsage) {
+  total.uncachedInput += usage.uncachedInput;
+  total.cacheRead += usage.cacheRead;
+  total.freshPrompt += usage.freshPrompt;
+  total.output += usage.output;
+  total.reasoning += usage.reasoning;
+  total.processed += usage.processed;
+  if (usage.cacheWrite !== undefined) {
+    total.cacheWrite = (total.cacheWrite ?? 0) + usage.cacheWrite;
+  }
+  if (usage.cacheWrite5m !== undefined) {
+    total.cacheWrite5m = (total.cacheWrite5m ?? 0) + usage.cacheWrite5m;
+  }
+  if (usage.cacheWrite1h !== undefined) {
+    total.cacheWrite1h = (total.cacheWrite1h ?? 0) + usage.cacheWrite1h;
+  }
+}
+
+function readRecords(path: string) {
+  const records: Record[] = [];
+  for (const line of Deno.readTextFileSync(path).split("\n")) {
+    if (!line) continue;
+    try {
+      const result = recordSchema.safeParse(JSON.parse(line));
+      if (result.success) records.push(result.data);
+    } catch {
+      // A partially written final line should not hide the rest of the session.
+    }
+  }
+  return records;
+}
+
+function blocks(record: Record) {
+  return Array.isArray(record.message?.content) ? record.message.content : [];
+}
+
+function userText(record: Record) {
+  const content = record.message?.content;
+  if (typeof content === "string") return content;
+  return content?.find((block) => block.type === "text")?.text;
+}
+
+function startsTurn(record: Record, hasTurns: boolean) {
+  if (record.type !== "user" || record.isMeta) return false;
+  const text = userText(record);
+  if (!text) return false;
+  return record.origin?.kind === "human" ||
+    record.promptSource === "typed" || record.promptSource === "sdk" ||
+    text.startsWith("❯ ") || (record.isSidechain === true && !hasTurns);
+}
+
+function decodeRecords(records: Record[]) {
+  const turns: Array<
+    { number: number; startedAt: number; calls: ModelCall[] }
+  > = [];
+  const calls = new Map<
+    string,
+    { call: ModelCall; blocks: ReturnType<typeof blocks> }
+  >();
+  const tokens = emptyTokens();
+  const providers = new Set<string>();
+  const models = new Set<string>();
+
+  for (const record of records) {
+    const timestamp = Date.parse(record.timestamp ?? "") || 0;
+    if (record.type === "user") {
+      const content = record.message?.content;
+      if (startsTurn(record, turns.length > 0)) {
+        turns.push({
+          number: turns.length + 1,
+          startedAt: timestamp,
+          calls: [],
+        });
+      }
+      if (Array.isArray(content)) {
+        for (const block of content) {
+          if (block.type !== "tool_result" || !block.tool_use_id) continue;
+          for (const value of calls.values()) {
+            const tool = value.call.activity.tools.find((item) =>
+              (item as { id?: string }).id === block.tool_use_id
+            );
+            if (tool) {
+              tool.status = block.is_error ? "error" : "completed";
+              tool.completedAt = timestamp;
+              if (record.toolUseResult?.agentId) {
+                tool.childSessionID = record.toolUseResult.agentId;
+              }
+            }
+          }
+        }
+      }
+      continue;
+    }
+    if (
+      record.type !== "assistant" || !record.message?.id ||
+      !record.message.usage || turns.length === 0
+    ) continue;
+
+    const id = record.message.id;
+    let decoded = calls.get(id);
+    if (!decoded) {
+      const source = record.message.usage;
+      const cacheWrite = source.cache_creation_input_tokens || undefined;
+      const cacheWrite5m = source.cache_creation?.ephemeral_5m_input_tokens ?? 0;
+      const cacheWrite1h = source.cache_creation?.ephemeral_1h_input_tokens ?? 0;
+      const callTokens: TokenUsage = {
+        uncachedInput: source.input_tokens,
+        cacheRead: source.cache_read_input_tokens,
+        cacheWrite,
+        cacheWrite5m,
+        cacheWrite1h,
+        freshPrompt: source.input_tokens + (cacheWrite ?? 0),
+        output: source.output_tokens,
+        reasoning: 0,
+        processed: source.input_tokens + source.cache_read_input_tokens +
+          source.cache_creation_input_tokens + source.output_tokens,
+      };
+      if (callTokens.processed === 0) continue;
+      const turn = turns.at(-1)!;
+      const model = record.message.model ?? "unknown";
+      const call: ModelCall = {
+        id,
+        callWithinTurn: turn.calls.length + 1,
+        provider: "anthropic",
+        model,
+        startedAt: timestamp,
+        tokens: callTokens,
+        activity: { hasText: false, hasReasoning: false, tools: [] },
+      };
+      turn.calls.push(call);
+      decoded = { call, blocks: [] };
+      calls.set(id, decoded);
+      providers.add("anthropic");
+      models.add(model);
+      addTokens(tokens, callTokens);
+    }
+
+    decoded.call.completedAt = timestamp;
+    decoded.call.activity.finishReason = record.message.stop_reason ??
+      undefined;
+    for (const block of blocks(record)) {
+      const key = JSON.stringify(block);
+      if (decoded.blocks.some((existing) => JSON.stringify(existing) === key)) {
+        continue;
+      }
+      decoded.blocks.push(block);
+      if (block.type === "text") decoded.call.activity.hasText = true;
+      if (block.type === "thinking") decoded.call.activity.hasReasoning = true;
+      if (block.type === "tool_use" && block.name && block.id) {
+        decoded.call.activity.tools.push(
+          {
+            name: block.name,
+            status: "pending",
+            startedAt: timestamp,
+            // Kept internally while matching the later tool_result record.
+            id: block.id,
+          } as ModelCall["activity"]["tools"][number],
+        );
+      }
+    }
+  }
+  return { turns, tokens, providers, models };
+}
+
+export class ClaudeCodeRepository {
+  #index = new Map<string, IndexEntry>();
+
+  constructor(private directory: string) {
+    try {
+      const parsed = z.object({
+        entries: z.array(z.object({
+          sessionId: z.string(),
+          summary: z.string().optional(),
+          firstPrompt: z.string().optional(),
+        })),
+      }).parse(
+        JSON.parse(Deno.readTextFileSync(`${directory}/sessions-index.json`)),
+      );
+      for (const entry of parsed.entries) {
+        this.#index.set(entry.sessionId, entry);
+      }
+    } catch {
+      // The transcript is authoritative; the optional index only improves titles.
+    }
+  }
+
+  #files() {
+    return [...Deno.readDirSync(this.directory)]
+      .filter((entry) => entry.isFile && entry.name.endsWith(".jsonl"))
+      .map((entry) => {
+        const path = `${this.directory}/${entry.name}`;
+        return {
+          id: entry.name.slice(0, -6),
+          path,
+          updatedAt: Deno.statSync(path).mtime?.getTime() ?? 0,
+        };
+      }).sort((a, b) => b.updatedAt - a.updatedAt || b.id.localeCompare(a.id));
+  }
+
+  listSessions(page: number, pageSize: number) {
+    const files = this.#files();
+    const items = files.map((file) =>
+      this.#summary(file.id, file.path, file.updatedAt)
+    ).sort((a, b) => b.updatedAt - a.updatedAt || b.id.localeCompare(a.id))
+      .slice((page - 1) * pageSize, page * pageSize);
+    return sessionListResponseSchema.parse({
+      items,
+      pagination: {
+        page,
+        pageSize,
+        totalItems: files.length,
+        totalPages: Math.ceil(files.length / pageSize),
+      },
+    });
+  }
+
+  getSession(id: string) {
+    const path = `${this.directory}/${id}.jsonl`;
+    try {
+      const stat = Deno.statSync(path);
+      return sessionDetailSchema.parse(
+        this.#detail(id, path, stat.mtime?.getTime() ?? 0),
+      );
+    } catch (error) {
+      if (error instanceof Deno.errors.NotFound) return undefined;
+      throw error;
+    }
+  }
+
+  #summary(id: string, path: string, updatedAt: number): SessionSummary {
+    const records = readRecords(path);
+    const decoded = decodeRecords(records);
+    const generatedTitle = [...records].reverse().find((record) =>
+      record.aiTitle
+    )?.aiTitle;
+    const firstPrompt = records.find((record) => startsTurn(record, false));
+    const promptTitle = userText(firstPrompt ?? { type: "" })?.replace(/\s+/g, " ")
+      .trim().slice(0, 100);
+    const transcriptUpdatedAt = [...records].reverse().find((record) =>
+      record.timestamp && Number.isFinite(Date.parse(record.timestamp))
+    )?.timestamp;
+    const title = this.#index.get(id)?.summary ?? generatedTitle ??
+      this.#index.get(id)?.firstPrompt ??
+      promptTitle ?? `Claude Code session ${id.slice(0, 8)}`;
+    return {
+      id,
+      harness: "claude-code",
+      title,
+      updatedAt: transcriptUpdatedAt ? Date.parse(transcriptUpdatedAt) : updatedAt,
+      providers: [...decoded.providers],
+      models: [...decoded.models],
+      userTurns: decoded.turns.length,
+      modelCalls: decoded.turns.reduce(
+        (sum, turn) => sum + turn.calls.length,
+        0,
+      ),
+      tokens: decoded.tokens,
+    };
+  }
+
+  #detail(
+    id: string,
+    path: string,
+    updatedAt: number,
+    parentID?: string,
+    title?: string,
+  ): unknown {
+    const records = readRecords(path);
+    const decoded = decodeRecords(records);
+    const summary = this.#summary(id, path, updatedAt);
+    const subagentDirectory = `${path.slice(0, -6)}/subagents`;
+    let subagents: unknown[] = [];
+    try {
+      subagents = [...Deno.readDirSync(subagentDirectory)]
+        .filter((entry) =>
+          entry.isFile && entry.name.startsWith("agent-") &&
+          entry.name.endsWith(".jsonl")
+        )
+        .map((entry) => {
+          const childPath = `${subagentDirectory}/${entry.name}`;
+          const childID = entry.name.slice(6, -6);
+          let childTitle = `Subagent ${childID}`;
+          try {
+            const meta = z.object({ description: z.string().optional() }).parse(
+              JSON.parse(
+                Deno.readTextFileSync(
+                  `${subagentDirectory}/agent-${childID}.meta.json`,
+                ),
+              ),
+            );
+            childTitle = meta.description ?? childTitle;
+          } catch { /* optional metadata */ }
+          return this.#detail(
+            childID,
+            childPath,
+            Deno.statSync(childPath).mtime?.getTime() ?? updatedAt,
+            id,
+            childTitle,
+          );
+        });
+    } catch (error) {
+      if (!(error instanceof Deno.errors.NotFound)) throw error;
+    }
+    return {
+      ...summary,
+      title: title ?? summary.title,
+      parentID,
+      turns: decoded.turns,
+      subagents,
+    };
+  }
+}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -1,6 +1,9 @@
 import { Hono } from "hono";
 import { serveStatic } from "hono/deno";
 import { OpenCodeRepository } from "./opencodeRepository.ts";
+import { ClaudeCodeRepository } from "./claudeCodeRepository.ts";
+import { priceSessionDetail } from "./pricing.ts";
+import type { SessionSummary } from "../shared/sessionSchemas.ts";
 
 const defaultDatabasePath = `${
   Deno.env.get("HOME")
@@ -8,7 +11,25 @@ const defaultDatabasePath = `${
 const repository = new OpenCodeRepository(
   Deno.env.get("OPENCODE_DB_PATH") ?? defaultDatabasePath,
 );
+const claudeCodeProjectPath = Deno.env.get("CLAUDE_CODE_PROJECT_PATH");
+if (!claudeCodeProjectPath) {
+  throw new Error("CLAUDE_CODE_PROJECT_PATH must be set");
+}
+const claudeRepository = new ClaudeCodeRepository(
+  claudeCodeProjectPath,
+);
 const app = new Hono();
+
+function priceSummaries(items: SessionSummary[]) {
+  return items.map((item) => {
+    const detail = item.harness === "claude-code"
+      ? claudeRepository.getSession(item.id)
+      : repository.getSession(item.id);
+    return detail
+      ? { ...item, computedCost: priceSessionDetail(detail).computedCost }
+      : item;
+  });
+}
 
 app.get("/api/sessions", (context) => {
   const page = Math.max(
@@ -18,15 +39,43 @@ app.get("/api/sessions", (context) => {
   const requestedPageSize =
     Number.parseInt(context.req.query("pageSize") ?? "10", 10) || 10;
   const pageSize = Math.min(100, Math.max(1, requestedPageSize));
-  return context.json(repository.listSessions(page, pageSize));
+  const harness = context.req.query("harness") ?? "all";
+  if (harness === "opencode") {
+    const result = repository.listSessions(page, pageSize);
+    return context.json({ ...result, items: priceSummaries(result.items) });
+  }
+  if (harness === "claude-code") {
+    const result = claudeRepository.listSessions(page, pageSize);
+    return context.json({ ...result, items: priceSummaries(result.items) });
+  }
+  const openCode = repository.listSessions(1, page * pageSize);
+  const claude = claudeRepository.listSessions(1, page * pageSize);
+  const totalItems = openCode.pagination.totalItems +
+    claude.pagination.totalItems;
+  const items = [...openCode.items, ...claude.items]
+    .sort((a, b) => b.updatedAt - a.updatedAt || b.id.localeCompare(a.id))
+    .slice((page - 1) * pageSize, page * pageSize);
+  return context.json({
+    items: priceSummaries(items),
+    pagination: {
+      page,
+      pageSize,
+      totalItems,
+      totalPages: Math.ceil(totalItems / pageSize),
+    },
+  });
 });
 
 app.get("/api/sessions/:id", (context) => {
-  const session = repository.getSession(context.req.param("id"));
+  const session = context.req.query("harness") === "claude-code"
+    ? claudeRepository.getSession(context.req.param("id"))
+    : repository.getSession(context.req.param("id"));
   return session
-    ? context.json(session)
+    ? context.json(priceSessionDetail(session))
     : context.json({ error: "Session not found" }, 404);
 });
+
+app.get("/api/*", (context) => context.json({ error: "API route not found" }, 404));
 
 app.use("/assets/*", serveStatic({ root: "./dist" }));
 app.get("*", serveStatic({ root: "./dist", path: "index.html" }));

--- a/src/server/opencodeRepository.ts
+++ b/src/server/opencodeRepository.ts
@@ -70,6 +70,8 @@ const emptyTokens = (): TokenUsage => ({
   uncachedInput: 0,
   cacheRead: 0,
   cacheWrite: undefined,
+  cacheWrite5m: undefined,
+  cacheWrite1h: undefined,
   freshPrompt: 0,
   output: 0,
   reasoning: 0,
@@ -85,6 +87,12 @@ function addTokens(total: TokenUsage, usage: TokenUsage) {
   total.processed += usage.processed;
   if (usage.cacheWrite !== undefined) {
     total.cacheWrite = (total.cacheWrite ?? 0) + usage.cacheWrite;
+  }
+  if (usage.cacheWrite5m !== undefined) {
+    total.cacheWrite5m = (total.cacheWrite5m ?? 0) + usage.cacheWrite5m;
+  }
+  if (usage.cacheWrite1h !== undefined) {
+    total.cacheWrite1h = (total.cacheWrite1h ?? 0) + usage.cacheWrite1h;
   }
 }
 
@@ -162,6 +170,8 @@ function decodeMessages(
       uncachedInput: source.input,
       cacheRead: source.cache.read,
       cacheWrite,
+      cacheWrite5m: undefined,
+      cacheWrite1h: undefined,
       freshPrompt: source.input + (cacheWrite ?? 0),
       output: source.output,
       reasoning: source.reasoning,
@@ -310,6 +320,7 @@ export class OpenCodeRepository {
     if (decoded.models.size === 0 && fallback) decoded.models.add(fallback.id);
     return {
       id: row.id,
+      harness: "opencode",
       title: row.title,
       updatedAt: row.time_updated,
       providers: [...decoded.providers],

--- a/src/server/pricing.ts
+++ b/src/server/pricing.ts
@@ -1,0 +1,106 @@
+import type {
+  SessionDetail,
+  TokenUsage,
+} from "../shared/sessionSchemas.ts";
+
+type RateCard = {
+  input: number;
+  cacheRead: number;
+  output: number;
+  cacheWrite?: number;
+  cacheWrite5m?: number;
+  cacheWrite1h?: number;
+};
+
+const standard: Record<string, RateCard> = {
+  "claude-fable-5": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50 },
+  "claude-mythos-5": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50 },
+  "claude-opus-4-8": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25 },
+  "claude-opus-4-7": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25 },
+  "claude-opus-4-6": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25 },
+  "claude-opus-4-5": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25 },
+  "claude-opus-4-1": { input: 15, cacheWrite5m: 18.75, cacheWrite1h: 30, cacheRead: 1.5, output: 75 },
+  "claude-opus-4": { input: 15, cacheWrite5m: 18.75, cacheWrite1h: 30, cacheRead: 1.5, output: 75 },
+  "claude-sonnet-4-6": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15 },
+  "claude-sonnet-4-5": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15 },
+  "claude-sonnet-4": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15 },
+  "claude-haiku-4-5": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5 },
+  "claude-haiku-3-5": { input: 0.8, cacheWrite5m: 1, cacheWrite1h: 1.6, cacheRead: 0.08, output: 4 },
+  "grok-4-5": { input: 2, cacheWrite5m: 0, cacheWrite1h: 0, cacheRead: 0.5, output: 6 },
+  "grok-4.5": { input: 2, cacheWrite5m: 0, cacheWrite1h: 0, cacheRead: 0.5, output: 6 },
+  "gpt-5.6-sol": { input: 5, cacheRead: 0.5, cacheWrite: 6.25, output: 30 },
+  "gpt-5.6-terra": { input: 2.5, cacheRead: 0.25, cacheWrite: 3.125, output: 15 },
+  "gpt-5.6-luna": { input: 1, cacheRead: 0.1, cacheWrite: 1.25, output: 6 },
+  "gpt-5.5": { input: 5, cacheRead: 0.5, output: 30 },
+  "gpt-5.5-pro": { input: 30, cacheRead: 0, output: 180 },
+  "gpt-5.4": { input: 2.5, cacheRead: 0.25, output: 15 },
+  "gpt-5.4-mini": { input: 0.75, cacheRead: 0.075, output: 4.5 },
+  "gpt-5.4-nano": { input: 0.2, cacheRead: 0.02, output: 1.25 },
+  "gpt-5.4-pro": { input: 30, cacheRead: 0, output: 180 },
+};
+
+function normalizedModel(model: string) {
+  return model.replace(/^.*?((?:claude|gpt|grok)-)/, "$1").replace(
+    /-\d{8}.*$/,
+    "",
+  );
+}
+
+function rateCard(model: string, timestamp: number) {
+  const normalized = normalizedModel(model);
+  if (normalized === "claude-sonnet-5") {
+    return timestamp < Date.parse("2026-09-01T00:00:00Z")
+      ? { input: 2, cacheWrite5m: 2.5, cacheWrite1h: 4, cacheRead: 0.2, output: 10 }
+      : { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15 };
+  }
+  return standard[normalized];
+}
+
+function compute(tokens: TokenUsage, model: string, timestamp: number) {
+  const rates = rateCard(model, timestamp);
+  if (!rates) return undefined;
+  const inputSideTokens = tokens.uncachedInput + tokens.cacheRead +
+    (tokens.cacheWrite ?? 0);
+  if (normalizedModel(model).startsWith("gpt-5.") && inputSideTokens >= 272_000) {
+    return undefined;
+  }
+
+  let cacheWriteCost = 0;
+  if (tokens.cacheWrite !== undefined) {
+    if (tokens.cacheWrite5m !== undefined && tokens.cacheWrite1h !== undefined &&
+      tokens.cacheWrite5m + tokens.cacheWrite1h === tokens.cacheWrite &&
+      rates.cacheWrite5m !== undefined && rates.cacheWrite1h !== undefined) {
+      cacheWriteCost = tokens.cacheWrite5m * rates.cacheWrite5m +
+        tokens.cacheWrite1h * rates.cacheWrite1h;
+    } else if (rates.cacheWrite !== undefined) {
+      cacheWriteCost = tokens.cacheWrite * rates.cacheWrite;
+    } else {
+      return undefined;
+    }
+  }
+  return (
+    tokens.uncachedInput * rates.input +
+    tokens.cacheRead * rates.cacheRead +
+    cacheWriteCost +
+    (tokens.output + tokens.reasoning) * rates.output
+  ) / 1_000_000;
+}
+
+export function priceSessionDetail(session: SessionDetail): SessionDetail {
+  const turns = session.turns.map((turn) => ({
+    ...turn,
+    calls: turn.calls.map((call) => ({
+      ...call,
+      computedCost: compute(call.tokens, call.model, call.startedAt),
+    })),
+  }));
+  const costs = turns.flatMap((turn) => turn.calls.map((call) => call.computedCost));
+  return {
+    ...session,
+    computedCost: costs.length > 0 && costs.every((cost) => cost !== undefined)
+      ? costs.reduce((sum, cost) => sum + cost!, 0)
+      : undefined,
+    turns,
+    subagents: session.subagents.map(priceSessionDetail),
+  };
+}

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -1,9 +1,13 @@
 import { z } from "zod";
 
+export const harnessSchema = z.enum(["opencode", "claude-code"]);
+
 export const tokenUsageSchema = z.object({
   uncachedInput: z.number().int().nonnegative(),
   cacheRead: z.number().int().nonnegative(),
   cacheWrite: z.number().int().positive().optional(),
+  cacheWrite5m: z.number().int().nonnegative().optional(),
+  cacheWrite1h: z.number().int().nonnegative().optional(),
   freshPrompt: z.number().int().nonnegative(),
   output: z.number().int().nonnegative(),
   reasoning: z.number().int().nonnegative(),
@@ -27,13 +31,15 @@ export const callActivitySchema = z.object({
 
 export const sessionSummarySchema = z.object({
   id: z.string(),
+  harness: harnessSchema,
   title: z.string(),
   updatedAt: z.number(),
   providers: z.array(z.string()),
   models: z.array(z.string()),
   userTurns: z.number().int().nonnegative(),
   modelCalls: z.number().int().nonnegative(),
-  reportedCost: z.number().nonnegative(),
+  reportedCost: z.number().nonnegative().optional(),
+  computedCost: z.number().nonnegative().optional(),
   tokens: tokenUsageSchema,
 });
 
@@ -44,7 +50,8 @@ export const modelCallSchema = z.object({
   model: z.string(),
   startedAt: z.number(),
   completedAt: z.number().optional(),
-  reportedCost: z.number().nonnegative(),
+  reportedCost: z.number().nonnegative().optional(),
+  computedCost: z.number().nonnegative().optional(),
   tokens: tokenUsageSchema,
   activity: callActivitySchema,
 });

--- a/tests/claudeCodeRepository.test.ts
+++ b/tests/claudeCodeRepository.test.ts
@@ -1,0 +1,337 @@
+import { deepStrictEqual } from "node:assert/strict";
+import { ClaudeCodeRepository } from "../src/server/claudeCodeRepository.ts";
+import type { SessionDetail } from "../src/shared/sessionSchemas.ts";
+
+function repository(files: Record<string, string>) {
+  const directory = Deno.makeTempDirSync();
+  for (const [relativePath, content] of Object.entries(files)) {
+    const path = `${directory}/${relativePath}`;
+    const parent = path.slice(0, path.lastIndexOf("/"));
+    Deno.mkdirSync(parent, { recursive: true });
+    Deno.writeTextFileSync(path, content.trim());
+  }
+  return new ClaudeCodeRepository(directory);
+}
+
+Deno.test("normalizes model changes without creating command turns", () => {
+  const actual = repository({
+    "model-switch.jsonl": `
+{"type":"user","uuid":"user-sonnet","timestamp":"2026-06-25T19:51:53.000Z","promptSource":"typed","origin":{"kind":"human"},"message":{"role":"user","content":"Start with Sonnet"}}
+{"type":"assistant","uuid":"sonnet-thinking","timestamp":"2026-06-25T19:51:54.000Z","message":{"id":"call-sonnet","role":"assistant","model":"claude-sonnet-4-5","stop_reason":"end_turn","content":[{"type":"thinking","thinking":"Considering the request"}],"usage":{"input_tokens":10,"cache_read_input_tokens":20,"cache_creation_input_tokens":30,"output_tokens":40,"cache_creation":{"ephemeral_5m_input_tokens":10,"ephemeral_1h_input_tokens":20}}}}
+{"type":"assistant","uuid":"sonnet-text","timestamp":"2026-06-25T19:51:55.000Z","message":{"id":"call-sonnet","role":"assistant","model":"claude-sonnet-4-5","stop_reason":"end_turn","content":[{"type":"text","text":"Sonnet response"}],"usage":{"input_tokens":10,"cache_read_input_tokens":20,"cache_creation_input_tokens":30,"output_tokens":40,"cache_creation":{"ephemeral_5m_input_tokens":10,"ephemeral_1h_input_tokens":20}}}}
+{"type":"user","uuid":"model-caveat","timestamp":"2026-06-25T19:52:00.000Z","isMeta":true,"message":{"role":"user","content":"<local-command-caveat>Generated while running a command</local-command-caveat>"}}
+{"type":"user","uuid":"model-command","timestamp":"2026-06-25T19:52:00.000Z","message":{"role":"user","content":"<command-name>/model</command-name>"}}
+{"type":"user","uuid":"model-output","timestamp":"2026-06-25T19:52:00.000Z","message":{"role":"user","content":"<local-command-stdout>Set model to Opus</local-command-stdout>"}}
+{"type":"user","uuid":"user-opus","timestamp":"2026-06-25T19:52:01.000Z","message":{"role":"user","content":"❯ Continue with Opus"}}
+{"type":"assistant","uuid":"opus-text","timestamp":"2026-06-25T19:52:02.000Z","message":{"id":"call-opus","role":"assistant","model":"claude-opus-4-7","stop_reason":"end_turn","content":[{"type":"text","text":"Opus response"}],"usage":{"input_tokens":5,"cache_read_input_tokens":50,"cache_creation_input_tokens":15,"output_tokens":25,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":15}}}}
+{"type":"ai-title","aiTitle":"Switch models","timestamp":"2026-06-25T19:52:03.000Z"}
+`,
+  }).getSession("model-switch");
+  const expected: SessionDetail = {
+    id: "model-switch",
+    harness: "claude-code",
+    title: "Switch models",
+    updatedAt: Date.parse("2026-06-25T19:52:03.000Z"),
+    providers: ["anthropic"],
+    models: ["claude-sonnet-4-5", "claude-opus-4-7"],
+    userTurns: 2,
+    modelCalls: 2,
+    tokens: {
+      uncachedInput: 15,
+      cacheRead: 70,
+      cacheWrite: 45,
+      cacheWrite5m: 10,
+      cacheWrite1h: 35,
+      freshPrompt: 60,
+      output: 65,
+      reasoning: 0,
+      processed: 195,
+    },
+    parentID: undefined,
+    turns: [
+      {
+        number: 1,
+        startedAt: Date.parse("2026-06-25T19:51:53.000Z"),
+        calls: [{
+          id: "call-sonnet",
+          callWithinTurn: 1,
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+          startedAt: Date.parse("2026-06-25T19:51:54.000Z"),
+          completedAt: Date.parse("2026-06-25T19:51:55.000Z"),
+          tokens: {
+            uncachedInput: 10,
+            cacheRead: 20,
+            cacheWrite: 30,
+            cacheWrite5m: 10,
+            cacheWrite1h: 20,
+            freshPrompt: 40,
+            output: 40,
+            reasoning: 0,
+            processed: 100,
+          },
+          activity: {
+            finishReason: "end_turn",
+            hasText: true,
+            hasReasoning: true,
+            tools: [],
+          },
+        }],
+      },
+      {
+        number: 2,
+        startedAt: Date.parse("2026-06-25T19:52:01.000Z"),
+        calls: [{
+          id: "call-opus",
+          callWithinTurn: 1,
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          startedAt: Date.parse("2026-06-25T19:52:02.000Z"),
+          completedAt: Date.parse("2026-06-25T19:52:02.000Z"),
+          tokens: {
+            uncachedInput: 5,
+            cacheRead: 50,
+            cacheWrite: 15,
+            cacheWrite5m: 0,
+            cacheWrite1h: 15,
+            freshPrompt: 20,
+            output: 25,
+            reasoning: 0,
+            processed: 95,
+          },
+          activity: {
+            finishReason: "end_turn",
+            hasText: true,
+            hasReasoning: false,
+            tools: [],
+          },
+        }],
+      },
+    ],
+    subagents: [],
+  };
+
+  deepStrictEqual(actual, expected);
+});
+
+Deno.test("normalizes an SDK prompt and deduplicates streamed usage", () => {
+  const actual = repository({
+    "sdk-session.jsonl": `
+{"type":"user","uuid":"sdk-user","timestamp":"2026-06-25T20:00:00.000Z","promptSource":"sdk","message":{"role":"user","content":"hi"}}
+{"type":"assistant","uuid":"sdk-thinking","timestamp":"2026-06-25T20:00:01.000Z","message":{"id":"sdk-call","role":"assistant","model":"claude-sonnet-4-5","stop_reason":"end_turn","content":[{"type":"thinking","thinking":"Respond briefly"}],"usage":{"input_tokens":2,"cache_read_input_tokens":100,"cache_creation_input_tokens":12,"output_tokens":8,"cache_creation":{"ephemeral_5m_input_tokens":12,"ephemeral_1h_input_tokens":0}}}}
+{"type":"assistant","uuid":"sdk-text","timestamp":"2026-06-25T20:00:02.000Z","message":{"id":"sdk-call","role":"assistant","model":"claude-sonnet-4-5","stop_reason":"end_turn","content":[{"type":"text","text":"Hi!"}],"usage":{"input_tokens":2,"cache_read_input_tokens":100,"cache_creation_input_tokens":12,"output_tokens":8,"cache_creation":{"ephemeral_5m_input_tokens":12,"ephemeral_1h_input_tokens":0}}}}
+{"type":"last-prompt","lastPrompt":"hi","timestamp":"2026-06-25T20:00:03.000Z"}
+`,
+  }).getSession("sdk-session");
+  const expected: SessionDetail = {
+    id: "sdk-session",
+    harness: "claude-code",
+    title: "hi",
+    updatedAt: Date.parse("2026-06-25T20:00:03.000Z"),
+    providers: ["anthropic"],
+    models: ["claude-sonnet-4-5"],
+    userTurns: 1,
+    modelCalls: 1,
+    tokens: {
+      uncachedInput: 2,
+      cacheRead: 100,
+      cacheWrite: 12,
+      cacheWrite5m: 12,
+      cacheWrite1h: 0,
+      freshPrompt: 14,
+      output: 8,
+      reasoning: 0,
+      processed: 122,
+    },
+    parentID: undefined,
+    turns: [{
+      number: 1,
+      startedAt: Date.parse("2026-06-25T20:00:00.000Z"),
+      calls: [{
+        id: "sdk-call",
+        callWithinTurn: 1,
+        provider: "anthropic",
+        model: "claude-sonnet-4-5",
+        startedAt: Date.parse("2026-06-25T20:00:01.000Z"),
+        completedAt: Date.parse("2026-06-25T20:00:02.000Z"),
+        tokens: {
+          uncachedInput: 2,
+          cacheRead: 100,
+          cacheWrite: 12,
+          cacheWrite5m: 12,
+          cacheWrite1h: 0,
+          freshPrompt: 14,
+          output: 8,
+          reasoning: 0,
+          processed: 122,
+        },
+        activity: {
+          finishReason: "end_turn",
+          hasText: true,
+          hasReasoning: true,
+          tools: [],
+        },
+      }],
+    }],
+    subagents: [],
+  };
+
+  deepStrictEqual(actual, expected);
+});
+
+Deno.test("normalizes a linked subagent without folding child usage into parent", () => {
+  const actual = repository({
+    "parent.jsonl": `
+{"type":"user","uuid":"parent-user","timestamp":"2026-06-25T21:00:00.000Z","promptSource":"typed","origin":{"kind":"human"},"message":{"role":"user","content":"Delegate this task"}}
+{"type":"assistant","uuid":"parent-agent-call","timestamp":"2026-06-25T21:00:01.000Z","message":{"id":"parent-call-1","role":"assistant","model":"claude-opus-4-7","stop_reason":"tool_use","content":[{"type":"tool_use","id":"tool-agent","name":"Agent"}],"usage":{"input_tokens":10,"cache_read_input_tokens":20,"cache_creation_input_tokens":30,"output_tokens":5,"cache_creation":{"ephemeral_5m_input_tokens":10,"ephemeral_1h_input_tokens":20}}}}
+{"type":"user","uuid":"parent-agent-result","timestamp":"2026-06-25T21:00:03.000Z","message":{"role":"user","content":[{"type":"tool_result","tool_use_id":"tool-agent"}]},"toolUseResult":{"agentId":"child"}}
+{"type":"assistant","uuid":"parent-final","timestamp":"2026-06-25T21:00:04.000Z","message":{"id":"parent-call-2","role":"assistant","model":"claude-opus-4-7","stop_reason":"end_turn","content":[{"type":"text","text":"Parent final response"}],"usage":{"input_tokens":2,"cache_read_input_tokens":60,"cache_creation_input_tokens":8,"output_tokens":10,"cache_creation":{"ephemeral_5m_input_tokens":0,"ephemeral_1h_input_tokens":8}}}}
+{"type":"ai-title","aiTitle":"Delegate work","timestamp":"2026-06-25T21:00:05.000Z"}
+`,
+    "parent/subagents/agent-child.jsonl": `
+{"type":"user","uuid":"child-user","timestamp":"2026-06-25T21:00:01.500Z","isSidechain":true,"message":{"role":"user","content":"Investigate the issue"}}
+{"type":"assistant","uuid":"child-final","timestamp":"2026-06-25T21:00:02.500Z","isSidechain":true,"message":{"id":"child-call","role":"assistant","model":"claude-sonnet-4-5","stop_reason":"end_turn","content":[{"type":"text","text":"Child result"}],"usage":{"input_tokens":7,"cache_read_input_tokens":11,"cache_creation_input_tokens":13,"output_tokens":17,"cache_creation":{"ephemeral_5m_input_tokens":3,"ephemeral_1h_input_tokens":10}}}}
+`,
+    "parent/subagents/agent-child.meta.json": `
+{"agentType":"Explore","description":"Investigate issue","toolUseId":"tool-agent","spawnDepth":1}
+`,
+  }).getSession("parent");
+  const expected: SessionDetail = {
+    id: "parent",
+    harness: "claude-code",
+    title: "Delegate work",
+    updatedAt: Date.parse("2026-06-25T21:00:05.000Z"),
+    providers: ["anthropic"],
+    models: ["claude-opus-4-7"],
+    userTurns: 1,
+    modelCalls: 2,
+    tokens: {
+      uncachedInput: 12,
+      cacheRead: 80,
+      cacheWrite: 38,
+      cacheWrite5m: 10,
+      cacheWrite1h: 28,
+      freshPrompt: 50,
+      output: 15,
+      reasoning: 0,
+      processed: 145,
+    },
+    parentID: undefined,
+    turns: [{
+      number: 1,
+      startedAt: Date.parse("2026-06-25T21:00:00.000Z"),
+      calls: [
+        {
+          id: "parent-call-1",
+          callWithinTurn: 1,
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          startedAt: Date.parse("2026-06-25T21:00:01.000Z"),
+          completedAt: Date.parse("2026-06-25T21:00:01.000Z"),
+          tokens: {
+            uncachedInput: 10,
+            cacheRead: 20,
+            cacheWrite: 30,
+            cacheWrite5m: 10,
+            cacheWrite1h: 20,
+            freshPrompt: 40,
+            output: 5,
+            reasoning: 0,
+            processed: 65,
+          },
+          activity: {
+            finishReason: "tool_use",
+            hasText: false,
+            hasReasoning: false,
+            tools: [{
+              name: "Agent",
+              status: "completed",
+              startedAt: Date.parse("2026-06-25T21:00:01.000Z"),
+              completedAt: Date.parse("2026-06-25T21:00:03.000Z"),
+              childSessionID: "child",
+            }],
+          },
+        },
+        {
+          id: "parent-call-2",
+          callWithinTurn: 2,
+          provider: "anthropic",
+          model: "claude-opus-4-7",
+          startedAt: Date.parse("2026-06-25T21:00:04.000Z"),
+          completedAt: Date.parse("2026-06-25T21:00:04.000Z"),
+          tokens: {
+            uncachedInput: 2,
+            cacheRead: 60,
+            cacheWrite: 8,
+            cacheWrite5m: 0,
+            cacheWrite1h: 8,
+            freshPrompt: 10,
+            output: 10,
+            reasoning: 0,
+            processed: 80,
+          },
+          activity: {
+            finishReason: "end_turn",
+            hasText: true,
+            hasReasoning: false,
+            tools: [],
+          },
+        },
+      ],
+    }],
+    subagents: [{
+      id: "child",
+      harness: "claude-code",
+      title: "Investigate issue",
+      updatedAt: Date.parse("2026-06-25T21:00:02.500Z"),
+      providers: ["anthropic"],
+      models: ["claude-sonnet-4-5"],
+      userTurns: 1,
+      modelCalls: 1,
+      tokens: {
+        uncachedInput: 7,
+        cacheRead: 11,
+        cacheWrite: 13,
+        cacheWrite5m: 3,
+        cacheWrite1h: 10,
+        freshPrompt: 20,
+        output: 17,
+        reasoning: 0,
+        processed: 48,
+      },
+      parentID: "parent",
+      turns: [{
+        number: 1,
+        startedAt: Date.parse("2026-06-25T21:00:01.500Z"),
+        calls: [{
+          id: "child-call",
+          callWithinTurn: 1,
+          provider: "anthropic",
+          model: "claude-sonnet-4-5",
+          startedAt: Date.parse("2026-06-25T21:00:02.500Z"),
+          completedAt: Date.parse("2026-06-25T21:00:02.500Z"),
+          tokens: {
+            uncachedInput: 7,
+            cacheRead: 11,
+            cacheWrite: 13,
+            cacheWrite5m: 3,
+            cacheWrite1h: 10,
+            freshPrompt: 20,
+            output: 17,
+            reasoning: 0,
+            processed: 48,
+          },
+          activity: {
+            finishReason: "end_turn",
+            hasText: true,
+            hasReasoning: false,
+            tools: [],
+          },
+        }],
+      }],
+      subagents: [],
+    }],
+  };
+
+  deepStrictEqual(actual, expected);
+});


### PR DESCRIPTION
- Add Claude Code JSONL session, turn, tool, and subagent normalization
- Add harness filtering and merged pagination
- Preserve cache-write TTL details and model changes
- Add computed Anthropic, Grok, and GPT pricing separately from reported cost
- Add cache-hit and token-activity metrics
- Add JSONL normalization contract fixtures and tests
- Document harness mappings, pricing boundaries, and known limitations