### PR TITLE
Prefer user custom titles for Claude Code sessions

### DIFF
--- a/src/server/claudeCodeRepository.ts
+++ b/src/server/claudeCodeRepository.ts
@@ -23,6 +23,7 @@ const recordSchema = z.object({
   uuid: z.string().optional(),
   timestamp: z.string().optional(),
   aiTitle: z.string().optional(),
+  customTitle: z.string().optional(),
   isMeta: z.boolean().optional(),
   isSidechain: z.boolean().optional(),
   promptSource: z.string().optional(),
@@ -345,6 +346,9 @@ export class ClaudeCodeRepository {
   #summary(id: string, path: string, updatedAt: number): SessionSummary {
     const records = readRecords(path);
     const decoded = decodeRecords(records);
+    const customTitle = [...records].reverse().find((record) =>
+      record.customTitle
+    )?.customTitle;
     const generatedTitle = [...records].reverse().find((record) =>
       record.aiTitle
     )?.aiTitle;
@@ -354,8 +358,8 @@ export class ClaudeCodeRepository {
     const transcriptUpdatedAt = [...records].reverse().find((record) =>
       record.timestamp && Number.isFinite(Date.parse(record.timestamp))
     )?.timestamp;
-    const title = this.#index.get(id)?.summary ?? generatedTitle ??
-      this.#index.get(id)?.firstPrompt ??
+    const title = customTitle ?? this.#index.get(id)?.summary ??
+      generatedTitle ?? this.#index.get(id)?.firstPrompt ??
       promptTitle ?? `Claude Code session ${id.slice(0, 8)}`;
     const bounds = sessionBounds(decoded.turns);
     return {

--- a/tests/claudeCodeRepository.test.ts
+++ b/tests/claudeCodeRepository.test.ts
@@ -359,6 +359,25 @@ Deno.test("normalizes a linked subagent without folding child usage into parent"
   deepStrictEqual(actual, expected);
 });
 
+Deno.test("prefers a user custom title over the generated ai-title", () => {
+  const actual = repository({
+    "custom.jsonl": `
+{"type":"user","uuid":"user","timestamp":"2026-07-05T00:00:00Z","promptSource":"typed","origin":{"kind":"human"},"message":{"role":"user","content":"fix it now"}}
+{"type":"assistant","uuid":"assistant","timestamp":"2026-07-05T00:00:01Z","message":{"id":"call","role":"assistant","model":"claude-sonnet-4-5","stop_reason":"end_turn","content":[{"type":"text","text":"Done"}],"usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"ai-title","aiTitle":"Fix the leak","timestamp":"2026-07-05T00:00:02Z"}
+{"type":"custom-title","customTitle":"PR 141273","timestamp":"2026-07-05T00:00:03Z"}
+`,
+    "generated.jsonl": `
+{"type":"user","uuid":"user","timestamp":"2026-07-05T00:00:00Z","promptSource":"typed","origin":{"kind":"human"},"message":{"role":"user","content":"fix it now"}}
+{"type":"assistant","uuid":"assistant","timestamp":"2026-07-05T00:00:01Z","message":{"id":"call","role":"assistant","model":"claude-sonnet-4-5","stop_reason":"end_turn","content":[{"type":"text","text":"Done"}],"usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+{"type":"ai-title","aiTitle":"Fix the leak","timestamp":"2026-07-05T00:00:02Z"}
+`,
+  });
+
+  deepStrictEqual(actual.getSession("custom")?.title, "PR 141273");
+  deepStrictEqual(actual.getSession("generated")?.title, "Fix the leak");
+});
+
 Deno.test("lists sessions from every Claude Code project directory", () => {
   const transcript = (prompt: string, timestamp: string) => `
 {"type":"user","uuid":"user","timestamp":"${timestamp}","promptSource":"typed","origin":{"kind":"human"},"message":{"role":"user","content":"${prompt}"}}


### PR DESCRIPTION
## Summary

The session list showed a different name than Claude Code's own resume/status picker for sessions that were manually renamed. Claude Code resolves a session's display name as: user-set `custom-title` → AI-generated `ai-title` → first prompt. The Claude Code repository only read `ai-title`, so renamed sessions showed the wrong name, or fell back to the first prompt when no `ai-title` existed.

This reads the latest `custom-title` record and places it at the front of the title chain (custom title, then ai-title, then first prompt), matching Claude Code.

## Changes

- `src/server/claudeCodeRepository.ts`: add `customTitle` to `recordSchema`, read the latest `custom-title` record, and prefer it in the title fallback chain.
- `tests/claudeCodeRepository.test.ts`: add a precedence test (custom title wins over ai-title; ai-title-only still resolves to the ai-title).

## Verification

- `deno task test tests/claudeCodeRepository.test.ts` - 6 passed, 0 failed.
- Ran the repository against real local data: two previously mislabeled sessions now resolve to "PR 141273" and "PR 141225", matching Claude Code's picker.
