### PR TITLE
Archive all harness sessions in SQLite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -2,3 +2,4 @@ OPENCODE_DB_PATH=/Users/yourname/.local/share/opencode/opencode.db
 CLAUDE_CODE_PROJECT_PATH=/Users/yourname/.claude/projects
 PI_SESSION_DIR=/Users/yourname/.pi/agent/sessions
 CODEX_SESSION_DIR=/Users/yourname/.codex/sessions
+FRUGAL_TOKENS_DATABASE_URL=sqlite:/Users/yourname/.local/share/frugal-tokens/archive.sqlite

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@ dist/
 node_modules/
 .deno/
 .env
+.DS_Store
+*.sqlite
+*.sqlite-shm
+*.sqlite-wal

--- a/db/migrations/20260714120000_create_initial_archive.sql
+++ b/db/migrations/20260714120000_create_initial_archive.sql
@@ -1,0 +1,188 @@
+-- migrate:up
+CREATE TABLE sources (
+  id INTEGER PRIMARY KEY,
+  harness TEXT NOT NULL,
+  kind TEXT NOT NULL,
+  label TEXT NOT NULL,
+  location TEXT NOT NULL,
+  enabled INTEGER NOT NULL DEFAULT 1 CHECK (enabled IN (0, 1)),
+  created_at INTEGER NOT NULL,
+  UNIQUE (harness, location)
+);
+
+CREATE TABLE source_sessions (
+  id INTEGER PRIMARY KEY,
+  source_id INTEGER NOT NULL REFERENCES sources(id) ON DELETE CASCADE,
+  external_id TEXT NOT NULL,
+  parent_id INTEGER REFERENCES source_sessions(id) ON DELETE SET NULL,
+  artifact_path TEXT,
+  availability TEXT NOT NULL DEFAULT 'available' CHECK (
+    availability IN ('available', 'missing')
+  ),
+  source_size INTEGER CHECK (source_size IS NULL OR source_size >= 0),
+  source_modified_at INTEGER,
+  checksum TEXT,
+  parser_version TEXT,
+  first_seen_at INTEGER NOT NULL,
+  last_seen_at INTEGER NOT NULL,
+  imported_at INTEGER,
+  last_error TEXT,
+  UNIQUE (source_id, external_id)
+);
+
+CREATE INDEX source_sessions_source_availability_idx
+  ON source_sessions(source_id, availability);
+CREATE INDEX source_sessions_parent_idx ON source_sessions(parent_id);
+
+CREATE TABLE sessions (
+  source_session_id INTEGER PRIMARY KEY
+    REFERENCES source_sessions(id) ON DELETE CASCADE,
+  title TEXT NOT NULL,
+  agent TEXT,
+  updated_at INTEGER NOT NULL,
+  started_at INTEGER,
+  ended_at INTEGER,
+  providers_json TEXT NOT NULL CHECK (json_valid(providers_json)),
+  models_json TEXT NOT NULL CHECK (json_valid(models_json)),
+  user_turns INTEGER NOT NULL CHECK (user_turns >= 0),
+  model_calls INTEGER NOT NULL CHECK (model_calls >= 0),
+  reported_cost REAL CHECK (reported_cost IS NULL OR reported_cost >= 0),
+  uncached_input_tokens INTEGER NOT NULL CHECK (uncached_input_tokens >= 0),
+  cache_read_tokens INTEGER NOT NULL CHECK (cache_read_tokens >= 0),
+  cache_write_tokens INTEGER CHECK (
+    cache_write_tokens IS NULL OR cache_write_tokens > 0
+  ),
+  cache_write_5m_tokens INTEGER CHECK (
+    cache_write_5m_tokens IS NULL OR cache_write_5m_tokens >= 0
+  ),
+  cache_write_1h_tokens INTEGER CHECK (
+    cache_write_1h_tokens IS NULL OR cache_write_1h_tokens >= 0
+  ),
+  fresh_prompt_tokens INTEGER NOT NULL CHECK (fresh_prompt_tokens >= 0),
+  output_tokens INTEGER NOT NULL CHECK (output_tokens >= 0),
+  reasoning_tokens INTEGER NOT NULL CHECK (reasoning_tokens >= 0),
+  processed_tokens INTEGER NOT NULL CHECK (processed_tokens >= 0)
+);
+
+CREATE INDEX sessions_updated_idx
+  ON sessions(updated_at DESC, source_session_id DESC);
+
+CREATE TABLE turns (
+  id INTEGER PRIMARY KEY,
+  session_id INTEGER NOT NULL
+    REFERENCES sessions(source_session_id) ON DELETE CASCADE,
+  ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+  started_at INTEGER NOT NULL,
+  UNIQUE (session_id, ordinal)
+);
+
+CREATE TABLE turn_inputs (
+  id INTEGER PRIMARY KEY,
+  turn_id INTEGER NOT NULL REFERENCES turns(id) ON DELETE CASCADE,
+  ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+  kind TEXT NOT NULL,
+  preview TEXT,
+  original_length INTEGER CHECK (
+    original_length IS NULL OR original_length >= 0
+  ),
+  truncated INTEGER NOT NULL DEFAULT 0 CHECK (truncated IN (0, 1)),
+  mime_type TEXT,
+  content_hash TEXT,
+  UNIQUE (turn_id, ordinal)
+);
+
+CREATE TABLE models (
+  id INTEGER PRIMARY KEY,
+  provider TEXT NOT NULL,
+  name TEXT NOT NULL,
+  UNIQUE (provider, name)
+);
+
+CREATE TABLE model_calls (
+  id INTEGER PRIMARY KEY,
+  turn_id INTEGER NOT NULL REFERENCES turns(id) ON DELETE CASCADE,
+  source_call_id TEXT,
+  ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+  model_id INTEGER NOT NULL REFERENCES models(id) ON DELETE RESTRICT,
+  started_at INTEGER NOT NULL,
+  completed_at INTEGER,
+  reported_cost REAL CHECK (reported_cost IS NULL OR reported_cost >= 0),
+  uncached_input_tokens INTEGER NOT NULL CHECK (uncached_input_tokens >= 0),
+  cache_read_tokens INTEGER NOT NULL CHECK (cache_read_tokens >= 0),
+  cache_write_tokens INTEGER CHECK (
+    cache_write_tokens IS NULL OR cache_write_tokens > 0
+  ),
+  cache_write_5m_tokens INTEGER CHECK (
+    cache_write_5m_tokens IS NULL OR cache_write_5m_tokens >= 0
+  ),
+  cache_write_1h_tokens INTEGER CHECK (
+    cache_write_1h_tokens IS NULL OR cache_write_1h_tokens >= 0
+  ),
+  fresh_prompt_tokens INTEGER NOT NULL CHECK (fresh_prompt_tokens >= 0),
+  output_tokens INTEGER NOT NULL CHECK (output_tokens >= 0),
+  reasoning_tokens INTEGER NOT NULL CHECK (reasoning_tokens >= 0),
+  processed_tokens INTEGER NOT NULL CHECK (processed_tokens >= 0),
+  finish_reason TEXT,
+  images INTEGER CHECK (images IS NULL OR images > 0),
+  has_text INTEGER NOT NULL CHECK (has_text IN (0, 1)),
+  has_reasoning INTEGER NOT NULL CHECK (has_reasoning IN (0, 1)),
+  UNIQUE (turn_id, ordinal)
+);
+
+CREATE INDEX model_calls_started_idx ON model_calls(started_at);
+
+CREATE TABLE call_content (
+  id INTEGER PRIMARY KEY,
+  model_call_id INTEGER NOT NULL
+    REFERENCES model_calls(id) ON DELETE CASCADE,
+  ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+  kind TEXT NOT NULL,
+  preview TEXT,
+  original_length INTEGER CHECK (
+    original_length IS NULL OR original_length >= 0
+  ),
+  truncated INTEGER NOT NULL DEFAULT 0 CHECK (truncated IN (0, 1)),
+  mime_type TEXT,
+  content_hash TEXT,
+  UNIQUE (model_call_id, ordinal)
+);
+
+CREATE TABLE tool_events (
+  id INTEGER PRIMARY KEY,
+  model_call_id INTEGER NOT NULL
+    REFERENCES model_calls(id) ON DELETE CASCADE,
+  source_tool_id TEXT,
+  ordinal INTEGER NOT NULL CHECK (ordinal > 0),
+  name TEXT NOT NULL,
+  status TEXT NOT NULL,
+  started_at INTEGER,
+  completed_at INTEGER,
+  child_source_session_id INTEGER
+    REFERENCES source_sessions(id) ON DELETE SET NULL,
+  input_preview TEXT,
+  input_original_length INTEGER CHECK (
+    input_original_length IS NULL OR input_original_length >= 0
+  ),
+  input_truncated INTEGER NOT NULL DEFAULT 0 CHECK (
+    input_truncated IN (0, 1)
+  ),
+  output_preview TEXT,
+  output_original_length INTEGER CHECK (
+    output_original_length IS NULL OR output_original_length >= 0
+  ),
+  output_truncated INTEGER NOT NULL DEFAULT 0 CHECK (
+    output_truncated IN (0, 1)
+  ),
+  UNIQUE (model_call_id, ordinal)
+);
+
+-- migrate:down
+DROP TABLE tool_events;
+DROP TABLE call_content;
+DROP TABLE model_calls;
+DROP TABLE models;
+DROP TABLE turn_inputs;
+DROP TABLE turns;
+DROP TABLE sessions;
+DROP TABLE source_sessions;
+DROP TABLE sources;

--- a/db/migrations/20260714130000_add_source_session_public_and_tree_ids.sql
+++ b/db/migrations/20260714130000_add_source_session_public_and_tree_ids.sql
@@ -1,0 +1,25 @@
+-- migrate:up
+ALTER TABLE source_sessions ADD COLUMN public_id TEXT;
+UPDATE source_sessions SET public_id = external_id;
+
+ALTER TABLE source_sessions ADD COLUMN tree_root_id INTEGER
+  REFERENCES source_sessions(id) ON DELETE CASCADE;
+
+WITH RECURSIVE source_session_trees(id, root_id) AS (
+  SELECT id, id FROM source_sessions WHERE parent_id IS NULL
+  UNION ALL
+  SELECT child.id, source_session_trees.root_id
+  FROM source_sessions child
+  JOIN source_session_trees ON child.parent_id = source_session_trees.id
+)
+UPDATE source_sessions
+SET tree_root_id = (
+  SELECT root_id FROM source_session_trees WHERE source_session_trees.id = source_sessions.id
+);
+
+CREATE INDEX source_sessions_tree_root_idx ON source_sessions(tree_root_id);
+
+-- migrate:down
+DROP INDEX source_sessions_tree_root_idx;
+ALTER TABLE source_sessions DROP COLUMN tree_root_id;
+ALTER TABLE source_sessions DROP COLUMN public_id;

--- a/db/migrations/20260714140000_add_source_session_change_hint.sql
+++ b/db/migrations/20260714140000_add_source_session_change_hint.sql
@@ -1,0 +1,5 @@
+-- migrate:up
+ALTER TABLE source_sessions ADD COLUMN change_hint TEXT;
+
+-- migrate:down
+ALTER TABLE source_sessions DROP COLUMN change_hint;

--- a/deno.json
+++ b/deno.json
@@ -28,11 +28,16 @@
     "include": ["src/", "deno.json", "vite.config.ts", "index.html"]
   },
   "tasks": {
+    "db:new": "deno run -A npm:dbmate@^2.28.0 --migrations-dir db/migrations --env FRUGAL_TOKENS_DATABASE_URL new",
+    "db:prepare": "deno run --env-file=.env --allow-env=FRUGAL_TOKENS_DATABASE_URL --allow-write scripts/prepareDatabase.ts",
+    "db:migrate": "deno task db:prepare && deno run -A npm:dbmate@^2.28.0 --migrations-dir db/migrations --no-dump-schema --env FRUGAL_TOKENS_DATABASE_URL up",
+    "db:rollback": "deno run -A npm:dbmate@^2.28.0 --migrations-dir db/migrations --env FRUGAL_TOKENS_DATABASE_URL down",
+    "db:status": "deno run -A npm:dbmate@^2.28.0 --migrations-dir db/migrations --env FRUGAL_TOKENS_DATABASE_URL status",
     "dev": "deno run -A npm:concurrently@10.0.3 --kill-others-on-fail --names api,web 'deno task dev:server' 'deno task dev:client'",
-    "dev:server": "deno run --env-file=.env --allow-env=OPENCODE_DB_PATH,CLAUDE_CODE_PROJECT_PATH,PI_SESSION_DIR,CODEX_SESSION_DIR,PORT --allow-read --allow-net --watch=src/server,src/shared src/server/main.ts",
+    "dev:server": "deno task db:migrate && deno run --env-file=.env --allow-env=OPENCODE_DB_PATH,CLAUDE_CODE_PROJECT_PATH,PI_SESSION_DIR,CODEX_SESSION_DIR,FRUGAL_TOKENS_DATABASE_URL,PORT --allow-read --allow-write --allow-net --watch=src/server,src/shared src/server/main.ts",
     "dev:client": "deno run -A npm:vite@8.1.4",
     "build": "deno run -A npm:vite@8.1.4 build",
-    "start": "deno run --env-file=.env --allow-env=OPENCODE_DB_PATH,CLAUDE_CODE_PROJECT_PATH,PI_SESSION_DIR,CODEX_SESSION_DIR,PORT --allow-read --allow-net src/server/main.ts",
+    "start": "deno task db:migrate && deno run --env-file=.env --allow-env=OPENCODE_DB_PATH,CLAUDE_CODE_PROJECT_PATH,PI_SESSION_DIR,CODEX_SESSION_DIR,FRUGAL_TOKENS_DATABASE_URL,PORT --allow-read --allow-write --allow-net src/server/main.ts",
     "check": "deno check src/server/main.ts src/client/main.tsx vite.config.ts",
     "test": "deno test --allow-env --allow-read --allow-write"
   }

--- a/deno.lock
+++ b/deno.lock
@@ -6,6 +6,7 @@
     "npm:@types/react@19.2.17": "19.2.17",
     "npm:@vitejs/plugin-react@6.0.3": "6.0.3_vite@8.1.4",
     "npm:concurrently@10.0.3": "10.0.3",
+    "npm:dbmate@^2.28.0": "2.33.0",
     "npm:hono@4.12.29": "4.12.29",
     "npm:react-dom@19.2.7": "19.2.7_react@19.2.7",
     "npm:react@19.2.7": "19.2.7",
@@ -14,6 +15,41 @@
     "npm:zod@4.4.3": "4.4.3"
   },
   "npm": {
+    "@dbmate/darwin-arm64@2.33.0": {
+      "integrity": "sha512-YbB2IYigcHV+5qo35wvHoKdRXPQdtXv+tUoiEEhXX9gmJm8t/OqsPguR5m7+6rRHE7hsBEtxruykBOKVArqc0A==",
+      "os": ["darwin"],
+      "cpu": ["arm64"]
+    },
+    "@dbmate/darwin-x64@2.33.0": {
+      "integrity": "sha512-6y4BSqUj6m9halhUi6PNVOUBmsciRjCFAlXWk0WFu35Eg7ojZWWW3BRD7bRcQwZcsmjKn6uCb/k5hFci5/gkxQ==",
+      "os": ["darwin"],
+      "cpu": ["x64"]
+    },
+    "@dbmate/linux-arm64@2.33.0": {
+      "integrity": "sha512-HFYIGBKTI+BQC8Ps6nzj1Zb8w7I61IGstveNeEQYKTxkV1CPDMajYX52heJ7Jv3ignOrzzy054YhV+z+j6xV8g==",
+      "os": ["linux"],
+      "cpu": ["arm64"]
+    },
+    "@dbmate/linux-arm@2.33.0": {
+      "integrity": "sha512-Xm6w63BjPtab0LgAleDqzhSDIvFJOqN7v8RMJaydPlrPNIBauJwEOWKu5nSnUGNKi9PHZXIHCu0hI8m0fAI6eQ==",
+      "os": ["linux"],
+      "cpu": ["arm"]
+    },
+    "@dbmate/linux-ia32@2.33.0": {
+      "integrity": "sha512-tyVbpGPRds5Rf5AbP5W1+ip319GZTWqy+jjMWKVyAuEbH/6Kjn88RhVqG6f7NsOvHgS3aekOQIBW6ZMkm0crEw==",
+      "os": ["linux"],
+      "cpu": ["ia32"]
+    },
+    "@dbmate/linux-x64@2.33.0": {
+      "integrity": "sha512-SxzgU1TzWA37N2GuOUCcV2JjQKiEdzQzfI7k15YRxPw2K3UZc2hueFtF1l2HAoilDi8ekOV2JFUb9XmfqhgSrA==",
+      "os": ["linux"],
+      "cpu": ["x64"]
+    },
+    "@dbmate/win32-x64@2.33.0": {
+      "integrity": "sha512-1axw11wBuJ6mLByBtJg4o7fxUkyX+Vz435N3vfdH8OdSPWnpygp/nVyo3iz58SR7XnJkCJBzoKjtsRONeAsO2g==",
+      "os": ["win32"],
+      "cpu": ["x64"]
+    },
     "@emnapi/core@1.11.1": {
       "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
       "dependencies": [
@@ -340,6 +376,19 @@
     },
     "d3-timer@3.0.1": {
       "integrity": "sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA=="
+    },
+    "dbmate@2.33.0": {
+      "integrity": "sha512-UNyMVmEt+AS0xXrcPIHtSRF8eMgh9YJDUyW2S/l8QO/yB8uGT4eO1g18g+4GKdkPWVY9NHUTA1584jvWHK57JQ==",
+      "optionalDependencies": [
+        "@dbmate/darwin-arm64",
+        "@dbmate/darwin-x64",
+        "@dbmate/linux-arm",
+        "@dbmate/linux-arm64",
+        "@dbmate/linux-ia32",
+        "@dbmate/linux-x64",
+        "@dbmate/win32-x64"
+      ],
+      "bin": true
     },
     "decimal.js-light@2.5.1": {
       "integrity": "sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg=="

--- a/scripts/prepareDatabase.ts
+++ b/scripts/prepareDatabase.ts
@@ -1,0 +1,9 @@
+import { dirname } from "node:path";
+import { sqlitePath } from "../src/server/database.ts";
+
+const databaseURL = Deno.env.get("FRUGAL_TOKENS_DATABASE_URL");
+if (!databaseURL) {
+  throw new Error("FRUGAL_TOKENS_DATABASE_URL is not set");
+}
+
+Deno.mkdirSync(dirname(sqlitePath(databaseURL)), { recursive: true });

--- a/src/server/cacheAnalysis.test.ts
+++ b/src/server/cacheAnalysis.test.ts
@@ -4,12 +4,12 @@ import {
   assessCache,
   summarizeSessionCache,
   summarizeTurnCache,
-} from "../src/server/cacheAnalysis.ts";
+} from "./cacheAnalysis.ts";
 import type {
   ModelCall,
   SessionDetail,
   TokenUsage,
-} from "../src/shared/sessionSchemas.ts";
+} from "../shared/sessionSchemas.ts";
 
 function tokens(cacheRead: number, cacheWrite?: number): TokenUsage {
   return {

--- a/src/server/claudeCodeImporter.test.ts
+++ b/src/server/claudeCodeImporter.test.ts
@@ -1,0 +1,161 @@
+import { strictEqual } from "node:assert/strict";
+import { syncClaudeCodeSessions } from "./claudeCodeImporter.ts";
+import { openArchiveDatabase } from "./database.ts";
+import { migrateTestDatabase } from "./databaseTestUtils.ts";
+import { SessionRepository } from "./sessionRepository.ts";
+
+function write(path: string, content: string) {
+  Deno.mkdirSync(path.slice(0, path.lastIndexOf("/")), { recursive: true });
+  Deno.writeTextFileSync(path, content.trim());
+}
+
+Deno.test("imports a Claude Code root and namespaced child tree", async () => {
+  const directory = Deno.makeTempDirSync();
+  const sessions = `${directory}/projects`;
+  const project = `${sessions}/project`;
+  const longPrompt = "p".repeat(600);
+  write(
+    `${project}/root.jsonl`,
+    `
+{"type":"user","timestamp":"2026-07-14T10:00:00Z","promptSource":"typed","origin":{"kind":"human"},"message":{"content":"${longPrompt}"}}
+{"type":"assistant","timestamp":"2026-07-14T10:00:01Z","message":{"id":"root-call","model":"claude-opus","stop_reason":"tool_use","content":[{"type":"thinking","thinking":"secret reasoning"},{"type":"text","text":"Calling child"},{"type":"tool_use","id":"tool-1","name":"Agent","input":{"prompt":"investigate"}}],"usage":{"input_tokens":2,"cache_read_input_tokens":3,"cache_creation_input_tokens":4,"output_tokens":5}}}
+{"type":"user","timestamp":"2026-07-14T10:00:02Z","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"child output"}]},"toolUseResult":{"agentId":"child"}}
+{"type":"user","timestamp":"2026-07-14T10:00:03Z","message":{"content":[{"type":"tool_result","tool_use_id":"unknown","content":"plain output"}]},"toolUseResult":"plain output"}
+  `,
+  );
+  write(
+    `${project}/root/subagents/agent-child.jsonl`,
+    `
+{"type":"user","timestamp":"2026-07-14T10:00:01Z","isSidechain":true,"message":{"content":"Investigate"}}
+{"type":"assistant","timestamp":"2026-07-14T10:00:02Z","message":{"id":"child-call","model":"claude-sonnet","content":[{"type":"text","text":"Child answer"}],"usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+  `,
+  );
+  write(
+    `${project}/root/subagents/agent-child.meta.json`,
+    JSON.stringify({
+      description: "Explorer child",
+      agentType: "Explore",
+    }),
+  );
+  write(
+    `${project}/sessions-index.json`,
+    JSON.stringify({
+      entries: [{ sessionId: "root", summary: "Indexed root" }],
+    }),
+  );
+
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  migrateTestDatabase(db);
+  const repository = new SessionRepository(db);
+  try {
+    const result = await syncClaudeCodeSessions(sessions, repository);
+    strictEqual(result.imported, 1);
+    const detail = repository.getSession("claude-code", "project/root")!;
+    strictEqual(detail.title, "Indexed root");
+    strictEqual(detail.subagents[0].id, "child");
+    strictEqual(detail.subagents[0].parentID, "project/root");
+    strictEqual(detail.subagents[0].title, "Explorer child");
+    strictEqual(detail.subagents[0].agent, "Explore");
+    strictEqual(
+      detail.turns[0].calls[0].activity.tools[0].childSessionID,
+      "child",
+    );
+    const childIdentity = db.prepare(`
+      SELECT external_id, public_id FROM source_sessions WHERE parent_id IS NOT NULL
+    `).get() as { external_id: string; public_id: string };
+    strictEqual(childIdentity.public_id, "child");
+    strictEqual(
+      childIdentity.external_id,
+      "project/root::project/root/subagents/agent-child.jsonl",
+    );
+    const input = db.prepare("SELECT preview, original_length FROM turn_inputs")
+      .get()!;
+    strictEqual(input.preview, longPrompt.slice(0, 512));
+    strictEqual(input.original_length, 600);
+    strictEqual(
+      db.prepare("SELECT preview FROM call_content WHERE kind = 'text'").get()!
+        .preview,
+      "Calling child",
+    );
+    strictEqual(
+      db.prepare("SELECT preview FROM call_content WHERE kind = 'reasoning'")
+        .get()!.preview,
+      null,
+    );
+    const tool = db.prepare(`
+      SELECT input_preview, output_preview FROM tool_events WHERE name = 'Agent'
+    `).get()!;
+    strictEqual(tool.input_preview, '{"prompt":"investigate"}');
+    strictEqual(tool.output_preview, "child output");
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});
+
+Deno.test("skips unchanged Claude trees and reimports index and agent metadata changes", async () => {
+  const directory = Deno.makeTempDirSync();
+  const sessions = `${directory}/projects`;
+  const project = `${sessions}/project`;
+  write(
+    `${project}/root.jsonl`,
+    `
+{"type":"user","timestamp":"2026-07-14T10:00:00Z","promptSource":"typed","message":{"content":"Root"}}
+{"type":"assistant","timestamp":"2026-07-14T10:00:01Z","message":{"id":"call","model":"claude-sonnet","content":[{"type":"text","text":"Done"}],"usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+  `,
+  );
+  write(
+    `${project}/root/subagents/agent-child.jsonl`,
+    `
+{"type":"user","timestamp":"2026-07-14T10:00:00Z","isSidechain":true,"message":{"content":"Child"}}
+{"type":"assistant","timestamp":"2026-07-14T10:00:01Z","message":{"id":"child-call","model":"claude-sonnet","content":[{"type":"text","text":"Done"}],"usage":{"input_tokens":1,"cache_read_input_tokens":0,"cache_creation_input_tokens":0,"output_tokens":1}}}
+  `,
+  );
+  const metaPath = `${project}/root/subagents/agent-child.meta.json`;
+  const indexPath = `${project}/sessions-index.json`;
+  write(metaPath, '{"description":"First child"}');
+  write(
+    indexPath,
+    '{"entries":[{"sessionId":"root","summary":"First title"}]}',
+  );
+
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  migrateTestDatabase(db);
+  const repository = new SessionRepository(db);
+  try {
+    strictEqual(
+      (await syncClaudeCodeSessions(sessions, repository)).imported,
+      1,
+    );
+    strictEqual(
+      (await syncClaudeCodeSessions(sessions, repository)).skipped,
+      1,
+    );
+
+    write(
+      indexPath,
+      '{"entries":[{"sessionId":"root","summary":"Changed title"}]}',
+    );
+    strictEqual(
+      (await syncClaudeCodeSessions(sessions, repository)).imported,
+      1,
+    );
+    strictEqual(
+      repository.getSession("claude-code", "project/root")?.title,
+      "Changed title",
+    );
+
+    write(metaPath, '{"description":"Changed child description"}');
+    strictEqual(
+      (await syncClaudeCodeSessions(sessions, repository)).imported,
+      1,
+    );
+    strictEqual(
+      repository.getSession("claude-code", "project/root")?.subagents[0].title,
+      "Changed child description",
+    );
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});

--- a/src/server/claudeCodeImporter.ts
+++ b/src/server/claudeCodeImporter.ts
@@ -1,0 +1,178 @@
+import {
+  type ClaudeCodeSessionCandidate,
+  discoverClaudeCodeSessions,
+  normalizeClaudeCodeSessionTree,
+} from "./claudeCodeRepository.ts";
+import { SessionRepository } from "./sessionRepository.ts";
+
+const parserVersion = "claude-code-1";
+
+function externalID(
+  candidate: ClaudeCodeSessionCandidate,
+  artifactPath: string,
+) {
+  return artifactPath === candidate.artifactPath
+    ? candidate.id
+    : `${candidate.id}::${artifactPath}`;
+}
+
+function recordUnchangedTree(
+  repository: SessionRepository,
+  sourceID: number,
+  candidate: ClaudeCodeSessionCandidate,
+  observedAt: number,
+  checkpoint?: {
+    sourceSize: number;
+    sourceModifiedAt: number;
+    checksum?: string;
+    parserVersion: string;
+  },
+) {
+  for (const dependency of candidate.dependencies) {
+    if (!dependency.artifactPath.endsWith(".jsonl")) continue;
+    repository.recordUnchangedSourceSession(
+      sourceID,
+      externalID(candidate, dependency.artifactPath),
+      dependency.artifactPath,
+      observedAt,
+      checkpoint,
+    );
+  }
+}
+
+function dependencyHint(candidate: ClaudeCodeSessionCandidate) {
+  return candidate.dependencies.map((dependency) =>
+    `${dependency.artifactPath}\0${dependency.size}\0${dependency.updatedAt}`
+  ).join("\n");
+}
+
+async function fingerprint(
+  candidate: ClaudeCodeSessionCandidate,
+  snapshots: Map<string, Uint8Array>,
+) {
+  const encoder = new TextEncoder();
+  const chunks = candidate.dependencies.flatMap((dependency) => [
+    encoder.encode(`${dependency.artifactPath}\0${dependency.size}\0`),
+    snapshots.get(dependency.path)!,
+    new Uint8Array([0]),
+  ]);
+  const size = chunks.reduce((sum, chunk) => sum + chunk.byteLength, 0);
+  const value = new Uint8Array(size);
+  let offset = 0;
+  for (const chunk of chunks) {
+    value.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  const digest = await crypto.subtle.digest("SHA-256", value);
+  return Array.from(
+    new Uint8Array(digest),
+    (byte) => byte.toString(16).padStart(2, "0"),
+  ).join("");
+}
+
+export async function syncClaudeCodeSessions(
+  directory: string,
+  repository: SessionRepository,
+) {
+  const observedAt = Date.now();
+  const sourceID = repository.ensureSource(
+    "claude-code",
+    "directory",
+    "Claude Code",
+    directory,
+  );
+  const candidates = discoverClaudeCodeSessions(directory);
+  let imported = 0;
+  let skipped = 0;
+  let failed = 0;
+
+  for (const candidate of candidates) {
+    const previous = repository.checkpoint(sourceID, candidate.id);
+    if (
+      previous?.parserVersion === parserVersion &&
+      previous.sourceSize === candidate.size &&
+      previous.sourceModifiedAt === candidate.changeHint
+    ) {
+      recordUnchangedTree(repository, sourceID, candidate, observedAt);
+      skipped++;
+      continue;
+    }
+
+    try {
+      const snapshots = new Map<string, Uint8Array>();
+      for (const dependency of candidate.dependencies) {
+        const bytes = Deno.readFileSync(dependency.path);
+        const stat = Deno.statSync(dependency.path);
+        if (
+          stat.size !== dependency.size ||
+          (stat.mtime?.getTime() ?? 0) !== dependency.updatedAt
+        ) {
+          throw new Error(
+            "Claude Code dependency changed while it was being read",
+          );
+        }
+        snapshots.set(dependency.path, bytes);
+      }
+      const afterRead = discoverClaudeCodeSessions(directory).find((item) =>
+        item.id === candidate.id
+      );
+      if (
+        !afterRead || dependencyHint(afterRead) !== dependencyHint(candidate)
+      ) {
+        throw new Error(
+          "Claude Code dependency tree changed while it was being read",
+        );
+      }
+      const checksum = await fingerprint(candidate, snapshots);
+      const checkpoint = {
+        sourceSize: candidate.size,
+        sourceModifiedAt: candidate.changeHint,
+        checksum,
+        parserVersion,
+      };
+      if (
+        previous?.parserVersion === parserVersion &&
+        previous.checksum === checksum
+      ) {
+        recordUnchangedTree(
+          repository,
+          sourceID,
+          candidate,
+          observedAt,
+          checkpoint,
+        );
+        skipped++;
+        continue;
+      }
+      repository.replaceSourceSessionTree(normalizeClaudeCodeSessionTree({
+        candidate,
+        snapshots,
+        sourceID,
+        observedAt,
+        checkpoint,
+      }));
+      imported++;
+    } catch (error) {
+      console.warn(
+        `[sync] harness=claude-code source=${candidate.path} failed`,
+        error,
+      );
+      repository.recordSourceSessionError(
+        sourceID,
+        candidate.id,
+        candidate.artifactPath,
+        observedAt,
+        error,
+      );
+      failed++;
+    }
+  }
+
+  repository.markMissingSourceSessions(sourceID, observedAt);
+  return {
+    discovered: candidates.length,
+    imported,
+    skipped,
+    failed,
+  };
+}

--- a/src/server/claudeCodeRepository.test.ts
+++ b/src/server/claudeCodeRepository.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual } from "node:assert/strict";
-import { ClaudeCodeRepository } from "../src/server/claudeCodeRepository.ts";
-import type { SessionDetail } from "../src/shared/sessionSchemas.ts";
+import { ClaudeCodeRepository } from "./claudeCodeRepository.ts";
+import type { SessionDetail } from "../shared/sessionSchemas.ts";
 
 function repository(files: Record<string, string>) {
   const directory = Deno.makeTempDirSync();

--- a/src/server/claudeCodeRepository.ts
+++ b/src/server/claudeCodeRepository.ts
@@ -1,12 +1,21 @@
 import { z } from "zod";
 import {
-  type ModelCall,
   sessionDetailSchema,
   sessionListResponseSchema,
   type SessionSummary,
   type TokenUsage,
 } from "../shared/sessionSchemas.ts";
 import { usageCallsFromSession } from "./usage.ts";
+import type {
+  SessionCallImport,
+  SessionContentImport,
+  SessionToolImport,
+  SessionTurnImport,
+  SourceSessionCheckpoint,
+  SourceSessionImport,
+} from "./sessionRepository.ts";
+
+const contentPreviewLimit = 512;
 
 const contentBlockSchema = z.object({
   type: z.string(),
@@ -16,6 +25,8 @@ const contentBlockSchema = z.object({
   name: z.string().optional(),
   tool_use_id: z.string().optional(),
   is_error: z.boolean().optional(),
+  input: z.unknown().optional(),
+  content: z.unknown().optional(),
 }).passthrough();
 
 const recordSchema = z.object({
@@ -45,13 +56,45 @@ const recordSchema = z.object({
       }).optional(),
     }).optional(),
   }).passthrough().optional(),
-  toolUseResult: z.object({
-    agentId: z.string().optional(),
-  }).passthrough().optional(),
+  toolUseResult: z.union([
+    z.string(),
+    z.object({
+      agentId: z.string().optional(),
+    }).passthrough(),
+  ]).optional(),
 }).passthrough();
 
 type Record = z.infer<typeof recordSchema>;
 type IndexEntry = { summary?: string; firstPrompt?: string };
+
+const indexSchema = z.object({
+  entries: z.array(z.object({
+    sessionId: z.string(),
+    summary: z.string().optional(),
+    firstPrompt: z.string().optional(),
+  })),
+});
+const agentMetaSchema = z.object({
+  description: z.string().optional(),
+  agentType: z.string().optional(),
+}).passthrough();
+
+export type ClaudeCodeDependency = {
+  path: string;
+  artifactPath: string;
+  size: number;
+  updatedAt: number;
+};
+
+export type ClaudeCodeSessionCandidate = {
+  id: string;
+  path: string;
+  artifactPath: string;
+  dependencies: ClaudeCodeDependency[];
+  size: number;
+  updatedAt: number;
+  changeHint: number;
+};
 
 const emptyTokens = (): TokenUsage => ({
   uncachedInput: 0,
@@ -97,6 +140,42 @@ function readRecords(path: string) {
   return records;
 }
 
+function readRecordsFromText(text: string, strict = false) {
+  const records: Record[] = [];
+  for (const line of text.split("\n")) {
+    if (!line.trim()) continue;
+    try {
+      const result = recordSchema.safeParse(JSON.parse(line));
+      if (result.success) records.push(result.data);
+      else if (strict) throw result.error;
+    } catch (error) {
+      if (strict) throw error;
+    }
+  }
+  return records;
+}
+
+function preview(value: string): SessionContentImport {
+  return {
+    kind: "text",
+    preview: value.slice(0, contentPreviewLimit),
+    originalLength: value.length,
+    truncated: value.length > contentPreviewLimit,
+  };
+}
+
+function serializedPreview(value: unknown) {
+  if (value === undefined) return undefined;
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (text === undefined) return undefined;
+  const valuePreview = preview(text);
+  return {
+    preview: valuePreview.preview,
+    originalLength: valuePreview.originalLength,
+    truncated: valuePreview.truncated,
+  };
+}
+
 function blocks(record: Record) {
   return Array.isArray(record.message?.content) ? record.message.content : [];
 }
@@ -117,7 +196,12 @@ function startsTurn(record: Record, hasTurns: boolean) {
 }
 
 function sessionBounds(
-  turns: Array<{ startedAt: number; calls: Array<{ startedAt: number; completedAt?: number }> }>,
+  turns: Array<
+    {
+      startedAt: number;
+      calls: Array<{ startedAt: number; completedAt?: number }>;
+    }
+  >,
 ) {
   if (turns.length === 0) return {};
   const startedAt = Math.min(...turns.map((turn) => turn.startedAt));
@@ -131,12 +215,10 @@ function sessionBounds(
 }
 
 function decodeRecords(records: Record[]) {
-  const turns: Array<
-    { number: number; startedAt: number; calls: ModelCall[] }
-  > = [];
+  const turns: SessionTurnImport[] = [];
   const calls = new Map<
     string,
-    { call: ModelCall; blocks: ReturnType<typeof blocks> }
+    { call: SessionCallImport; blocks: ReturnType<typeof blocks> }
   >();
   const tokens = emptyTokens();
   const providers = new Set<string>();
@@ -146,11 +228,13 @@ function decodeRecords(records: Record[]) {
     const timestamp = Date.parse(record.timestamp ?? "") || 0;
     if (record.type === "user") {
       const content = record.message?.content;
+      const text = userText(record);
       if (startsTurn(record, turns.length > 0)) {
         turns.push({
           number: turns.length + 1,
           startedAt: timestamp,
           calls: [],
+          inputs: text === undefined ? [] : [preview(text)],
         });
       }
       if (Array.isArray(content)) {
@@ -163,9 +247,16 @@ function decodeRecords(records: Record[]) {
             if (tool) {
               tool.status = block.is_error ? "error" : "completed";
               tool.completedAt = timestamp;
-              if (record.toolUseResult?.agentId) {
-                tool.childSessionID = record.toolUseResult.agentId;
+              if (
+                typeof record.toolUseResult === "object" &&
+                record.toolUseResult.agentId
+              ) {
+                (tool as SessionToolImport & { childSessionID?: string })
+                  .childSessionID = record.toolUseResult.agentId;
               }
+              tool.output = serializedPreview(
+                block.content ?? record.toolUseResult,
+              );
             }
           }
         }
@@ -182,8 +273,10 @@ function decodeRecords(records: Record[]) {
     if (!decoded) {
       const source = record.message.usage;
       const cacheWrite = source.cache_creation_input_tokens || undefined;
-      const cacheWrite5m = source.cache_creation?.ephemeral_5m_input_tokens ?? 0;
-      const cacheWrite1h = source.cache_creation?.ephemeral_1h_input_tokens ?? 0;
+      const cacheWrite5m = source.cache_creation?.ephemeral_5m_input_tokens ??
+        0;
+      const cacheWrite1h = source.cache_creation?.ephemeral_1h_input_tokens ??
+        0;
       const callTokens: TokenUsage = {
         uncachedInput: source.input_tokens,
         cacheRead: source.cache_read_input_tokens,
@@ -199,7 +292,7 @@ function decodeRecords(records: Record[]) {
       if (callTokens.processed === 0) continue;
       const turn = turns.at(-1)!;
       const model = record.message.model ?? "unknown";
-      const call: ModelCall = {
+      const call: SessionCallImport = {
         id,
         callWithinTurn: turn.calls.length + 1,
         provider: "anthropic",
@@ -207,6 +300,7 @@ function decodeRecords(records: Record[]) {
         startedAt: timestamp,
         tokens: callTokens,
         activity: { hasText: false, hasReasoning: false, tools: [] },
+        content: [],
       };
       turn.calls.push(call);
       decoded = { call, blocks: [] };
@@ -226,17 +320,27 @@ function decodeRecords(records: Record[]) {
         continue;
       }
       decoded.blocks.push(block);
-      if (block.type === "text") decoded.call.activity.hasText = true;
-      if (block.type === "thinking") decoded.call.activity.hasReasoning = true;
+      if (block.type === "text") {
+        decoded.call.activity.hasText = true;
+        if (block.text !== undefined) {
+          decoded.call.content?.push(preview(block.text));
+        }
+      }
+      if (block.type === "thinking") {
+        decoded.call.activity.hasReasoning = true;
+        decoded.call.content?.push({ kind: "reasoning" });
+      }
       if (block.type === "tool_use" && block.name && block.id) {
         decoded.call.activity.tools.push(
           {
+            sourceID: block.id,
             name: block.name,
             status: "pending",
             startedAt: timestamp,
+            input: serializedPreview(block.input),
             // Kept internally while matching the later tool_result record.
             id: block.id,
-          } as ModelCall["activity"]["tools"][number],
+          } as SessionToolImport,
         );
       }
     }
@@ -245,6 +349,260 @@ function decodeRecords(records: Record[]) {
     .filter((turn) => turn.calls.length > 0)
     .map((turn, index) => ({ ...turn, number: index + 1 }));
   return { turns: nonEmptyTurns, tokens, providers, models };
+}
+
+function dependency(path: string, artifactPath: string): ClaudeCodeDependency {
+  const stat = Deno.statSync(path);
+  return {
+    path,
+    artifactPath,
+    size: stat.size,
+    updatedAt: stat.mtime?.getTime() ?? 0,
+  };
+}
+
+function existingDependency(
+  path: string,
+  artifactPath: string,
+): ClaudeCodeDependency | undefined {
+  try {
+    return dependency(path, artifactPath);
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return undefined;
+    throw error;
+  }
+}
+
+function collectSubagentDependencies(
+  transcriptPath: string,
+  rootDirectory: string,
+  dependencies: ClaudeCodeDependency[],
+) {
+  const subagents = `${transcriptPath.slice(0, -6)}/subagents`;
+  let entries: Deno.DirEntry[];
+  try {
+    entries = [...Deno.readDirSync(subagents)];
+  } catch (error) {
+    if (error instanceof Deno.errors.NotFound) return;
+    throw error;
+  }
+  for (const entry of entries.sort((a, b) => a.name.localeCompare(b.name))) {
+    if (
+      !entry.isFile || !entry.name.startsWith("agent-") ||
+      !entry.name.endsWith(".jsonl")
+    ) continue;
+    const path = `${subagents}/${entry.name}`;
+    const artifactPath = path.slice(rootDirectory.length + 1);
+    dependencies.push(dependency(path, artifactPath));
+    const metaPath = path.slice(0, -6) + ".meta.json";
+    const meta = existingDependency(
+      metaPath,
+      metaPath.slice(rootDirectory.length + 1),
+    );
+    if (meta) dependencies.push(meta);
+    collectSubagentDependencies(path, rootDirectory, dependencies);
+  }
+}
+
+function metadataHint(dependencies: ClaudeCodeDependency[]) {
+  let hash = 2166136261;
+  for (const item of dependencies) {
+    const value = `${item.artifactPath}\0${item.size}\0${item.updatedAt}`;
+    for (let index = 0; index < value.length; index++) {
+      hash ^= value.charCodeAt(index);
+      hash = Math.imul(hash, 16777619);
+    }
+  }
+  return hash >>> 0;
+}
+
+export function discoverClaudeCodeSessions(
+  directory: string,
+): ClaudeCodeSessionCandidate[] {
+  const roots: Array<{ id: string; path: string; artifactPath: string }> = [];
+  for (const entry of Deno.readDirSync(directory)) {
+    if (entry.isFile && entry.name.endsWith(".jsonl")) {
+      roots.push({
+        id: entry.name.slice(0, -6),
+        path: `${directory}/${entry.name}`,
+        artifactPath: entry.name,
+      });
+      continue;
+    }
+    if (!entry.isDirectory) continue;
+    for (const session of Deno.readDirSync(`${directory}/${entry.name}`)) {
+      if (!session.isFile || !session.name.endsWith(".jsonl")) continue;
+      roots.push({
+        id: `${entry.name}/${session.name.slice(0, -6)}`,
+        path: `${directory}/${entry.name}/${session.name}`,
+        artifactPath: `${entry.name}/${session.name}`,
+      });
+    }
+  }
+
+  return roots.map((root) => {
+    const dependencies = [dependency(root.path, root.artifactPath)];
+    collectSubagentDependencies(root.path, directory, dependencies);
+    const rootParent = root.path.slice(0, root.path.lastIndexOf("/"));
+    const indexPath = `${rootParent}/sessions-index.json`;
+    const index = existingDependency(
+      indexPath,
+      indexPath.slice(directory.length + 1),
+    );
+    if (index) dependencies.push(index);
+    dependencies.sort((a, b) => a.artifactPath.localeCompare(b.artifactPath));
+    return {
+      ...root,
+      dependencies,
+      size: dependencies.reduce((sum, item) => sum + item.size, 0),
+      updatedAt: dependencies.find((item) =>
+        item.path === root.path
+      )!.updatedAt,
+      changeHint: metadataHint(dependencies),
+    };
+  }).sort((a, b) => b.updatedAt - a.updatedAt || b.id.localeCompare(a.id));
+}
+
+function normalizedTitle(
+  records: Record[],
+  id: string,
+  index?: IndexEntry,
+  override?: string,
+) {
+  const customTitle = [...records].reverse().find((record) =>
+    record.customTitle
+  )
+    ?.customTitle;
+  const generatedTitle = [...records].reverse().find((record) => record.aiTitle)
+    ?.aiTitle;
+  const firstPrompt = records.find((record) => startsTurn(record, false));
+  const promptTitle = userText(firstPrompt ?? { type: "" })?.replace(
+    /\s+/g,
+    " ",
+  )
+    .trim().slice(0, 100);
+  return override ?? customTitle ?? index?.summary ?? generatedTitle ??
+    index?.firstPrompt ?? promptTitle ??
+    `Claude Code session ${id.slice(0, 8)}`;
+}
+
+export function normalizeClaudeCodeSessionTree(options: {
+  candidate: ClaudeCodeSessionCandidate;
+  snapshots: Map<string, Uint8Array>;
+  sourceID: number;
+  observedAt: number;
+  checkpoint: SourceSessionCheckpoint;
+}): SourceSessionImport[] {
+  const decoder = new TextDecoder();
+  const text = (path: string) => {
+    const bytes = options.snapshots.get(path);
+    if (!bytes) {
+      throw new Error(`Missing Claude Code dependency snapshot: ${path}`);
+    }
+    return decoder.decode(bytes);
+  };
+  const indexDependency = options.candidate.dependencies.find((item) =>
+    item.artifactPath.endsWith("sessions-index.json")
+  );
+  const index = indexDependency
+    ? indexSchema.parse(JSON.parse(text(indexDependency.path))).entries.find(
+      (entry) => entry.sessionId === options.candidate.id.split("/").at(-1),
+    )
+    : undefined;
+  const transcripts = options.candidate.dependencies.filter((item) =>
+    item.artifactPath.endsWith(".jsonl")
+  );
+  const externalIDs = new Map<string, string>();
+  for (const transcript of transcripts) {
+    externalIDs.set(
+      transcript.artifactPath,
+      transcript.path === options.candidate.path
+        ? options.candidate.id
+        : `${options.candidate.id}::${transcript.artifactPath}`,
+    );
+  }
+
+  return transcripts.map((transcript) => {
+    const isRoot = transcript.path === options.candidate.path;
+    const records = readRecordsFromText(text(transcript.path), true);
+    const decoded = decodeRecords(records);
+    const rawID = isRoot
+      ? options.candidate.id
+      : transcript.artifactPath.split("/").at(-1)!.slice(6, -6);
+    const parentArtifactPath = isRoot
+      ? undefined
+      : transcript.artifactPath.replace(
+        /\/subagents\/agent-[^/]+\.jsonl$/,
+        ".jsonl",
+      );
+    const metaPath = transcript.path.slice(0, -6) + ".meta.json";
+    const metaDependency = options.candidate.dependencies.find((item) =>
+      item.path === metaPath
+    );
+    const meta = metaDependency
+      ? agentMetaSchema.parse(JSON.parse(text(metaPath)))
+      : undefined;
+    for (const turn of decoded.turns) {
+      for (const call of turn.calls) {
+        for (const tool of call.activity.tools) {
+          const rawChild = (tool as SessionToolImport & {
+            childSessionID?: string;
+          }).childSessionID;
+          delete (tool as SessionToolImport & { childSessionID?: string })
+            .childSessionID;
+          if (rawChild) {
+            const child = transcripts.find((item) =>
+              item.artifactPath.startsWith(
+                transcript.artifactPath.slice(0, -6) + "/subagents/",
+              ) && item.artifactPath.endsWith(`/agent-${rawChild}.jsonl`)
+            );
+            if (child) {
+              tool.childExternalID = externalIDs.get(child.artifactPath);
+            }
+          }
+        }
+      }
+    }
+    const transcriptUpdatedAt = [...records].reverse().find((record) =>
+      record.timestamp && Number.isFinite(Date.parse(record.timestamp))
+    )?.timestamp;
+    const bounds = sessionBounds(decoded.turns);
+    const externalID = externalIDs.get(transcript.artifactPath)!;
+    return {
+      sourceID: options.sourceID,
+      externalID,
+      publicID: rawID,
+      parentExternalID: parentArtifactPath === undefined
+        ? undefined
+        : externalIDs.get(parentArtifactPath),
+      artifactPath: transcript.artifactPath,
+      observedAt: options.observedAt,
+      checkpoint: options.checkpoint,
+      session: {
+        title: normalizedTitle(
+          records,
+          rawID,
+          isRoot ? index : undefined,
+          meta?.description,
+        ),
+        agent: meta?.agentType,
+        updatedAt: transcriptUpdatedAt
+          ? Date.parse(transcriptUpdatedAt)
+          : transcript.updatedAt,
+        startedAt: bounds.startedAt,
+        endedAt: bounds.endedAt,
+        providers: [...decoded.providers],
+        models: [...decoded.models],
+        userTurns: decoded.turns.length,
+        modelCalls: decoded.turns.reduce(
+          (sum, turn) => sum + turn.calls.length,
+          0,
+        ),
+        tokens: decoded.tokens,
+        turns: decoded.turns,
+      },
+    };
+  });
 }
 
 export class ClaudeCodeRepository {
@@ -353,7 +711,10 @@ export class ClaudeCodeRepository {
       record.aiTitle
     )?.aiTitle;
     const firstPrompt = records.find((record) => startsTurn(record, false));
-    const promptTitle = userText(firstPrompt ?? { type: "" })?.replace(/\s+/g, " ")
+    const promptTitle = userText(firstPrompt ?? { type: "" })?.replace(
+      /\s+/g,
+      " ",
+    )
       .trim().slice(0, 100);
     const transcriptUpdatedAt = [...records].reverse().find((record) =>
       record.timestamp && Number.isFinite(Date.parse(record.timestamp))
@@ -366,7 +727,9 @@ export class ClaudeCodeRepository {
       id,
       harness: "claude-code",
       title,
-      updatedAt: transcriptUpdatedAt ? Date.parse(transcriptUpdatedAt) : updatedAt,
+      updatedAt: transcriptUpdatedAt
+        ? Date.parse(transcriptUpdatedAt)
+        : updatedAt,
       startedAt: bounds.startedAt,
       endedAt: bounds.endedAt,
       providers: [...decoded.providers],

--- a/src/server/codexImporter.test.ts
+++ b/src/server/codexImporter.test.ts
@@ -1,0 +1,64 @@
+import { strictEqual } from "node:assert/strict";
+import { syncCodexSessions } from "./codexImporter.ts";
+import { openArchiveDatabase } from "./database.ts";
+import { migrateTestDatabase } from "./databaseTestUtils.ts";
+import { SessionRepository } from "./sessionRepository.ts";
+
+const transcript = `
+{"id":"session","timestamp":"2026-07-11T13:59:59.000Z","instructions":null,"git":null}
+{"timestamp":"2026-07-11T13:59:59.000Z","type":"response_item","payload":{"type":"reasoning","summary":[],"content":null,"encrypted_content":"ignored"}}
+{"timestamp":"2026-07-11T13:59:59.000Z","type":"event_msg","payload":{"type":"token_count","info":null,"rate_limits":null}}
+{"timestamp":"2026-07-11T14:00:00.000Z","type":"turn_context","payload":{"model":"gpt-5.6-luna"}}
+{"timestamp":"2026-07-11T14:00:01.000Z","type":"event_msg","payload":{"type":"task_started"}}
+{"timestamp":"2026-07-11T14:00:02.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Import Codex"}]}}
+{"timestamp":"2026-07-11T14:00:03.000Z","type":"response_item","payload":{"type":"custom_tool_call","call_id":"call-1","name":"exec_command","input":"ls"}}
+{"timestamp":"2026-07-11T14:00:04.000Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-1","output":"ok"}}
+{"timestamp":"2026-07-11T14:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Imported"}]}}
+{"timestamp":"2026-07-11T14:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":25,"output_tokens":10,"reasoning_output_tokens":2}}}}
+`.trim();
+
+Deno.test("imports Codex sessions for SQLite reads", async () => {
+  const directory = Deno.makeTempDirSync();
+  const sessions = `${directory}/sessions`;
+  const rolloutDirectory = `${sessions}/2026/07/11`;
+  Deno.mkdirSync(rolloutDirectory, { recursive: true });
+  Deno.writeTextFileSync(
+    `${rolloutDirectory}/rollout-session.jsonl`,
+    transcript,
+  );
+
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  migrateTestDatabase(db);
+  const repository = new SessionRepository(db);
+  try {
+    const result = await syncCodexSessions(sessions, repository);
+    strictEqual(result.imported, 1);
+
+    const id = "2026/07/11/rollout-session";
+    strictEqual(repository.listSessions(1, 10, "codex").items[0].id, id);
+    strictEqual(repository.getSession("codex", id)?.title, "Import Codex");
+    strictEqual(repository.listUsageCalls(undefined, "codex").length, 1);
+    strictEqual(
+      (db.prepare("SELECT preview FROM turn_inputs").get() as {
+        preview: string;
+      })
+        .preview,
+      "Import Codex",
+    );
+    strictEqual(
+      (db.prepare("SELECT preview FROM call_content").get() as {
+        preview: string;
+      })
+        .preview,
+      "Imported",
+    );
+    const tool = db.prepare(`
+      SELECT input_preview, output_preview FROM tool_events
+    `).get()!;
+    strictEqual(tool.input_preview, "ls");
+    strictEqual(tool.output_preview, "ok");
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});

--- a/src/server/codexImporter.ts
+++ b/src/server/codexImporter.ts
@@ -1,0 +1,21 @@
+import {
+  discoverCodexSessions,
+  normalizeCodexSession,
+} from "./codexRepository.ts";
+import { syncFileSessions } from "./fileSessionImporter.ts";
+import { SessionRepository } from "./sessionRepository.ts";
+
+export async function syncCodexSessions(
+  directory: string,
+  repository: SessionRepository,
+) {
+  return await syncFileSessions({
+    harness: "codex",
+    label: "Codex",
+    directory,
+    parserVersion: "codex-2",
+    repository,
+    discover: discoverCodexSessions,
+    normalize: normalizeCodexSession,
+  });
+}

--- a/src/server/codexRepository.test.ts
+++ b/src/server/codexRepository.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual } from "node:assert/strict";
-import { CodexRepository } from "../src/server/codexRepository.ts";
-import type { SessionDetail } from "../src/shared/sessionSchemas.ts";
+import { CodexRepository } from "./codexRepository.ts";
+import type { SessionDetail } from "../shared/sessionSchemas.ts";
 
 function repository(files: Record<string, string>) {
   const directory = Deno.makeTempDirSync();

--- a/src/server/codexRepository.ts
+++ b/src/server/codexRepository.ts
@@ -1,12 +1,19 @@
 import { z } from "zod";
 import {
-  type ModelCall,
   sessionDetailSchema,
   sessionListResponseSchema,
   type SessionSummary,
   type TokenUsage,
 } from "../shared/sessionSchemas.ts";
 import { usageCallsFromSession } from "./usage.ts";
+import type {
+  SessionCallImport,
+  SessionContentImport,
+  SessionToolImport,
+  SessionTurnImport,
+} from "./sessionRepository.ts";
+
+const contentPreviewLimit = 512;
 
 const contentBlockSchema = z.object({
   type: z.string(),
@@ -14,7 +21,7 @@ const contentBlockSchema = z.object({
 }).passthrough();
 
 const recordSchema = z.object({
-  type: z.string(),
+  type: z.string().optional(),
   timestamp: z.string().optional(),
   payload: z.object({
     type: z.string().optional(),
@@ -26,7 +33,7 @@ const recordSchema = z.object({
     output: z.unknown().optional(),
     call_id: z.string().optional(),
     id: z.string().optional(),
-    content: z.array(contentBlockSchema).optional(),
+    content: z.array(contentBlockSchema).nullable().optional(),
     info: z.object({
       last_token_usage: z.object({
         input_tokens: z.number().int().nonnegative().default(0),
@@ -34,15 +41,17 @@ const recordSchema = z.object({
         output_tokens: z.number().int().nonnegative().default(0),
         reasoning_output_tokens: z.number().int().nonnegative().default(0),
       }).optional(),
-    }).passthrough().optional(),
+    }).passthrough().nullable().optional(),
   }).passthrough().optional(),
 }).passthrough();
 
 type Record = z.infer<typeof recordSchema>;
-type FileEntry = {
+export type CodexSessionCandidate = {
   id: string;
   path: string;
+  artifactPath: string;
   updatedAt: number;
+  size: number;
 };
 
 const emptyTokens = (): TokenUsage => ({
@@ -66,18 +75,51 @@ function addTokens(total: TokenUsage, usage: TokenUsage) {
   total.processed += usage.processed;
 }
 
-function readRecords(path: string) {
+function readRecordsFromText(text: string, strict = false) {
   const records: Record[] = [];
-  for (const line of Deno.readTextFileSync(path).split("\n")) {
+  for (const line of text.split("\n")) {
     if (!line) continue;
     try {
       const result = recordSchema.safeParse(JSON.parse(line));
       if (result.success) records.push(result.data);
-    } catch {
+      else if (strict) throw result.error;
+    } catch (error) {
+      if (strict) throw error;
       // A partially written final line should not hide the rest of the session.
     }
   }
   return records;
+}
+
+function readRecords(path: string) {
+  return readRecordsFromText(Deno.readTextFileSync(path));
+}
+
+function preview(value: string): SessionContentImport {
+  return {
+    kind: "text",
+    preview: value.slice(0, contentPreviewLimit),
+    originalLength: value.length,
+    truncated: value.length > contentPreviewLimit,
+  };
+}
+
+function serializedPreview(value: unknown) {
+  if (value === undefined) return undefined;
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (text === undefined) return undefined;
+  const metadata = preview(text);
+  return {
+    preview: metadata.preview,
+    originalLength: metadata.originalLength,
+    truncated: metadata.truncated,
+  };
+}
+
+function messageContent(record: Record): SessionContentImport[] {
+  return (record.payload?.content ?? []).flatMap((block) =>
+    block.text === undefined ? [] : [preview(block.text)]
+  );
 }
 
 function timestamp(record: Record) {
@@ -107,13 +149,18 @@ function hasText(record: Record) {
   return payload?.type === "message" && payload.role === "assistant" &&
     (payload.phase === "final_answer" ||
       payload.content?.some((block) =>
-        (block.type === "output_text" || block.type === "text") &&
-        block.text?.trim()
-      ) === true);
+          (block.type === "output_text" || block.type === "text") &&
+          block.text?.trim()
+        ) === true);
 }
 
 function sessionBounds(
-  turns: Array<{ startedAt: number; calls: Array<{ startedAt: number; completedAt?: number }> }>,
+  turns: Array<
+    {
+      startedAt: number;
+      calls: Array<{ startedAt: number; completedAt?: number }>;
+    }
+  >,
 ) {
   if (turns.length === 0) return {};
   const startedAt = Math.min(...turns.map((turn) => turn.startedAt));
@@ -127,18 +174,15 @@ function sessionBounds(
 }
 
 function decodeRecords(records: Record[]) {
-  const turns: Array<
-    { number: number; startedAt: number; calls: ModelCall[] }
-  > = [];
+  const turns: SessionTurnImport[] = [];
   const tokens = emptyTokens();
   const providers = new Set<string>();
   const models = new Set<string>();
-  const tools = new Map<string, ModelCall["activity"]["tools"][number]>();
+  const tools = new Map<string, SessionToolImport>();
   let currentModel = "unknown";
   let pendingHasText = false;
-  let pendingTools: Array<
-    ModelCall["activity"]["tools"][number] & { id?: string }
-  > = [];
+  let pendingTools: SessionToolImport[] = [];
+  let pendingContent: SessionContentImport[] = [];
 
   for (const record of records) {
     const payload = record.payload;
@@ -157,22 +201,34 @@ function decodeRecords(records: Record[]) {
       });
       pendingHasText = false;
       pendingTools = [];
+      pendingContent = [];
       continue;
     }
 
     if (turns.length === 0) continue;
 
-    if (record.type === "response_item" && payload?.type === "custom_tool_call") {
+    if (
+      record.type === "response_item" && payload?.type === "message" &&
+      payload.role === "user"
+    ) {
+      turns.at(-1)!.inputs = messageContent(record);
+      continue;
+    }
+
+    if (
+      record.type === "response_item" && payload?.type === "custom_tool_call"
+    ) {
       const name = toolName(record);
       if (!name) continue;
       const tool = {
         name,
         status: "pending",
         startedAt: time,
-        id: payload.call_id ?? payload.id,
+        sourceID: payload.call_id ?? payload.id,
+        input: serializedPreview(payload.input),
       };
       pendingTools.push(tool);
-      if (tool.id) tools.set(tool.id, tool);
+      if (tool.sourceID) tools.set(tool.sourceID, tool);
       continue;
     }
 
@@ -185,12 +241,14 @@ function decodeRecords(records: Record[]) {
       if (tool) {
         tool.status = "completed";
         tool.completedAt = time;
+        tool.output = serializedPreview(payload.output);
       }
       continue;
     }
 
     if (record.type === "response_item" && hasText(record)) {
       pendingHasText = true;
+      pendingContent.push(...messageContent(record));
       continue;
     }
 
@@ -217,7 +275,7 @@ function decodeRecords(records: Record[]) {
     if (callTokens.processed === 0) continue;
 
     const turn = turns.at(-1)!;
-    const call: ModelCall = {
+    const call: SessionCallImport = {
       id: `${turn.number}-${turn.calls.length + 1}`,
       callWithinTurn: turn.calls.length + 1,
       provider: "openai",
@@ -230,6 +288,7 @@ function decodeRecords(records: Record[]) {
         hasReasoning: source.reasoning_output_tokens > 0,
         tools: pendingTools,
       },
+      content: pendingContent,
     };
 
     providers.add("openai");
@@ -239,6 +298,7 @@ function decodeRecords(records: Record[]) {
     turn.calls.push(call);
     pendingHasText = false;
     pendingTools = [];
+    pendingContent = [];
   }
 
   const nonEmptyTurns = turns
@@ -250,31 +310,8 @@ function decodeRecords(records: Record[]) {
 export class CodexRepository {
   constructor(private directory: string) {}
 
-  #collectFiles(directory: string, prefix = ""): FileEntry[] {
-    const files: FileEntry[] = [];
-    for (const entry of Deno.readDirSync(directory)) {
-      const path = `${directory}/${entry.name}`;
-      const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
-      if (entry.isDirectory) {
-        files.push(...this.#collectFiles(path, relative));
-        continue;
-      }
-      if (!entry.isFile || !entry.name.startsWith("rollout-") || !entry.name.endsWith(".jsonl")) {
-        continue;
-      }
-      files.push({
-        id: relative.slice(0, -6),
-        path,
-        updatedAt: Deno.statSync(path).mtime?.getTime() ?? 0,
-      });
-    }
-    return files;
-  }
-
   #files() {
-    return this.#collectFiles(this.directory).sort((a, b) =>
-      b.updatedAt - a.updatedAt || b.id.localeCompare(a.id)
-    );
+    return discoverCodexSessions(this.directory);
   }
 
   listSessions(page: number, pageSize: number) {
@@ -309,41 +346,101 @@ export class CodexRepository {
   }
 
   #summary(id: string, path: string, updatedAt: number): SessionSummary {
-    const records = readRecords(path);
-    const decoded = decodeRecords(records);
-    const firstPrompt = records.find((record) => userText(record)?.trim());
-    const promptTitle = userText(firstPrompt ?? { type: "" })?.replace(/\s+/g, " ")
-      .trim().slice(0, 100);
-    const transcriptUpdatedAt = [...records].reverse().find((record) =>
-      record.timestamp && Number.isFinite(Date.parse(record.timestamp))
-    )?.timestamp;
-    const bounds = sessionBounds(decoded.turns);
-    return {
-      id,
-      harness: "codex",
-      title: promptTitle ?? `Codex session ${id.split("/").at(-1)?.slice(8, 16) ?? id.slice(0, 8)}`,
-      updatedAt: transcriptUpdatedAt ? Date.parse(transcriptUpdatedAt) : updatedAt,
-      startedAt: bounds.startedAt,
-      endedAt: bounds.endedAt,
-      providers: [...decoded.providers],
-      models: [...decoded.models],
-      userTurns: decoded.turns.length,
-      modelCalls: decoded.turns.reduce(
-        (sum, turn) => sum + turn.calls.length,
-        0,
-      ),
-      tokens: decoded.tokens,
-    };
+    return codexSession(readRecords(path), id, updatedAt).summary;
   }
 
-  #detail(file: FileEntry): unknown {
-    const records = readRecords(file.path);
-    const decoded = decodeRecords(records);
+  #detail(file: CodexSessionCandidate): unknown {
+    const normalized = codexSession(
+      readRecords(file.path),
+      file.id,
+      file.updatedAt,
+    );
     return {
-      ...this.#summary(file.id, file.path, file.updatedAt),
+      ...normalized.summary,
       parentID: undefined,
-      turns: decoded.turns,
+      turns: normalized.turns,
       subagents: [],
     };
   }
+}
+
+function collectCodexSessions(
+  directory: string,
+  prefix = "",
+): CodexSessionCandidate[] {
+  const files: CodexSessionCandidate[] = [];
+  for (const entry of Deno.readDirSync(directory)) {
+    const path = `${directory}/${entry.name}`;
+    const relative = prefix ? `${prefix}/${entry.name}` : entry.name;
+    if (entry.isDirectory) {
+      files.push(...collectCodexSessions(path, relative));
+      continue;
+    }
+    if (
+      !entry.isFile || !entry.name.startsWith("rollout-") ||
+      !entry.name.endsWith(".jsonl")
+    ) {
+      continue;
+    }
+    const stat = Deno.statSync(path);
+    files.push({
+      id: relative.slice(0, -6),
+      path,
+      artifactPath: relative,
+      updatedAt: stat.mtime?.getTime() ?? 0,
+      size: stat.size,
+    });
+  }
+  return files;
+}
+
+export function discoverCodexSessions(directory: string) {
+  return collectCodexSessions(directory).sort((a, b) =>
+    b.updatedAt - a.updatedAt || b.id.localeCompare(a.id)
+  );
+}
+
+function codexSession(records: Record[], id: string, updatedAt: number) {
+  const decoded = decodeRecords(records);
+  const firstPrompt = records.find((record) => userText(record)?.trim());
+  const promptTitle = userText(firstPrompt ?? { type: "" })?.replace(
+    /\s+/g,
+    " ",
+  )
+    .trim().slice(0, 100);
+  const transcriptUpdatedAt = [...records].reverse().find((record) =>
+    record.timestamp && Number.isFinite(Date.parse(record.timestamp))
+  )?.timestamp;
+  const bounds = sessionBounds(decoded.turns);
+  const summary: SessionSummary = {
+    id,
+    harness: "codex",
+    title: promptTitle ??
+      `Codex session ${id.split("/").at(-1)?.slice(8, 16) ?? id.slice(0, 8)}`,
+    updatedAt: transcriptUpdatedAt
+      ? Date.parse(transcriptUpdatedAt)
+      : updatedAt,
+    startedAt: bounds.startedAt,
+    endedAt: bounds.endedAt,
+    providers: [...decoded.providers],
+    models: [...decoded.models],
+    userTurns: decoded.turns.length,
+    modelCalls: decoded.turns.reduce(
+      (sum, turn) => sum + turn.calls.length,
+      0,
+    ),
+    tokens: decoded.tokens,
+  };
+  return { summary, turns: decoded.turns };
+}
+
+export function normalizeCodexSession(
+  candidate: CodexSessionCandidate,
+  text: string,
+) {
+  return codexSession(
+    readRecordsFromText(text, true),
+    candidate.id,
+    candidate.updatedAt,
+  );
 }

--- a/src/server/database.test.ts
+++ b/src/server/database.test.ts
@@ -1,0 +1,33 @@
+import { strictEqual } from "node:assert/strict";
+import { openArchiveDatabase } from "./database.ts";
+import { migrateTestDatabase } from "./databaseTestUtils.ts";
+
+Deno.test("opens an archive database with the required SQLite settings", () => {
+  const directory = Deno.makeTempDirSync();
+  const path = `${directory}/archive.sqlite`;
+  try {
+    const first = openArchiveDatabase(path);
+    migrateTestDatabase(first);
+    const tables = first.prepare(`
+      SELECT COUNT(*) AS count
+      FROM sqlite_schema
+      WHERE type = 'table'
+        AND name IN (
+          'sources',
+          'source_sessions',
+          'sessions',
+          'turns',
+          'turn_inputs',
+          'models',
+          'model_calls',
+          'call_content',
+          'tool_events'
+        )
+    `).get() as { count: number };
+    strictEqual(tables.count, 9);
+    strictEqual(first.prepare("PRAGMA foreign_keys").get()!.foreign_keys, 1);
+    first.close();
+  } finally {
+    Deno.removeSync(directory, { recursive: true });
+  }
+});

--- a/src/server/database.ts
+++ b/src/server/database.ts
@@ -1,0 +1,26 @@
+import { DatabaseSync } from "node:sqlite";
+import { dirname } from "node:path";
+
+export function sqlitePath(databaseURL: string) {
+  if (!databaseURL.startsWith("sqlite:")) {
+    throw new Error("FRUGAL_TOKENS_DATABASE_URL must use the sqlite: scheme");
+  }
+  const path = decodeURIComponent(databaseURL.slice("sqlite:".length));
+  if (!path) throw new Error("FRUGAL_TOKENS_DATABASE_URL has no database path");
+  return path;
+}
+
+export function openArchiveDatabase(path: string) {
+  Deno.mkdirSync(dirname(path), { recursive: true });
+  const db = new DatabaseSync(path);
+  try {
+    db.exec("PRAGMA foreign_keys = ON");
+    db.exec("PRAGMA journal_mode = WAL");
+    db.exec("PRAGMA busy_timeout = 5000");
+    db.exec("PRAGMA synchronous = NORMAL");
+    return db;
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+}

--- a/src/server/databaseTestUtils.ts
+++ b/src/server/databaseTestUtils.ts
@@ -3,6 +3,7 @@ import type { DatabaseSync } from "node:sqlite";
 const migrations = [
   "../../db/migrations/20260714120000_create_initial_archive.sql",
   "../../db/migrations/20260714130000_add_source_session_public_and_tree_ids.sql",
+  "../../db/migrations/20260714140000_add_source_session_change_hint.sql",
 ].map((path) => new URL(path, import.meta.url));
 
 export function migrateTestDatabase(db: DatabaseSync) {

--- a/src/server/databaseTestUtils.ts
+++ b/src/server/databaseTestUtils.ts
@@ -1,0 +1,12 @@
+import type { DatabaseSync } from "node:sqlite";
+
+const migration = new URL(
+  "../../db/migrations/20260714120000_create_initial_archive.sql",
+  import.meta.url,
+);
+
+export function migrateTestDatabase(db: DatabaseSync) {
+  const sql = Deno.readTextFileSync(migration);
+  const up = sql.split("-- migrate:down", 1)[0].replace("-- migrate:up", "");
+  db.exec(up);
+}

--- a/src/server/databaseTestUtils.ts
+++ b/src/server/databaseTestUtils.ts
@@ -1,12 +1,14 @@
 import type { DatabaseSync } from "node:sqlite";
 
-const migration = new URL(
+const migrations = [
   "../../db/migrations/20260714120000_create_initial_archive.sql",
-  import.meta.url,
-);
+  "../../db/migrations/20260714130000_add_source_session_public_and_tree_ids.sql",
+].map((path) => new URL(path, import.meta.url));
 
 export function migrateTestDatabase(db: DatabaseSync) {
-  const sql = Deno.readTextFileSync(migration);
-  const up = sql.split("-- migrate:down", 1)[0].replace("-- migrate:up", "");
-  db.exec(up);
+  for (const migration of migrations) {
+    const sql = Deno.readTextFileSync(migration);
+    const up = sql.split("-- migrate:down", 1)[0].replace("-- migrate:up", "");
+    db.exec(up);
+  }
 }

--- a/src/server/fileSessionImporter.ts
+++ b/src/server/fileSessionImporter.ts
@@ -1,0 +1,173 @@
+import type {
+  SessionRepository,
+  SessionTurnImport,
+} from "./sessionRepository.ts";
+import type { SessionSummary } from "../shared/sessionSchemas.ts";
+
+export type FileSessionCandidate = {
+  id: string;
+  path: string;
+  artifactPath: string;
+  updatedAt: number;
+  size: number;
+};
+
+type NormalizedFileSession = {
+  summary: SessionSummary;
+  turns: SessionTurnImport[];
+};
+
+function checksum(bytes: Uint8Array) {
+  const buffer = bytes.buffer.slice(
+    bytes.byteOffset,
+    bytes.byteOffset + bytes.byteLength,
+  ) as ArrayBuffer;
+  return crypto.subtle.digest("SHA-256", buffer).then((digest) =>
+    Array.from(
+      new Uint8Array(digest),
+      (byte) => byte.toString(16).padStart(2, "0"),
+    ).join("")
+  );
+}
+
+function failureCategory(error: unknown) {
+  if (error instanceof SyntaxError) return "invalid-json";
+  const message = error instanceof Error ? error.message : String(error);
+  if (message.includes("changed while it was being read")) {
+    return "changed-during-read";
+  }
+  if (message.toLowerCase().includes("constraint")) {
+    return "database-constraint";
+  }
+  return "import-error";
+}
+
+export async function syncFileSessions(options: {
+  harness: SessionSummary["harness"];
+  label: string;
+  directory: string;
+  parserVersion: string;
+  repository: SessionRepository;
+  discover: (directory: string) => FileSessionCandidate[];
+  normalize: (
+    candidate: FileSessionCandidate,
+    text: string,
+  ) => NormalizedFileSession;
+}) {
+  const observedAt = Date.now();
+  const sourceID = options.repository.ensureSource(
+    options.harness,
+    "directory",
+    options.label,
+    options.directory,
+  );
+  const candidates = options.discover(options.directory);
+  let imported = 0;
+  let skipped = 0;
+  let failed = 0;
+  const failureCategories: Record<string, number> = {};
+
+  for (const candidate of candidates) {
+    const previous = options.repository.checkpoint(sourceID, candidate.id);
+    if (
+      previous?.parserVersion === options.parserVersion &&
+      previous.sourceSize === candidate.size &&
+      previous.sourceModifiedAt === candidate.updatedAt
+    ) {
+      options.repository.recordUnchangedSourceSession(
+        sourceID,
+        candidate.id,
+        candidate.artifactPath,
+        observedAt,
+      );
+      skipped++;
+      continue;
+    }
+
+    try {
+      const bytes = Deno.readFileSync(candidate.path);
+      const afterRead = Deno.statSync(candidate.path);
+      const modifiedAt = afterRead.mtime?.getTime() ?? 0;
+      if (
+        afterRead.size !== candidate.size || modifiedAt !== candidate.updatedAt
+      ) {
+        throw new Error("Source changed while it was being read");
+      }
+      const fingerprint = await checksum(bytes);
+      if (
+        previous?.parserVersion === options.parserVersion &&
+        previous.checksum === fingerprint
+      ) {
+        options.repository.recordUnchangedSourceSession(
+          sourceID,
+          candidate.id,
+          candidate.artifactPath,
+          observedAt,
+          {
+            sourceSize: candidate.size,
+            sourceModifiedAt: candidate.updatedAt,
+            checksum: fingerprint,
+            parserVersion: options.parserVersion,
+          },
+        );
+        skipped++;
+        continue;
+      }
+
+      const normalized = options.normalize(
+        candidate,
+        new TextDecoder().decode(bytes),
+      );
+      options.repository.replaceSourceSession({
+        sourceID,
+        externalID: candidate.id,
+        artifactPath: candidate.artifactPath,
+        observedAt,
+        checkpoint: {
+          sourceSize: candidate.size,
+          sourceModifiedAt: candidate.updatedAt,
+          checksum: fingerprint,
+          parserVersion: options.parserVersion,
+        },
+        session: {
+          title: normalized.summary.title,
+          updatedAt: normalized.summary.updatedAt,
+          startedAt: normalized.summary.startedAt,
+          endedAt: normalized.summary.endedAt,
+          providers: normalized.summary.providers,
+          models: normalized.summary.models,
+          userTurns: normalized.summary.userTurns,
+          modelCalls: normalized.summary.modelCalls,
+          reportedCost: normalized.summary.reportedCost,
+          tokens: normalized.summary.tokens,
+          turns: normalized.turns,
+        },
+      });
+      imported++;
+    } catch (error) {
+      const category = failureCategory(error);
+      failureCategories[category] = (failureCategories[category] ?? 0) + 1;
+      console.warn(
+        `[sync] harness=${options.harness} source=${candidate.path} failed category=${category}`,
+        error,
+      );
+      options.repository.recordSourceSessionError(
+        sourceID,
+        candidate.id,
+        candidate.artifactPath,
+        observedAt,
+        error,
+      );
+      failed++;
+    }
+  }
+
+  options.repository.markMissingSourceSessions(sourceID, observedAt);
+  return {
+    discovered: candidates.length,
+    imported,
+    skipped,
+    failed,
+    failureCategories,
+  };
+}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -77,31 +77,69 @@ const archiveDatabase = archiveURL
 const archiveRepository = archiveDatabase
   ? new SessionRepository(archiveDatabase)
   : undefined;
-if (archiveRepository && openCodePath) {
-  const result = syncOpenCodeSessions(openCodePath, archiveRepository);
+
+async function runSync(
+  harness: SessionSummary["harness"],
+  sync: () =>
+    | {
+      discovered: number;
+      imported: number;
+      skipped: number;
+      failed: number;
+      timings?: Record<string, number>;
+    }
+    | Promise<
+      {
+        discovered: number;
+        imported: number;
+        skipped: number;
+        failed: number;
+        timings?: Record<string, number>;
+      }
+    >,
+) {
+  const startedAt = performance.now();
+  const result = await sync();
+  const phases = result.timings
+    ? ` ${
+      Object.entries(result.timings).map(([name, duration]) =>
+        `${name}=${duration.toFixed(1)}ms`
+      ).join(" ")
+    }`
+    : "";
   console.info(
-    `[sync] harness=opencode discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed}`,
+    `[sync] harness=${harness} discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed} duration=${
+      (performance.now() - startedAt).toFixed(1)
+    }ms${phases}`,
   );
 }
-if (archiveRepository && claudeDirectory) {
-  const result = await syncClaudeCodeSessions(
-    claudeDirectory,
-    archiveRepository,
-  );
+
+async function syncSources() {
+  if (!archiveRepository) return;
+  const startedAt = performance.now();
+  if (openCodePath) {
+    await runSync(
+      "opencode",
+      () => syncOpenCodeSessions(openCodePath, archiveRepository),
+    );
+  }
+  if (claudeDirectory) {
+    await runSync(
+      "claude-code",
+      () => syncClaudeCodeSessions(claudeDirectory, archiveRepository),
+    );
+  }
+  if (piDirectory) {
+    await runSync("pi", () => syncPiSessions(piDirectory, archiveRepository));
+  }
+  if (codexDirectory) {
+    await runSync(
+      "codex",
+      () => syncCodexSessions(codexDirectory, archiveRepository),
+    );
+  }
   console.info(
-    `[sync] harness=claude-code discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed}`,
-  );
-}
-if (archiveRepository && piDirectory) {
-  const result = await syncPiSessions(piDirectory, archiveRepository);
-  console.info(
-    `[sync] harness=pi discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed}`,
-  );
-}
-if (archiveRepository && codexDirectory) {
-  const result = await syncCodexSessions(codexDirectory, archiveRepository);
-  console.info(
-    `[sync] harness=codex discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed}`,
+    `[sync] complete duration=${(performance.now() - startedAt).toFixed(1)}ms`,
   );
 }
 const claudeRepository = archiveRepository
@@ -345,5 +383,9 @@ app.use("/assets/*", serveStatic({ root: "./dist" }));
 app.get("*", serveStatic({ root: "./dist", path: "index.html" }));
 
 const port = Number.parseInt(Deno.env.get("PORT") ?? "9000", 10);
-console.log(`Frugal Tokens API listening on http://localhost:${port}`);
-Deno.serve({ port }, app.fetch);
+Deno.serve({
+  port,
+  onListen: ({ port }) =>
+    console.log(`Frugal Tokens API listening on http://localhost:${port}`),
+}, app.fetch);
+await syncSources();

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -12,6 +12,10 @@ import type {
 } from "../shared/sessionSchemas.ts";
 import type { UsageCall } from "./usage.ts";
 import { aggregateUsage } from "./usageAnalytics.ts";
+import { openArchiveDatabase, sqlitePath } from "./database.ts";
+import { SessionRepository } from "./sessionRepository.ts";
+import { syncPiSessions } from "./piImporter.ts";
+import { syncCodexSessions } from "./codexImporter.ts";
 
 function configuredPath<T>(
   harness: string,
@@ -52,18 +56,59 @@ const claudeRepository = configuredPath(
   "directory",
   (path) => new ClaudeCodeRepository(path),
 );
-const piRepository = configuredPath(
+const piDirectory = configuredPath(
   "pi",
   "PI_SESSION_DIR",
   "directory",
-  (path) => new PiRepository(path),
+  (path) => path,
 );
-const codexRepository = configuredPath(
+const codexDirectory = configuredPath(
   "codex",
   "CODEX_SESSION_DIR",
   "directory",
-  (path) => new CodexRepository(path),
+  (path) => path,
 );
+const archiveURL = Deno.env.get("FRUGAL_TOKENS_DATABASE_URL");
+const archiveDatabase = archiveURL
+  ? openArchiveDatabase(sqlitePath(archiveURL))
+  : undefined;
+const archiveRepository = archiveDatabase
+  ? new SessionRepository(archiveDatabase)
+  : undefined;
+if (archiveRepository && piDirectory) {
+  const result = await syncPiSessions(piDirectory, archiveRepository);
+  console.info(
+    `[sync] harness=pi discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed}`,
+  );
+}
+if (archiveRepository && codexDirectory) {
+  const result = await syncCodexSessions(codexDirectory, archiveRepository);
+  console.info(
+    `[sync] harness=codex discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed}`,
+  );
+}
+const piRepository = archiveRepository
+  ? {
+    listSessions: (page: number, pageSize: number) =>
+      archiveRepository.listSessions(page, pageSize, "pi"),
+    getSession: (id: string) => archiveRepository.getSession("pi", id),
+    listUsageCalls: (startedAt?: number) =>
+      archiveRepository.listUsageCalls(startedAt, "pi"),
+  }
+  : piDirectory
+  ? new PiRepository(piDirectory)
+  : undefined;
+const codexRepository = archiveRepository
+  ? {
+    listSessions: (page: number, pageSize: number) =>
+      archiveRepository.listSessions(page, pageSize, "codex"),
+    getSession: (id: string) => archiveRepository.getSession("codex", id),
+    listUsageCalls: (startedAt?: number) =>
+      archiveRepository.listUsageCalls(startedAt, "codex"),
+  }
+  : codexDirectory
+  ? new CodexRepository(codexDirectory)
+  : undefined;
 const app = new Hono();
 
 function repositoryForHarness(harness: SessionSummary["harness"]) {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -17,6 +17,7 @@ import { SessionRepository } from "./sessionRepository.ts";
 import { syncPiSessions } from "./piImporter.ts";
 import { syncCodexSessions } from "./codexImporter.ts";
 import { syncClaudeCodeSessions } from "./claudeCodeImporter.ts";
+import { syncOpenCodeSessions } from "./openCodeImporter.ts";
 
 function configuredPath<T>(
   harness: string,
@@ -45,11 +46,11 @@ function configuredPath<T>(
   }
   return create(path);
 }
-const repository = configuredPath(
+const openCodePath = configuredPath(
   "opencode",
   "OPENCODE_DB_PATH",
   "file",
-  (path) => new OpenCodeRepository(path),
+  (path) => path,
 );
 const claudeDirectory = configuredPath(
   "claude-code",
@@ -76,6 +77,12 @@ const archiveDatabase = archiveURL
 const archiveRepository = archiveDatabase
   ? new SessionRepository(archiveDatabase)
   : undefined;
+if (archiveRepository && openCodePath) {
+  const result = syncOpenCodeSessions(openCodePath, archiveRepository);
+  console.info(
+    `[sync] harness=opencode discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed}`,
+  );
+}
 if (archiveRepository && claudeDirectory) {
   const result = await syncClaudeCodeSessions(
     claudeDirectory,
@@ -129,6 +136,17 @@ const codexRepository = archiveRepository
   }
   : codexDirectory
   ? new CodexRepository(codexDirectory)
+  : undefined;
+const repository = archiveRepository
+  ? {
+    listSessions: (page: number, pageSize: number) =>
+      archiveRepository.listSessions(page, pageSize, "opencode"),
+    getSession: (id: string) => archiveRepository.getSession("opencode", id),
+    listUsageCalls: (startedAt?: number) =>
+      archiveRepository.listUsageCalls(startedAt, "opencode"),
+  }
+  : openCodePath
+  ? new OpenCodeRepository(openCodePath)
   : undefined;
 const app = new Hono();
 

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -16,6 +16,7 @@ import { openArchiveDatabase, sqlitePath } from "./database.ts";
 import { SessionRepository } from "./sessionRepository.ts";
 import { syncPiSessions } from "./piImporter.ts";
 import { syncCodexSessions } from "./codexImporter.ts";
+import { syncClaudeCodeSessions } from "./claudeCodeImporter.ts";
 
 function configuredPath<T>(
   harness: string,
@@ -50,11 +51,11 @@ const repository = configuredPath(
   "file",
   (path) => new OpenCodeRepository(path),
 );
-const claudeRepository = configuredPath(
+const claudeDirectory = configuredPath(
   "claude-code",
   "CLAUDE_CODE_PROJECT_PATH",
   "directory",
-  (path) => new ClaudeCodeRepository(path),
+  (path) => path,
 );
 const piDirectory = configuredPath(
   "pi",
@@ -75,6 +76,15 @@ const archiveDatabase = archiveURL
 const archiveRepository = archiveDatabase
   ? new SessionRepository(archiveDatabase)
   : undefined;
+if (archiveRepository && claudeDirectory) {
+  const result = await syncClaudeCodeSessions(
+    claudeDirectory,
+    archiveRepository,
+  );
+  console.info(
+    `[sync] harness=claude-code discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed}`,
+  );
+}
 if (archiveRepository && piDirectory) {
   const result = await syncPiSessions(piDirectory, archiveRepository);
   console.info(
@@ -87,6 +97,17 @@ if (archiveRepository && codexDirectory) {
     `[sync] harness=codex discovered=${result.discovered} imported=${result.imported} skipped=${result.skipped} failed=${result.failed}`,
   );
 }
+const claudeRepository = archiveRepository
+  ? {
+    listSessions: (page: number, pageSize: number) =>
+      archiveRepository.listSessions(page, pageSize, "claude-code"),
+    getSession: (id: string) => archiveRepository.getSession("claude-code", id),
+    listUsageCalls: (startedAt?: number) =>
+      archiveRepository.listUsageCalls(startedAt, "claude-code"),
+  }
+  : claudeDirectory
+  ? new ClaudeCodeRepository(claudeDirectory)
+  : undefined;
 const piRepository = archiveRepository
   ? {
     listSessions: (page: number, pageSize: number) =>

--- a/src/server/openCodeImporter.test.ts
+++ b/src/server/openCodeImporter.test.ts
@@ -183,6 +183,8 @@ Deno.test("incrementally imports OpenCode session trees", () => {
         data = json_set(data, '$.state.output', 'changed')
       WHERE id = 'tool'
     `).run();
+    source.prepare("UPDATE session SET time_updated = 21 WHERE id = 'root'")
+      .run();
     strictEqual(syncOpenCodeSessions(sourcePath, repository).imported, 1);
     strictEqual(
       archive.prepare("SELECT output_preview FROM tool_events").get()!

--- a/src/server/openCodeImporter.test.ts
+++ b/src/server/openCodeImporter.test.ts
@@ -1,0 +1,205 @@
+import { strictEqual } from "node:assert/strict";
+import { DatabaseSync } from "node:sqlite";
+import { migrateTestDatabase } from "./databaseTestUtils.ts";
+import { openArchiveDatabase } from "./database.ts";
+import { syncOpenCodeSessions } from "./openCodeImporter.ts";
+import { SessionRepository } from "./sessionRepository.ts";
+
+function sourceDatabase(path: string) {
+  const db = new DatabaseSync(path);
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      parent_id TEXT,
+      title TEXT NOT NULL,
+      model TEXT,
+      agent TEXT,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `);
+  return db;
+}
+
+Deno.test("incrementally imports OpenCode session trees", () => {
+  const directory = Deno.makeTempDirSync();
+  const sourcePath = `${directory}/opencode.sqlite`;
+  const source = sourceDatabase(sourcePath);
+  const insertSession = source.prepare(`
+    INSERT INTO session VALUES (?, ?, ?, ?, ?, ?, ?)
+  `);
+  insertSession.run("root", null, "Root", null, "build", 1, 10);
+  insertSession.run("child", "root", "Child", null, "explore", 2, 9);
+  const insertMessage = source.prepare(`
+    INSERT INTO message VALUES (?, ?, ?, ?, ?)
+  `);
+  insertMessage.run("user", "root", 1, 1, JSON.stringify({ role: "user" }));
+  insertMessage.run(
+    "assistant",
+    "root",
+    2,
+    2,
+    JSON.stringify({
+      role: "assistant",
+      providerID: "anthropic",
+      modelID: "claude",
+      time: { created: 2, completed: 3 },
+      cost: 0.1,
+      tokens: {
+        input: 2,
+        output: 3,
+        reasoning: 0,
+        cache: { read: 4, write: 0 },
+      },
+    }),
+  );
+  insertMessage.run(
+    "child-user",
+    "child",
+    2,
+    2,
+    JSON.stringify({ role: "user" }),
+  );
+  insertMessage.run(
+    "child-assistant",
+    "child",
+    3,
+    3,
+    JSON.stringify({
+      role: "assistant",
+      providerID: "anthropic",
+      modelID: "claude",
+      tokens: {
+        input: 1,
+        output: 1,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    }),
+  );
+  insertMessage.run(
+    "invalid-assistant",
+    "root",
+    4,
+    4,
+    JSON.stringify({
+      role: "assistant",
+      providerID: "anthropic",
+      modelID: "claude",
+      tokens: {
+        input: 1,
+        output: -1,
+        reasoning: 0,
+        cache: { read: 0, write: 0 },
+      },
+    }),
+  );
+  const insertPart = source.prepare(`
+    INSERT INTO part VALUES (?, ?, ?, ?, ?, ?)
+  `);
+  insertPart.run(
+    "user-text",
+    "user",
+    "root",
+    1,
+    1,
+    JSON.stringify({ type: "text", text: "Inspect archive" }),
+  );
+  insertPart.run(
+    "assistant-text",
+    "assistant",
+    "root",
+    2,
+    2,
+    JSON.stringify({ type: "text", text: "Working" }),
+  );
+  insertPart.run(
+    "tool",
+    "assistant",
+    "root",
+    2,
+    2,
+    JSON.stringify({
+      type: "tool",
+      callID: "tool-1",
+      tool: "task",
+      state: {
+        status: "completed",
+        input: { prompt: "inspect" },
+        output: "done",
+        metadata: { sessionId: "child" },
+        time: { start: 2, end: 3 },
+      },
+    }),
+  );
+
+  const archive = openArchiveDatabase(`${directory}/archive.sqlite`);
+  migrateTestDatabase(archive);
+  const repository = new SessionRepository(archive);
+  try {
+    const first = syncOpenCodeSessions(sourcePath, repository);
+    strictEqual(first.imported, 1);
+    const detail = repository.getSession("opencode", "root")!;
+    strictEqual(detail.subagents[0].id, "child");
+    strictEqual(
+      detail.turns[0].calls[0].activity.tools[0].childSessionID,
+      "child",
+    );
+    strictEqual(
+      archive.prepare("SELECT preview FROM turn_inputs").get()!.preview,
+      "Inspect archive",
+    );
+    strictEqual(
+      archive.prepare("SELECT preview FROM call_content").get()!.preview,
+      "Working",
+    );
+    const tool = archive.prepare(`
+      SELECT input_preview, output_preview FROM tool_events
+    `).get()!;
+    strictEqual(tool.input_preview, '{"prompt":"inspect"}');
+    strictEqual(tool.output_preview, "done");
+
+    strictEqual(syncOpenCodeSessions(sourcePath, repository).skipped, 1);
+    source.prepare("UPDATE part SET time_updated = 20 WHERE id = 'tool'").run();
+    strictEqual(syncOpenCodeSessions(sourcePath, repository).skipped, 1);
+
+    source.prepare(`
+      UPDATE part SET time_updated = 21,
+        data = json_set(data, '$.state.output', 'changed')
+      WHERE id = 'tool'
+    `).run();
+    strictEqual(syncOpenCodeSessions(sourcePath, repository).imported, 1);
+    strictEqual(
+      archive.prepare("SELECT output_preview FROM tool_events").get()!
+        .output_preview,
+      "changed",
+    );
+
+    source.prepare("DELETE FROM message WHERE session_id = 'child'").run();
+    source.prepare("DELETE FROM session WHERE id = 'child'").run();
+    strictEqual(syncOpenCodeSessions(sourcePath, repository).imported, 1);
+    strictEqual(
+      repository.getSession("opencode", "root")?.subagents.length,
+      0,
+    );
+  } finally {
+    source.close();
+    archive.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});

--- a/src/server/openCodeImporter.ts
+++ b/src/server/openCodeImporter.ts
@@ -1,0 +1,330 @@
+import { createHash } from "node:crypto";
+import { DatabaseSync } from "node:sqlite";
+import {
+  normalizeOpenCodeSessionTree,
+  type OpenCodeMessageRow,
+  type OpenCodePartRow,
+  type OpenCodeSessionRow,
+} from "./opencodeRepository.ts";
+import {
+  SessionRepository,
+  type SourceSessionCheckpoint,
+} from "./sessionRepository.ts";
+
+const parserVersion = "opencode-1";
+
+type AggregateRow = {
+  session_id: string;
+  row_count: number;
+  max_updated: number | null;
+  update_sum: string | null;
+};
+
+type OpenCodeCandidate = {
+  id: string;
+  sessions: OpenCodeSessionRow[];
+  changeHint: string;
+  rowCount: number;
+  updatedAt: number;
+};
+
+type OpenCodeSnapshot = {
+  sessions: OpenCodeSessionRow[];
+  messages: OpenCodeMessageRow[];
+  parts: OpenCodePartRow[];
+};
+
+const sessionColumns = `
+  id, parent_id, title, model, agent, time_created, time_updated
+`;
+
+function digest(values: unknown[]) {
+  const hash = createHash("sha256");
+  for (const value of values) {
+    hash.update(JSON.stringify(value));
+    hash.update("\0");
+  }
+  return hash.digest("hex");
+}
+
+function aggregates(db: DatabaseSync, table: "message" | "part") {
+  return new Map(
+    (db.prepare(`
+      SELECT session_id, COUNT(*) AS row_count,
+        MAX(time_updated) AS max_updated,
+        CAST(SUM(time_updated) AS TEXT) AS update_sum
+      FROM ${table}
+      GROUP BY session_id
+      ORDER BY session_id
+    `).all() as AggregateRow[]).map((row) => [row.session_id, row]),
+  );
+}
+
+function candidate(
+  sessions: OpenCodeSessionRow[],
+  messages: Map<string, AggregateRow>,
+  parts: Map<string, AggregateRow>,
+): OpenCodeCandidate {
+  const ordered = sessions.toSorted((a, b) => a.id.localeCompare(b.id));
+  const hintValues = ordered.map((session) => ({
+    session,
+    messages: messages.get(session.id) ?? null,
+    parts: parts.get(session.id) ?? null,
+  }));
+  return {
+    id: ordered.find((session) => session.parent_id === null)?.id ??
+      ordered[0].id,
+    sessions: ordered,
+    changeHint: digest(hintValues),
+    rowCount: ordered.reduce(
+      (total, session) =>
+        total + 1 + (messages.get(session.id)?.row_count ?? 0) +
+        (parts.get(session.id)?.row_count ?? 0),
+      0,
+    ),
+    updatedAt: ordered.reduce(
+      (latest, session) =>
+        Math.max(
+          latest,
+          session.time_updated,
+          messages.get(session.id)?.max_updated ?? 0,
+          parts.get(session.id)?.max_updated ?? 0,
+        ),
+      0,
+    ),
+  };
+}
+
+function discover(db: DatabaseSync) {
+  const sessions = db.prepare(`
+    SELECT ${sessionColumns} FROM session ORDER BY id
+  `).all() as OpenCodeSessionRow[];
+  const messages = aggregates(db, "message");
+  const parts = aggregates(db, "part");
+  const children = Map.groupBy(
+    sessions.filter((session) => session.parent_id !== null),
+    (session) => session.parent_id!,
+  );
+
+  function tree(root: OpenCodeSessionRow) {
+    const result: OpenCodeSessionRow[] = [];
+    const pending = [root];
+    const visited = new Set<string>();
+    while (pending.length > 0) {
+      const session = pending.shift()!;
+      if (visited.has(session.id)) continue;
+      visited.add(session.id);
+      result.push(session);
+      pending.push(...(children.get(session.id) ?? []));
+    }
+    return result;
+  }
+
+  return sessions.filter((session) => session.parent_id === null)
+    .map((root) => candidate(tree(root), messages, parts))
+    .sort((a, b) => b.updatedAt - a.updatedAt || b.id.localeCompare(a.id));
+}
+
+function placeholders(values: unknown[]) {
+  return values.map(() => "?").join(", ");
+}
+
+function snapshot(db: DatabaseSync, rootID: string): OpenCodeSnapshot {
+  const sessions = db.prepare(`
+    WITH RECURSIVE tree(id) AS (
+      SELECT id FROM session WHERE id = ?
+      UNION ALL
+      SELECT child.id FROM session child JOIN tree ON child.parent_id = tree.id
+    )
+    SELECT ${sessionColumns} FROM session
+    WHERE id IN (SELECT id FROM tree)
+    ORDER BY id
+  `).all(rootID) as OpenCodeSessionRow[];
+  if (sessions.length === 0) {
+    throw new Error("OpenCode session tree disappeared");
+  }
+  const sessionIDs = sessions.map((session) => session.id);
+  const ids = placeholders(sessionIDs);
+  const messages = db.prepare(`
+    SELECT id, session_id, time_created, time_updated, data
+    FROM message WHERE session_id IN (${ids})
+    ORDER BY session_id, time_created, id
+  `).all(...sessionIDs) as OpenCodeMessageRow[];
+  const parts = db.prepare(`
+    SELECT id, message_id, session_id, time_created, time_updated, data
+    FROM part WHERE session_id IN (${ids})
+    ORDER BY session_id, time_created, id
+  `).all(...sessionIDs) as OpenCodePartRow[];
+  return { sessions, messages, parts };
+}
+
+function snapshotCandidate(value: OpenCodeSnapshot) {
+  function aggregate<T extends { session_id: string; time_updated: number }>(
+    rows: T[],
+  ) {
+    return new Map(
+      [...Map.groupBy(rows, (row) => row.session_id)].map((
+        [sessionID, values],
+      ) => [
+        sessionID,
+        {
+          session_id: sessionID,
+          row_count: values.length,
+          max_updated: Math.max(...values.map((row) => row.time_updated)),
+          update_sum: values.reduce(
+            (sum, row) => sum + BigInt(row.time_updated),
+            0n,
+          ).toString(),
+        },
+      ]),
+    );
+  }
+  return candidate(
+    value.sessions,
+    aggregate(value.messages),
+    aggregate(value.parts),
+  );
+}
+
+function checksum(value: OpenCodeSnapshot) {
+  return digest([
+    ...value.sessions.map((row) => [
+      row.id,
+      row.parent_id,
+      row.title,
+      row.model,
+      row.agent,
+      row.time_created,
+      row.time_updated,
+    ]),
+    ...value.messages.map((row) => [
+      row.id,
+      row.session_id,
+      row.time_created,
+      row.data,
+    ]),
+    ...value.parts.map((row) => [
+      row.id,
+      row.message_id,
+      row.session_id,
+      row.time_created,
+      row.data,
+    ]),
+  ]);
+}
+
+function recordUnchangedTree(
+  repository: SessionRepository,
+  sourceID: number,
+  value: OpenCodeCandidate,
+  observedAt: number,
+  checkpoint?: SourceSessionCheckpoint,
+) {
+  for (const session of value.sessions) {
+    repository.recordUnchangedSourceSession(
+      sourceID,
+      session.id,
+      `session:${session.id}`,
+      observedAt,
+      checkpoint,
+    );
+  }
+}
+
+export function syncOpenCodeSessions(
+  path: string,
+  repository: SessionRepository,
+) {
+  const source = new DatabaseSync(path, { readOnly: true });
+  const observedAt = Date.now();
+  const sourceID = repository.ensureSource(
+    "opencode",
+    "database",
+    "OpenCode",
+    path,
+  );
+  let imported = 0;
+  let skipped = 0;
+  let failed = 0;
+  let candidates: OpenCodeCandidate[] = [];
+
+  try {
+    candidates = discover(source);
+    for (const initial of candidates) {
+      const previous = repository.checkpoint(sourceID, initial.id);
+      if (
+        previous?.parserVersion === parserVersion &&
+        previous.changeHint === initial.changeHint
+      ) {
+        skipped++;
+        continue;
+      }
+
+      let transaction = false;
+      try {
+        source.exec("BEGIN");
+        transaction = true;
+        const rows = snapshot(source, initial.id);
+        const fresh = snapshotCandidate(rows);
+        const contentChecksum = checksum(rows);
+        const checkpoint: SourceSessionCheckpoint = {
+          changeHint: fresh.changeHint,
+          sourceSize: fresh.rowCount,
+          sourceModifiedAt: fresh.updatedAt,
+          checksum: contentChecksum,
+          parserVersion,
+        };
+        const normalized = normalizeOpenCodeSessionTree({
+          ...rows,
+          sourceID,
+          observedAt,
+          checkpoint,
+        });
+        source.exec("COMMIT");
+        transaction = false;
+
+        if (
+          previous?.parserVersion === parserVersion &&
+          previous.checksum === contentChecksum
+        ) {
+          recordUnchangedTree(
+            repository,
+            sourceID,
+            fresh,
+            observedAt,
+            checkpoint,
+          );
+          skipped++;
+          continue;
+        }
+        repository.replaceSourceSessionTree(normalized);
+        imported++;
+      } catch (error) {
+        if (transaction) source.exec("ROLLBACK");
+        console.warn(
+          `[sync] harness=opencode session=${initial.id} failed`,
+          error,
+        );
+        repository.recordSourceSessionError(
+          sourceID,
+          initial.id,
+          `session:${initial.id}`,
+          observedAt,
+          error,
+        );
+        failed++;
+      }
+    }
+    repository.markSourceSessionsSeen(
+      sourceID,
+      candidates.flatMap((value) =>
+        value.sessions.map((session) => session.id)
+      ),
+      observedAt,
+    );
+    repository.markMissingSourceSessions(sourceID, observedAt);
+    return { discovered: candidates.length, imported, skipped, failed };
+  } finally {
+    source.close();
+  }
+}

--- a/src/server/openCodeImporter.ts
+++ b/src/server/openCodeImporter.ts
@@ -11,13 +11,11 @@ import {
   type SourceSessionCheckpoint,
 } from "./sessionRepository.ts";
 
-const parserVersion = "opencode-1";
+const parserVersion = "opencode-2";
 
 type AggregateRow = {
   session_id: string;
   row_count: number;
-  max_updated: number | null;
-  update_sum: string | null;
 };
 
 type OpenCodeCandidate = {
@@ -34,9 +32,7 @@ type OpenCodeSnapshot = {
   parts: OpenCodePartRow[];
 };
 
-const sessionColumns = `
-  id, parent_id, title, model, agent, time_created, time_updated
-`;
+const sessionColumns = "*";
 
 function digest(values: unknown[]) {
   const hash = createHash("sha256");
@@ -47,12 +43,13 @@ function digest(values: unknown[]) {
   return hash.digest("hex");
 }
 
+// Selecting part.time_updated forces SQLite to visit rows spread across the
+// large JSON payload table. The complete session row plus indexed child counts
+// is the cheap hint; changed trees still receive a full content checksum below.
 function aggregates(db: DatabaseSync, table: "message" | "part") {
   return new Map(
     (db.prepare(`
-      SELECT session_id, COUNT(*) AS row_count,
-        MAX(time_updated) AS max_updated,
-        CAST(SUM(time_updated) AS TEXT) AS update_sum
+      SELECT session_id, COUNT(*) AS row_count
       FROM ${table}
       GROUP BY session_id
       ORDER BY session_id
@@ -67,7 +64,7 @@ function candidate(
 ): OpenCodeCandidate {
   const ordered = sessions.toSorted((a, b) => a.id.localeCompare(b.id));
   const hintValues = ordered.map((session) => ({
-    session,
+    session: Object.entries(session).toSorted(([a], [b]) => a.localeCompare(b)),
     messages: messages.get(session.id) ?? null,
     parts: parts.get(session.id) ?? null,
   }));
@@ -83,13 +80,7 @@ function candidate(
       0,
     ),
     updatedAt: ordered.reduce(
-      (latest, session) =>
-        Math.max(
-          latest,
-          session.time_updated,
-          messages.get(session.id)?.max_updated ?? 0,
-          parts.get(session.id)?.max_updated ?? 0,
-        ),
+      (latest, session) => Math.max(latest, session.time_updated),
       0,
     ),
   };
@@ -159,9 +150,7 @@ function snapshot(db: DatabaseSync, rootID: string): OpenCodeSnapshot {
 }
 
 function snapshotCandidate(value: OpenCodeSnapshot) {
-  function aggregate<T extends { session_id: string; time_updated: number }>(
-    rows: T[],
-  ) {
+  function aggregate<T extends { session_id: string }>(rows: T[]) {
     return new Map(
       [...Map.groupBy(rows, (row) => row.session_id)].map((
         [sessionID, values],
@@ -170,11 +159,6 @@ function snapshotCandidate(value: OpenCodeSnapshot) {
         {
           session_id: sessionID,
           row_count: values.length,
-          max_updated: Math.max(...values.map((row) => row.time_updated)),
-          update_sum: values.reduce(
-            (sum, row) => sum + BigInt(row.time_updated),
-            0n,
-          ).toString(),
         },
       ]),
     );
@@ -247,11 +231,20 @@ export function syncOpenCodeSessions(
   let skipped = 0;
   let failed = 0;
   let candidates: OpenCodeCandidate[] = [];
+  let discoveryDuration = 0;
+  let checkpointDuration = 0;
+  let sourceReadDuration = 0;
+  let normalizeDuration = 0;
+  let archiveWriteDuration = 0;
 
   try {
+    const discoveryStartedAt = performance.now();
     candidates = discover(source);
+    discoveryDuration = performance.now() - discoveryStartedAt;
     for (const initial of candidates) {
+      const checkpointStartedAt = performance.now();
       const previous = repository.checkpoint(sourceID, initial.id);
+      checkpointDuration += performance.now() - checkpointStartedAt;
       if (
         previous?.parserVersion === parserVersion &&
         previous.changeHint === initial.changeHint
@@ -262,11 +255,13 @@ export function syncOpenCodeSessions(
 
       let transaction = false;
       try {
+        const sourceReadStartedAt = performance.now();
         source.exec("BEGIN");
         transaction = true;
         const rows = snapshot(source, initial.id);
         const fresh = snapshotCandidate(rows);
         const contentChecksum = checksum(rows);
+        sourceReadDuration += performance.now() - sourceReadStartedAt;
         const checkpoint: SourceSessionCheckpoint = {
           changeHint: fresh.changeHint,
           sourceSize: fresh.rowCount,
@@ -274,12 +269,14 @@ export function syncOpenCodeSessions(
           checksum: contentChecksum,
           parserVersion,
         };
+        const normalizeStartedAt = performance.now();
         const normalized = normalizeOpenCodeSessionTree({
           ...rows,
           sourceID,
           observedAt,
           checkpoint,
         });
+        normalizeDuration += performance.now() - normalizeStartedAt;
         source.exec("COMMIT");
         transaction = false;
 
@@ -287,6 +284,7 @@ export function syncOpenCodeSessions(
           previous?.parserVersion === parserVersion &&
           previous.checksum === contentChecksum
         ) {
+          const archiveWriteStartedAt = performance.now();
           recordUnchangedTree(
             repository,
             sourceID,
@@ -294,10 +292,13 @@ export function syncOpenCodeSessions(
             observedAt,
             checkpoint,
           );
+          archiveWriteDuration += performance.now() - archiveWriteStartedAt;
           skipped++;
           continue;
         }
+        const archiveWriteStartedAt = performance.now();
         repository.replaceSourceSessionTree(normalized);
+        archiveWriteDuration += performance.now() - archiveWriteStartedAt;
         imported++;
       } catch (error) {
         if (transaction) source.exec("ROLLBACK");
@@ -315,6 +316,7 @@ export function syncOpenCodeSessions(
         failed++;
       }
     }
+    const finalizeStartedAt = performance.now();
     repository.markSourceSessionsSeen(
       sourceID,
       candidates.flatMap((value) =>
@@ -323,7 +325,21 @@ export function syncOpenCodeSessions(
       observedAt,
     );
     repository.markMissingSourceSessions(sourceID, observedAt);
-    return { discovered: candidates.length, imported, skipped, failed };
+    const finalizeDuration = performance.now() - finalizeStartedAt;
+    return {
+      discovered: candidates.length,
+      imported,
+      skipped,
+      failed,
+      timings: {
+        discovery: discoveryDuration,
+        checkpoints: checkpointDuration,
+        sourceRead: sourceReadDuration,
+        normalize: normalizeDuration,
+        archiveWrite: archiveWriteDuration,
+        finalize: finalizeDuration,
+      },
+    };
   } finally {
     source.close();
   }

--- a/src/server/opencodeRepository.test.ts
+++ b/src/server/opencodeRepository.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual, strictEqual } from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
-import { OpenCodeRepository } from "../src/server/opencodeRepository.ts";
+import { OpenCodeRepository } from "./opencodeRepository.ts";
 
 Deno.test("removes empty turns without dropping reported cost", () => {
   const path = Deno.makeTempFileSync({ suffix: ".db" });

--- a/src/server/opencodeRepository.ts
+++ b/src/server/opencodeRepository.ts
@@ -1,13 +1,22 @@
 import { DatabaseSync } from "node:sqlite";
 import { z } from "zod";
 import {
-  type ModelCall,
   sessionDetailSchema,
   sessionListResponseSchema,
   type SessionSummary,
   type TokenUsage,
 } from "../shared/sessionSchemas.ts";
 import type { UsageCall } from "./usage.ts";
+import type {
+  SessionCallImport,
+  SessionContentImport,
+  SessionToolImport,
+  SessionTurnImport,
+  SourceSessionCheckpoint,
+  SourceSessionImport,
+} from "./sessionRepository.ts";
+
+const contentPreviewLimit = 512;
 
 const messageDataSchema = z.object({
   role: z.string(),
@@ -32,10 +41,14 @@ const messageDataSchema = z.object({
 
 const partDataSchema = z.object({
   type: z.string(),
+  text: z.string().optional(),
   mime: z.string().optional(),
+  callID: z.string().optional(),
   tool: z.string().optional(),
   state: z.object({
     status: z.string().optional(),
+    input: z.unknown().optional(),
+    output: z.unknown().optional(),
     metadata: z.object({
       sessionId: z.string().optional(),
     }).optional(),
@@ -46,34 +59,48 @@ const partDataSchema = z.object({
   }).optional(),
 }).passthrough();
 
-type SessionRow = {
+export type OpenCodeSessionRow = {
   id: string;
   parent_id: string | null;
   title: string;
   model: string | null;
   agent: string | null;
+  time_created: number;
   time_updated: number;
 };
 
-type MessageRow = {
+export type OpenCodeMessageRow = {
   id: string;
+  session_id: string;
   time_created: number;
+  time_updated: number;
   data: string;
 };
 
-type UsageMessageRow = MessageRow & { session_id: string };
+type UsageMessageRow = OpenCodeMessageRow;
 type UsageSessionRow = {
   id: string;
   parent_id: string | null;
   time_created: number;
 };
 
-type PartRow = {
+export type OpenCodePartRow = {
+  id: string;
   message_id: string;
+  session_id: string;
+  time_created: number;
+  time_updated: number;
   data: string;
 };
 
-type CallActivity = ModelCall["activity"];
+type SessionRow = OpenCodeSessionRow;
+type MessageRow = OpenCodeMessageRow;
+type PartRow = OpenCodePartRow;
+
+type DecodedParts = {
+  activity: SessionCallImport["activity"];
+  content: SessionContentImport[];
+};
 
 const emptyTokens = (): TokenUsage => ({
   uncachedInput: 0,
@@ -105,49 +132,92 @@ function addTokens(total: TokenUsage, usage: TokenUsage) {
   }
 }
 
-function decodeParts(rows: PartRow[]) {
-  const activity = new Map<string, CallActivity>();
+function preview(value: string): SessionContentImport {
+  return {
+    kind: "text",
+    preview: value.slice(0, contentPreviewLimit),
+    originalLength: value.length,
+    truncated: value.length > contentPreviewLimit,
+  };
+}
+
+function serializedPreview(value: unknown) {
+  if (value === undefined) return undefined;
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (text === undefined) return undefined;
+  const valuePreview = preview(text);
+  return {
+    preview: valuePreview.preview,
+    originalLength: valuePreview.originalLength,
+    truncated: valuePreview.truncated,
+  };
+}
+
+function decodeParts(rows: OpenCodePartRow[], strict = false) {
+  const decoded = new Map<string, DecodedParts>();
   for (const row of rows) {
     let raw: unknown;
     try {
       raw = JSON.parse(row.data);
-    } catch {
+    } catch (error) {
+      if (strict) throw error;
       continue;
     }
     const result = partDataSchema.safeParse(raw);
-    if (!result.success) continue;
+    if (!result.success) {
+      if (strict) throw result.error;
+      continue;
+    }
     const part = result.data;
-    const current = activity.get(row.message_id) ?? {
-      hasText: false,
-      hasReasoning: false,
-      tools: [],
+    const current = decoded.get(row.message_id) ?? {
+      activity: {
+        hasText: false,
+        hasReasoning: false,
+        tools: [],
+      },
+      content: [],
     };
-    if (part.type === "text") current.hasText = true;
-    if (part.type === "reasoning") current.hasReasoning = true;
-    if (part.type === "file" && part.mime?.startsWith("image/")) {
-      current.images = (current.images ?? 0) + 1;
+    if (part.type === "text") {
+      current.activity.hasText = true;
+      if (part.text !== undefined) current.content.push(preview(part.text));
+    }
+    if (part.type === "reasoning") {
+      current.activity.hasReasoning = true;
+      current.content.push({ kind: "reasoning" });
+    }
+    if (part.type === "file") {
+      const image = part.mime?.startsWith("image/") === true;
+      if (image) {
+        current.activity.images = (current.activity.images ?? 0) + 1;
+      }
+      current.content.push({
+        kind: image ? "image" : "file",
+        mimeType: part.mime,
+      });
     }
     if (part.type === "tool" && part.tool) {
-      current.tools.push({
+      current.activity.tools.push({
+        sourceID: part.callID,
         name: part.tool,
         status: part.state?.status ?? "unknown",
         startedAt: part.state?.time?.start,
         completedAt: part.state?.time?.end,
-        childSessionID: part.state?.metadata?.sessionId,
+        childExternalID: part.state?.metadata?.sessionId,
+        input: serializedPreview(part.state?.input),
+        output: serializedPreview(part.state?.output),
       });
     }
-    activity.set(row.message_id, current);
+    decoded.set(row.message_id, current);
   }
-  return activity;
+  return decoded;
 }
 
 function decodeMessages(
-  rows: MessageRow[],
-  activityByMessage = new Map<string, CallActivity>(),
+  rows: OpenCodeMessageRow[],
+  partsByMessage = new Map<string, DecodedParts>(),
+  strict = false,
 ) {
-  const turns: Array<
-    { number: number; startedAt: number; calls: ModelCall[] }
-  > = [];
+  const turns: SessionTurnImport[] = [];
   const providers = new Set<string>();
   const models = new Set<string>();
   const tokens = emptyTokens();
@@ -158,19 +228,28 @@ function decodeMessages(
     let raw: unknown;
     try {
       raw = JSON.parse(row.data);
-    } catch {
+    } catch (error) {
+      if (strict) throw error;
       continue;
     }
     const result = messageDataSchema.safeParse(raw);
-    if (!result.success) continue;
+    if (!result.success) {
+      const invalidTokenCount = result.error.issues.every((issue) =>
+        issue.code === "too_small" && issue.path[0] === "tokens"
+      );
+      if (strict && !invalidTokenCount) throw result.error;
+      continue;
+    }
     const message = result.data;
 
     if (message.role === "user") {
-      pendingImages = activityByMessage.get(row.id)?.images ?? 0;
+      const parts = partsByMessage.get(row.id);
+      pendingImages = parts?.activity.images ?? 0;
       turns.push({
         number: turns.length + 1,
         startedAt: row.time_created,
         calls: [],
+        inputs: parts?.content ?? [],
       });
       continue;
     }
@@ -198,7 +277,8 @@ function decodeMessages(
     const turn = turns.at(-1)!;
     const provider = message.providerID ?? "unknown";
     const model = message.modelID ?? "unknown";
-    const activity = activityByMessage.get(row.id) ?? {
+    const decodedParts = partsByMessage.get(row.id);
+    const activity = decodedParts?.activity ?? {
       hasText: false,
       hasReasoning: source.reasoning > 0,
       tools: [],
@@ -213,7 +293,7 @@ function decodeMessages(
     models.add(model);
     addTokens(tokens, callTokens);
     reportedCost += cost;
-    turn.calls.push({
+    const call: SessionCallImport = {
       id: row.id,
       callWithinTurn: turn.calls.length + 1,
       provider,
@@ -223,7 +303,9 @@ function decodeMessages(
       reportedCost: cost,
       tokens: callTokens,
       activity,
-    });
+      content: decodedParts?.content ?? [],
+    };
+    turn.calls.push(call);
   }
 
   const nonEmptyTurns = turns
@@ -326,6 +408,81 @@ function sessionBounds(
     ? Math.max(...ends)
     : Math.max(...turns.map((turn) => turn.startedAt));
   return { startedAt, endedAt };
+}
+
+function summaryFromDecoded(
+  row: SessionRow,
+  decoded: ReturnType<typeof decodeMessages>,
+): SessionSummary {
+  const fallback = fallbackModel(row.model);
+  if (decoded.providers.size === 0 && fallback) {
+    decoded.providers.add(fallback.providerID);
+  }
+  if (decoded.models.size === 0 && fallback) decoded.models.add(fallback.id);
+  const bounds = sessionBounds(decoded.turns);
+  return {
+    id: row.id,
+    harness: "opencode",
+    title: row.title,
+    updatedAt: row.time_updated,
+    startedAt: bounds.startedAt,
+    endedAt: bounds.endedAt,
+    providers: [...decoded.providers],
+    models: [...decoded.models],
+    userTurns: decoded.turns.length,
+    modelCalls: decoded.turns.reduce(
+      (sum, turn) => sum + turn.calls.length,
+      0,
+    ),
+    reportedCost: decoded.reportedCost,
+    tokens: decoded.tokens,
+  };
+}
+
+export function normalizeOpenCodeSessionTree(options: {
+  sessions: OpenCodeSessionRow[];
+  messages: OpenCodeMessageRow[];
+  parts: OpenCodePartRow[];
+  sourceID: number;
+  observedAt: number;
+  checkpoint: SourceSessionCheckpoint;
+}): SourceSessionImport[] {
+  const messagesBySession = Map.groupBy(
+    options.messages,
+    (message) => message.session_id,
+  );
+  const partsBySession = Map.groupBy(options.parts, (part) => part.session_id);
+  return options.sessions.map((row) => {
+    const sessionMessages = messagesBySession.get(row.id) ?? [];
+    const decoded = decodeMessages(
+      sessionMessages,
+      decodeParts(partsBySession.get(row.id) ?? [], true),
+      true,
+    );
+    const summary = summaryFromDecoded(row, decoded);
+    return {
+      sourceID: options.sourceID,
+      externalID: row.id,
+      parentExternalID: row.parent_id ?? undefined,
+      artifactPath: `session:${row.id}`,
+      observedAt: options.observedAt,
+      checkpoint: options.checkpoint,
+      session: {
+        title: summary.title,
+        agent: row.agent ?? undefined,
+        updatedAt: summary.updatedAt,
+        startedAt: summary.startedAt,
+        endedAt: summary.endedAt,
+        providers: summary.providers,
+        models: summary.models,
+        userTurns: summary.userTurns,
+        modelCalls: summary.modelCalls,
+        reportedCost: summary.reportedCost,
+        tokens: summary.tokens,
+        turns: decoded.turns,
+      },
+    };
+  });
 }
 
 export class OpenCodeRepository {
@@ -491,28 +648,6 @@ export class OpenCodeRepository {
     row: SessionRow,
     decoded: ReturnType<typeof decodeMessages>,
   ): SessionSummary {
-    const fallback = fallbackModel(row.model);
-    if (decoded.providers.size === 0 && fallback) {
-      decoded.providers.add(fallback.providerID);
-    }
-    if (decoded.models.size === 0 && fallback) decoded.models.add(fallback.id);
-    const bounds = sessionBounds(decoded.turns);
-    return {
-      id: row.id,
-      harness: "opencode",
-      title: row.title,
-      updatedAt: row.time_updated,
-      startedAt: bounds.startedAt,
-      endedAt: bounds.endedAt,
-      providers: [...decoded.providers],
-      models: [...decoded.models],
-      userTurns: decoded.turns.length,
-      modelCalls: decoded.turns.reduce(
-        (sum, turn) => sum + turn.calls.length,
-        0,
-      ),
-      reportedCost: decoded.reportedCost,
-      tokens: decoded.tokens,
-    };
+    return summaryFromDecoded(row, decoded);
   }
 }

--- a/src/server/opencodeRepository.ts
+++ b/src/server/opencodeRepository.ts
@@ -60,6 +60,7 @@ const partDataSchema = z.object({
 }).passthrough();
 
 export type OpenCodeSessionRow = {
+  [column: string]: unknown;
   id: string;
   parent_id: string | null;
   title: string;

--- a/src/server/piImporter.test.ts
+++ b/src/server/piImporter.test.ts
@@ -1,0 +1,73 @@
+import { strictEqual } from "node:assert/strict";
+import { openArchiveDatabase } from "./database.ts";
+import { syncPiSessions } from "./piImporter.ts";
+import { SessionRepository } from "./sessionRepository.ts";
+import { migrateTestDatabase } from "./databaseTestUtils.ts";
+
+function transcript(prompt: string) {
+  return `
+{"type":"session","version":3,"id":"session","timestamp":"2026-07-11T13:36:32.689Z","cwd":"/Users/test/project"}
+{"type":"message","id":"user-1","timestamp":"2026-07-11T13:36:55.000Z","message":{"role":"user","content":[{"type":"text","text":"${prompt}"}]}}
+{"type":"message","id":"assistant-1","timestamp":"2026-07-11T13:36:59.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Stored answer"}],"provider":"anthropic","model":"claude-opus","usage":{"input":2,"output":3,"cacheRead":0,"cacheWrite":0,"reasoning":0,"cost":{"total":0.01}},"stopReason":"stop"}}
+`.trim();
+}
+
+Deno.test("incrementally imports PI sessions and preserves the last good archive", async () => {
+  const directory = Deno.makeTempDirSync();
+  const sessions = `${directory}/sessions`;
+  const project = `${sessions}/project`;
+  const transcriptPath = `${project}/session.jsonl`;
+  Deno.mkdirSync(project, { recursive: true });
+  Deno.writeTextFileSync(transcriptPath, transcript("Initial prompt"));
+
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  migrateTestDatabase(db);
+  const repository = new SessionRepository(db);
+  try {
+    const initial = await syncPiSessions(sessions, repository);
+    strictEqual(initial.imported, 1);
+    strictEqual(
+      repository.getSession("pi", "project/session")?.title,
+      "Initial prompt",
+    );
+    strictEqual(
+      (db.prepare("SELECT COUNT(*) AS count FROM turn_inputs").get() as {
+        count: number;
+      }).count,
+      1,
+    );
+    strictEqual(
+      (db.prepare("SELECT COUNT(*) AS count FROM call_content").get() as {
+        count: number;
+      }).count,
+      1,
+    );
+
+    const unchanged = await syncPiSessions(sessions, repository);
+    strictEqual(unchanged.skipped, 1);
+
+    Deno.writeTextFileSync(
+      transcriptPath,
+      `${transcript("Broken replacement")}\n{`,
+    );
+    const failed = await syncPiSessions(sessions, repository);
+    strictEqual(failed.failed, 1);
+    strictEqual(
+      repository.getSession("pi", "project/session")?.title,
+      "Initial prompt",
+    );
+
+    Deno.removeSync(transcriptPath);
+    await syncPiSessions(sessions, repository);
+    strictEqual(repository.listSessions(1, 10, "pi").pagination.totalItems, 1);
+    strictEqual(
+      db.prepare(`
+        SELECT availability FROM source_sessions WHERE external_id = 'project/session'
+      `).get()!.availability,
+      "missing",
+    );
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});

--- a/src/server/piImporter.ts
+++ b/src/server/piImporter.ts
@@ -1,0 +1,18 @@
+import { discoverPiSessions, normalizePiSession } from "./piRepository.ts";
+import { SessionRepository } from "./sessionRepository.ts";
+import { syncFileSessions } from "./fileSessionImporter.ts";
+
+export async function syncPiSessions(
+  directory: string,
+  repository: SessionRepository,
+) {
+  return await syncFileSessions({
+    harness: "pi",
+    label: "PI",
+    directory,
+    parserVersion: "pi-1",
+    repository,
+    discover: discoverPiSessions,
+    normalize: normalizePiSession,
+  });
+}

--- a/src/server/piRepository.test.ts
+++ b/src/server/piRepository.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual } from "node:assert/strict";
-import { PiRepository } from "../src/server/piRepository.ts";
-import type { SessionDetail } from "../src/shared/sessionSchemas.ts";
+import { PiRepository } from "./piRepository.ts";
+import type { SessionDetail } from "../shared/sessionSchemas.ts";
 
 function repository(files: Record<string, string>) {
   const directory = Deno.makeTempDirSync();

--- a/src/server/piRepository.ts
+++ b/src/server/piRepository.ts
@@ -1,12 +1,19 @@
 import { z } from "zod";
 import {
-  type ModelCall,
   sessionDetailSchema,
   sessionListResponseSchema,
   type SessionSummary,
   type TokenUsage,
 } from "../shared/sessionSchemas.ts";
 import { usageCallsFromSession } from "./usage.ts";
+import type {
+  SessionCallImport,
+  SessionContentImport,
+  SessionToolImport,
+  SessionTurnImport,
+} from "./sessionRepository.ts";
+
+const contentPreviewLimit = 512;
 
 const contentBlockSchema = z.object({
   type: z.string(),
@@ -15,6 +22,9 @@ const contentBlockSchema = z.object({
   id: z.string().optional(),
   name: z.string().optional(),
   isError: z.boolean().optional(),
+  mime: z.string().optional(),
+  mediaType: z.string().optional(),
+  arguments: z.unknown().optional(),
 }).passthrough();
 
 const recordSchema = z.object({
@@ -49,10 +59,12 @@ const recordSchema = z.object({
 }).passthrough();
 
 type Record = z.infer<typeof recordSchema>;
-type FileEntry = {
+export type PiSessionCandidate = {
   id: string;
   path: string;
+  artifactPath: string;
   updatedAt: number;
+  size: number;
 };
 
 const emptyTokens = (): TokenUsage => ({
@@ -85,18 +97,63 @@ function addTokens(total: TokenUsage, usage: TokenUsage) {
   }
 }
 
-function readRecords(path: string) {
+function readRecordsFromText(text: string, strict = false) {
   const records: Record[] = [];
-  for (const line of Deno.readTextFileSync(path).split("\n")) {
+  for (const line of text.split("\n")) {
     if (!line) continue;
     try {
       const result = recordSchema.safeParse(JSON.parse(line));
       if (result.success) records.push(result.data);
-    } catch {
+      else if (strict) throw result.error;
+    } catch (error) {
+      if (strict) throw error;
       // A partially written final line should not hide the rest of the session.
     }
   }
   return records;
+}
+
+function readRecords(path: string) {
+  return readRecordsFromText(Deno.readTextFileSync(path));
+}
+
+function preview(value: string): SessionContentImport {
+  return {
+    kind: "text",
+    preview: value.slice(0, contentPreviewLimit),
+    originalLength: value.length,
+    truncated: value.length > contentPreviewLimit,
+  };
+}
+
+function contentMetadata(
+  blocks: z.infer<typeof contentBlockSchema>[],
+  includeReasoning = false,
+): SessionContentImport[] {
+  return blocks.flatMap((block) => {
+    if (block.type === "text" && block.text !== undefined) {
+      return [preview(block.text)];
+    }
+    if (block.type === "thinking") {
+      return includeReasoning ? [{ kind: "reasoning" }] : [];
+    }
+    if (block.type === "image" || block.type === "input_image") {
+      return [{ kind: "image", mimeType: block.mime ?? block.mediaType }];
+    }
+    return [];
+  });
+}
+
+function serializedPreview(value: unknown) {
+  if (value === undefined) return undefined;
+  const text = typeof value === "string" ? value : JSON.stringify(value);
+  if (text === undefined) return undefined;
+  const metadata = preview(text);
+  return {
+    preview: metadata.preview,
+    originalLength: metadata.originalLength,
+    truncated: metadata.truncated,
+  };
 }
 
 function userText(record: Record) {
@@ -105,9 +162,10 @@ function userText(record: Record) {
 
 function userImages(record: Record) {
   const content = record.message?.content ?? [];
-  const blocks = content.filter((block) =>
-    block.type === "image" || block.type === "input_image"
-  ).length;
+  const blocks =
+    content.filter((block) =>
+      block.type === "image" || block.type === "input_image"
+    ).length;
   if (blocks > 0) return blocks;
   // Pi may persist a clipboard attachment as its temporary image path in a
   // text block rather than as an image content block.
@@ -125,7 +183,12 @@ function basename(path: string | undefined) {
 }
 
 function sessionBounds(
-  turns: Array<{ startedAt: number; calls: Array<{ startedAt: number; completedAt?: number }> }>,
+  turns: Array<
+    {
+      startedAt: number;
+      calls: Array<{ startedAt: number; completedAt?: number }>;
+    }
+  >,
 ) {
   if (turns.length === 0) return {};
   const startedAt = Math.min(...turns.map((turn) => turn.startedAt));
@@ -139,16 +202,11 @@ function sessionBounds(
 }
 
 function decodeRecords(records: Record[]) {
-  const turns: Array<
-    { number: number; startedAt: number; calls: ModelCall[]; images?: number }
-  > = [];
+  const turns: Array<SessionTurnImport & { images?: number }> = [];
   const tokens = emptyTokens();
   const providers = new Set<string>();
   const models = new Set<string>();
-  const tools = new Map<
-    string,
-    ModelCall["activity"]["tools"][number]
-  >();
+  const tools = new Map<string, SessionToolImport>();
   let reportedCost = 0;
 
   for (const record of records) {
@@ -163,6 +221,7 @@ function decodeRecords(records: Record[]) {
           number: turns.length + 1,
           startedAt: timestamp,
           calls: [],
+          inputs: contentMetadata(record.message?.content ?? []),
           images: userImages(record),
         });
       }
@@ -175,6 +234,12 @@ function decodeRecords(records: Record[]) {
       if (!tool) continue;
       tool.status = message.isError ? "error" : "completed";
       tool.completedAt = timestamp;
+      tool.output = serializedPreview(
+        message.content?.map((block) => block.text ?? block.thinking).filter(
+          Boolean,
+        )
+          .join("\n"),
+      );
       continue;
     }
 
@@ -207,7 +272,7 @@ function decodeRecords(records: Record[]) {
     const turn = turns.at(-1)!;
     const provider = message.provider ?? "unknown";
     const model = message.model ?? "unknown";
-    const call: ModelCall = {
+    const call: SessionCallImport = {
       id: record.id ?? `${turn.number}-${turn.calls.length + 1}`,
       callWithinTurn: turn.calls.length + 1,
       provider,
@@ -225,6 +290,7 @@ function decodeRecords(records: Record[]) {
         hasReasoning: source.reasoning > 0,
         tools: [],
       },
+      content: contentMetadata(message.content ?? [], true),
     };
 
     for (const block of message.content ?? []) {
@@ -232,9 +298,11 @@ function decodeRecords(records: Record[]) {
       if (block.type === "thinking") call.activity.hasReasoning = true;
       if (block.type === "toolCall" && block.id && block.name) {
         const tool = {
+          sourceID: block.id,
           name: block.name,
           status: "pending",
           startedAt: timestamp,
+          input: serializedPreview(block.arguments),
         };
         call.activity.tools.push(tool);
         tools.set(block.id, tool);
@@ -259,23 +327,7 @@ export class PiRepository {
   constructor(private directory: string) {}
 
   #files() {
-    const files: FileEntry[] = [];
-    for (const project of Deno.readDirSync(this.directory)) {
-      if (!project.isDirectory) continue;
-      const projectPath = `${this.directory}/${project.name}`;
-      for (const entry of Deno.readDirSync(projectPath)) {
-        if (!entry.isFile || !entry.name.endsWith(".jsonl")) continue;
-        const path = `${projectPath}/${entry.name}`;
-        files.push({
-          id: `${project.name}/${entry.name.slice(0, -6)}`,
-          path,
-          updatedAt: Deno.statSync(path).mtime?.getTime() ?? 0,
-        });
-      }
-    }
-    return files.sort((a, b) =>
-      b.updatedAt - a.updatedAt || b.id.localeCompare(a.id)
-    );
+    return discoverPiSessions(this.directory);
   }
 
   listSessions(page: number, pageSize: number) {
@@ -310,48 +362,94 @@ export class PiRepository {
   }
 
   #summary(id: string, path: string, updatedAt: number): SessionSummary {
-    const records = readRecords(path);
-    const decoded = decodeRecords(records);
-    const header = records.find((record) => record.type === "session");
-    const firstPrompt = records.find((record) =>
-      record.type === "message" && record.message?.role === "user" &&
-      userText(record)?.trim()
-    );
-    const promptTitle = userText(firstPrompt ?? { type: "" })?.replace(/\s+/g, " ")
-      .trim().slice(0, 100);
-    const title = promptTitle ??
-      `Pi session ${basename(header?.cwd) ?? id.split("/").at(-1)?.slice(0, 8)}`;
-    const transcriptUpdatedAt = [...records].reverse().find((record) =>
-      record.timestamp && Number.isFinite(Date.parse(record.timestamp))
-    )?.timestamp;
-    const bounds = sessionBounds(decoded.turns);
-    return {
-      id,
-      harness: "pi",
-      title,
-      updatedAt: transcriptUpdatedAt ? Date.parse(transcriptUpdatedAt) : updatedAt,
-      startedAt: bounds.startedAt,
-      endedAt: bounds.endedAt,
-      providers: [...decoded.providers],
-      models: [...decoded.models],
-      userTurns: decoded.turns.length,
-      modelCalls: decoded.turns.reduce(
-        (sum, turn) => sum + turn.calls.length,
-        0,
-      ),
-      reportedCost: decoded.reportedCost,
-      tokens: decoded.tokens,
-    };
+    return piSession(readRecords(path), id, updatedAt).summary;
   }
 
-  #detail(file: FileEntry): unknown {
-    const records = readRecords(file.path);
-    const decoded = decodeRecords(records);
+  #detail(file: PiSessionCandidate): unknown {
+    const normalized = piSession(
+      readRecords(file.path),
+      file.id,
+      file.updatedAt,
+    );
     return {
-      ...this.#summary(file.id, file.path, file.updatedAt),
+      ...normalized.summary,
       parentID: undefined,
-      turns: decoded.turns,
+      turns: normalized.turns,
       subagents: [],
     };
   }
+}
+
+export function discoverPiSessions(directory: string) {
+  const files: PiSessionCandidate[] = [];
+  for (const project of Deno.readDirSync(directory)) {
+    if (!project.isDirectory) continue;
+    const projectPath = `${directory}/${project.name}`;
+    for (const entry of Deno.readDirSync(projectPath)) {
+      if (!entry.isFile || !entry.name.endsWith(".jsonl")) continue;
+      const path = `${projectPath}/${entry.name}`;
+      const stat = Deno.statSync(path);
+      files.push({
+        id: `${project.name}/${entry.name.slice(0, -6)}`,
+        path,
+        artifactPath: `${project.name}/${entry.name}`,
+        updatedAt: stat.mtime?.getTime() ?? 0,
+        size: stat.size,
+      });
+    }
+  }
+  return files.sort((a, b) =>
+    b.updatedAt - a.updatedAt || b.id.localeCompare(a.id)
+  );
+}
+
+function piSession(records: Record[], id: string, updatedAt: number) {
+  const decoded = decodeRecords(records);
+  const header = records.find((record) => record.type === "session");
+  const firstPrompt = records.find((record) =>
+    record.type === "message" && record.message?.role === "user" &&
+    userText(record)?.trim()
+  );
+  const promptTitle = userText(firstPrompt ?? { type: "" })?.replace(
+    /\s+/g,
+    " ",
+  )
+    .trim().slice(0, 100);
+  const title = promptTitle ??
+    `Pi session ${basename(header?.cwd) ?? id.split("/").at(-1)?.slice(0, 8)}`;
+  const transcriptUpdatedAt = [...records].reverse().find((record) =>
+    record.timestamp && Number.isFinite(Date.parse(record.timestamp))
+  )?.timestamp;
+  const bounds = sessionBounds(decoded.turns);
+  const summary: SessionSummary = {
+    id,
+    harness: "pi",
+    title,
+    updatedAt: transcriptUpdatedAt
+      ? Date.parse(transcriptUpdatedAt)
+      : updatedAt,
+    startedAt: bounds.startedAt,
+    endedAt: bounds.endedAt,
+    providers: [...decoded.providers],
+    models: [...decoded.models],
+    userTurns: decoded.turns.length,
+    modelCalls: decoded.turns.reduce(
+      (sum, turn) => sum + turn.calls.length,
+      0,
+    ),
+    reportedCost: decoded.reportedCost,
+    tokens: decoded.tokens,
+  };
+  return { summary, turns: decoded.turns };
+}
+
+export function normalizePiSession(
+  candidate: PiSessionCandidate,
+  text: string,
+) {
+  return piSession(
+    readRecordsFromText(text, true),
+    candidate.id,
+    candidate.updatedAt,
+  );
 }

--- a/src/server/sessionRepository.test.ts
+++ b/src/server/sessionRepository.test.ts
@@ -162,3 +162,100 @@ Deno.test("stores and reads canonical sessions atomically", () => {
     Deno.removeSync(directory, { recursive: true });
   }
 });
+
+Deno.test("atomically replaces trees with root-scoped public child IDs", () => {
+  const directory = Deno.makeTempDirSync();
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  try {
+    migrateTestDatabase(db);
+    const sourceID = Number(
+      (db.prepare(`
+      INSERT INTO sources (harness, kind, label, location, created_at)
+      VALUES ('claude-code', 'directory', 'Claude', '/claude', 1)
+      RETURNING id
+    `).get() as { id: number }).id,
+    );
+    const repository = new SessionRepository(db);
+
+    const tree = (namespace: string): SourceSessionImport[] => {
+      const root = importedSession(sourceID, `${namespace}:root`);
+      root.publicID = namespace;
+      root.session.turns[0].calls[0].activity.tools.push({
+        name: "subagent",
+        status: "completed",
+        childExternalID: `${namespace}:child`,
+      });
+      const child = importedSession(
+        sourceID,
+        `${namespace}:child`,
+        `${namespace}:root`,
+      );
+      child.publicID = "child";
+      return [root, child];
+    };
+
+    repository.replaceSourceSessionTree(tree("root-a"));
+    repository.replaceSourceSessionTree(tree("root-b"));
+
+    deepStrictEqual(
+      repository.listSessions(1, 10, "claude-code").items.map(({ id }) => id)
+        .sort(),
+      ["root-a", "root-b"],
+    );
+    for (const rootID of ["root-a", "root-b"]) {
+      const detail = repository.getSession("claude-code", rootID)!;
+      strictEqual(detail.subagents[0].id, "child");
+      strictEqual(detail.subagents[0].parentID, rootID);
+      strictEqual(
+        detail.turns[0].calls[0].activity.tools[0].childSessionID,
+        "child",
+      );
+    }
+
+    const invalid = tree("root-a");
+    invalid[0].session.title = "must-roll-back";
+    invalid[0].checkpoint.checksum = "must-roll-back";
+    invalid[1].session.turns.push({ ...invalid[1].session.turns[0] });
+    throws(() => repository.replaceSourceSessionTree(invalid));
+    strictEqual(
+      repository.getSession("claude-code", "root-a")?.title,
+      "root-a:root",
+    );
+    strictEqual(
+      repository.getSession("claude-code", "root-a")?.subagents.length,
+      1,
+    );
+    strictEqual(
+      (db.prepare(`
+        SELECT checksum FROM source_sessions
+        WHERE source_id = ? AND external_id = 'root-a:root'
+      `).get(sourceID) as { checksum: string }).checksum,
+      "checksum-root-a:root",
+    );
+
+    const rootOnly = tree("root-a")[0];
+    rootOnly.session.turns[0].calls[0].activity.tools = [];
+    repository.replaceSourceSessionTree([rootOnly]);
+    strictEqual(
+      repository.getSession("claude-code", "root-a")?.subagents.length,
+      0,
+    );
+    strictEqual(
+      repository.getSession("claude-code", "root-b")?.subagents[0].id,
+      "child",
+    );
+    deepStrictEqual(
+      (db.prepare(`
+        SELECT external_id FROM source_sessions
+        WHERE source_id = ? AND public_id = 'child'
+        ORDER BY external_id
+      `).all(sourceID) as Array<{ external_id: string }>).map((row) =>
+        row.external_id
+      ),
+      ["root-b:child"],
+    );
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});

--- a/src/server/sessionRepository.test.ts
+++ b/src/server/sessionRepository.test.ts
@@ -1,0 +1,164 @@
+import { deepStrictEqual, strictEqual, throws } from "node:assert/strict";
+import { openArchiveDatabase } from "./database.ts";
+import {
+  SessionRepository,
+  type SourceSessionImport,
+} from "./sessionRepository.ts";
+import type { TokenUsage } from "../shared/sessionSchemas.ts";
+import { migrateTestDatabase } from "./databaseTestUtils.ts";
+
+const tokens: TokenUsage = {
+  uncachedInput: 3,
+  cacheRead: 2,
+  cacheWrite: 5,
+  cacheWrite5m: 0,
+  cacheWrite1h: 0,
+  freshPrompt: 8,
+  output: 4,
+  reasoning: 1,
+  processed: 15,
+};
+
+function importedSession(
+  sourceID: number,
+  externalID: string,
+  parentExternalID?: string,
+): SourceSessionImport {
+  return {
+    sourceID,
+    externalID,
+    parentExternalID,
+    artifactPath: `/sessions/${externalID}.jsonl`,
+    observedAt: 90,
+    checkpoint: {
+      sourceSize: 123,
+      sourceModifiedAt: 80,
+      checksum: `checksum-${externalID}`,
+      parserVersion: "pi-1",
+      importedAt: 100,
+    },
+    session: {
+      title: externalID,
+      agent: "pi",
+      updatedAt: parentExternalID ? 30 : 20,
+      startedAt: parentExternalID ? 11 : 10,
+      endedAt: parentExternalID ? 31 : 21,
+      providers: ["anthropic"],
+      models: ["claude"],
+      userTurns: 1,
+      modelCalls: 1,
+      reportedCost: 0,
+      tokens,
+      turns: [{
+        number: 1,
+        startedAt: parentExternalID ? 11 : 10,
+        inputs: [{ kind: "text", preview: "hello", originalLength: 5 }],
+        calls: [{
+          id: `call-${externalID}`,
+          callWithinTurn: 1,
+          provider: "anthropic",
+          model: "claude",
+          startedAt: parentExternalID ? 12 : 11,
+          completedAt: parentExternalID ? 13 : 12,
+          reportedCost: 0,
+          tokens,
+          content: [{ kind: "text", preview: "answer", originalLength: 6 }],
+          activity: {
+            finishReason: "stop",
+            hasText: true,
+            hasReasoning: true,
+            tools: [],
+          },
+        }],
+      }],
+    },
+  };
+}
+
+Deno.test("stores and reads canonical sessions atomically", () => {
+  const directory = Deno.makeTempDirSync();
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  try {
+    migrateTestDatabase(db);
+    const sourceID = Number(
+      (db.prepare(`
+      INSERT INTO sources (harness, kind, label, location, created_at)
+      VALUES ('pi', 'directory', 'PI', '/pi', 1)
+      RETURNING id
+    `).get() as { id: number }).id,
+    );
+    const repository = new SessionRepository(db);
+
+    repository.replaceSourceSession(importedSession(sourceID, "root"));
+    repository.replaceSourceSession(importedSession(sourceID, "child", "root"));
+    const root = importedSession(sourceID, "root");
+    root.session.turns[0].calls[0].activity.tools.push({
+      sourceID: "tool-1",
+      name: "subagent",
+      status: "completed",
+      startedAt: 11,
+      completedAt: 12,
+      childExternalID: "child",
+    });
+    repository.replaceSourceSession(root);
+
+    const listed = repository.listSessions(1, 10, "pi");
+    strictEqual(listed.pagination.totalItems, 1);
+    deepStrictEqual(listed.items.map(({ id }) => id), ["root"]);
+
+    const detail = repository.getSession("pi", "root")!;
+    strictEqual(detail.reportedCost, 0);
+    strictEqual(detail.turns[0].calls[0].tokens.cacheWrite5m, 0);
+    strictEqual(detail.turns[0].calls[0].tokens.cacheWrite1h, 0);
+    strictEqual(
+      detail.turns[0].calls[0].activity.tools[0].childSessionID,
+      "child",
+    );
+    strictEqual(detail.subagents[0].id, "child");
+    strictEqual(detail.subagents[0].parentID, "root");
+
+    const usage = repository.listUsageCalls(12, "pi");
+    deepStrictEqual(
+      usage.map((call) => ({
+        id: call.session.id,
+        rootID: call.session.rootID,
+        sessionStartedAt: call.sessionStartedAt,
+      })),
+      [{ id: "child", rootID: "root", sessionStartedAt: 10 }],
+    );
+    strictEqual(
+      (db.prepare("SELECT COUNT(*) AS count FROM models").get() as {
+        count: number;
+      }).count,
+      1,
+    );
+    strictEqual(
+      (db.prepare("SELECT COUNT(*) AS count FROM turn_inputs").get() as {
+        count: number;
+      }).count,
+      2,
+    );
+    strictEqual(
+      (db.prepare("SELECT COUNT(*) AS count FROM call_content").get() as {
+        count: number;
+      }).count,
+      2,
+    );
+
+    const invalid = importedSession(sourceID, "root");
+    invalid.checkpoint.checksum = "must-roll-back";
+    invalid.session.title = "must-roll-back";
+    invalid.session.turns.push({ ...invalid.session.turns[0] });
+    throws(() => repository.replaceSourceSession(invalid));
+    strictEqual(repository.getSession("pi", "root")?.title, "root");
+    const checkpoint = db.prepare(`
+      SELECT checksum, imported_at FROM source_sessions
+      WHERE source_id = ? AND external_id = 'root'
+    `).get(sourceID)!;
+    strictEqual(checkpoint.checksum, "checksum-root");
+    strictEqual(checkpoint.imported_at, 100);
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -58,6 +58,7 @@ export type SessionTurnImport = {
 export type SourceSessionImport = {
   sourceID: number;
   externalID: string;
+  publicID?: string;
   parentExternalID?: string;
   artifactPath?: string;
   observedAt: number;
@@ -87,6 +88,7 @@ export type SourceSessionImport = {
 type SummaryRow = {
   source_session_id: number;
   external_id: string;
+  public_id: string;
   harness: Harness;
   title: string;
   agent: string | null;
@@ -107,7 +109,7 @@ type SummaryRow = {
   output_tokens: number;
   reasoning_tokens: number;
   processed_tokens: number;
-  parent_external_id: string | null;
+  parent_public_id: string | null;
 };
 
 type CallRow = {
@@ -140,18 +142,19 @@ type ToolRow = {
   status: string;
   started_at: number | null;
   completed_at: number | null;
-  child_external_id: string | null;
+  child_public_id: string | null;
 };
 
 const summaryColumns = `
-  ss.id AS source_session_id, ss.external_id, so.harness,
+  ss.id AS source_session_id, ss.external_id,
+  COALESCE(ss.public_id, ss.external_id) AS public_id, so.harness,
   s.title, s.agent, s.updated_at, s.started_at, s.ended_at,
   s.providers_json, s.models_json, s.user_turns, s.model_calls,
   s.reported_cost, s.uncached_input_tokens, s.cache_read_tokens,
   s.cache_write_tokens, s.cache_write_5m_tokens,
   s.cache_write_1h_tokens, s.fresh_prompt_tokens, s.output_tokens,
   s.reasoning_tokens, s.processed_tokens,
-  parent.external_id AS parent_external_id
+  COALESCE(parent.public_id, parent.external_id) AS parent_public_id
 `;
 
 const callColumns = `
@@ -184,7 +187,7 @@ function tokens(row: SummaryRow | CallRow): TokenUsage {
 
 function summary(row: SummaryRow): SessionSummary {
   return {
-    id: row.external_id,
+    id: row.public_id,
     harness: row.harness,
     title: row.title,
     updatedAt: row.updated_at,
@@ -249,10 +252,10 @@ export class SessionRepository {
   ) {
     this.db.prepare(`
       INSERT INTO source_sessions (
-        source_id, external_id, artifact_path, availability, source_size,
+        source_id, external_id, public_id, artifact_path, availability, source_size,
         source_modified_at, checksum, parser_version, first_seen_at,
         last_seen_at, last_error
-      ) VALUES (?, ?, ?, 'available', ?, ?, ?, ?, ?, ?, NULL)
+      ) VALUES (?, ?, ?, ?, 'available', ?, ?, ?, ?, ?, ?, NULL)
       ON CONFLICT (source_id, external_id) DO UPDATE SET
         artifact_path = excluded.artifact_path,
         availability = 'available',
@@ -268,6 +271,7 @@ export class SessionRepository {
         last_error = NULL
     `).run(
       sourceID,
+      externalID,
       externalID,
       artifactPath,
       checkpoint?.sourceSize ?? null,
@@ -288,9 +292,9 @@ export class SessionRepository {
   ) {
     this.db.prepare(`
       INSERT INTO source_sessions (
-        source_id, external_id, artifact_path, availability, first_seen_at,
+        source_id, external_id, public_id, artifact_path, availability, first_seen_at,
         last_seen_at, last_error
-      ) VALUES (?, ?, ?, 'available', ?, ?, ?)
+      ) VALUES (?, ?, ?, ?, 'available', ?, ?, ?)
       ON CONFLICT (source_id, external_id) DO UPDATE SET
         artifact_path = excluded.artifact_path,
         availability = 'available',
@@ -298,6 +302,7 @@ export class SessionRepository {
         last_error = excluded.last_error
     `).run(
       sourceID,
+      externalID,
       externalID,
       artifactPath,
       observedAt,
@@ -364,7 +369,8 @@ export class SessionRepository {
       JOIN source_sessions ss ON ss.id = s.source_session_id
       JOIN sources so ON so.id = ss.source_id
       LEFT JOIN source_sessions parent ON parent.id = ss.parent_id
-      WHERE so.harness = ? AND ss.external_id = ?
+       WHERE so.harness = ? AND ss.parent_id IS NULL
+         AND COALESCE(ss.public_id, ss.external_id) = ?
       ORDER BY ss.id
       LIMIT 1
     `).get(harness, id) as SummaryRow | undefined;
@@ -376,8 +382,9 @@ export class SessionRepository {
     type UsageRow = CallRow & {
       harness: Harness;
       external_id: string;
-      root_external_id: string;
-      parent_external_id: string | null;
+      public_id: string;
+      root_public_id: string;
+      parent_public_id: string | null;
       root_started_at: number | null;
       root_updated_at: number;
     };
@@ -394,8 +401,9 @@ export class SessionRepository {
         JOIN session_tree ON session_tree.id = child.parent_id
       )
       SELECT ${callColumns}, so.harness, ss.external_id,
-        root.external_id AS root_external_id,
-        parent.external_id AS parent_external_id,
+        COALESCE(ss.public_id, ss.external_id) AS public_id,
+        COALESCE(root.public_id, root.external_id) AS root_public_id,
+        COALESCE(parent.public_id, parent.external_id) AS parent_public_id,
         root_session.started_at AS root_started_at,
         root_session.updated_at AS root_updated_at
       FROM model_calls mc
@@ -421,9 +429,9 @@ export class SessionRepository {
     return rows.map((row) => ({
       harness: row.harness,
       session: {
-        id: row.external_id,
-        rootID: row.root_external_id,
-        parentID: optional(row.parent_external_id),
+        id: row.public_id,
+        rootID: row.root_public_id,
+        parentID: optional(row.parent_public_id),
       },
       cacheChainID: row.external_id,
       sessionStartedAt: row.root_started_at ?? row.root_updated_at,
@@ -438,37 +446,135 @@ export class SessionRepository {
   replaceSourceSession(value: SourceSessionImport): void {
     this.db.exec("BEGIN IMMEDIATE");
     try {
-      const parentID = value.parentExternalID === undefined
-        ? null
-        : this.#sourceSessionID(value.sourceID, value.parentExternalID);
-      const sourceSessionID = Number(
-        (this.db.prepare(`
+      this.#replaceSourceSession(value, null);
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  replaceSourceSessionTree(values: SourceSessionImport[]): void {
+    if (values.length === 0) {
+      throw new Error("A source session tree must not be empty");
+    }
+    const sourceID = values[0].sourceID;
+    const externalIDs = new Set(values.map((value) => value.externalID));
+    if (externalIDs.size !== values.length) {
+      throw new Error("A source session tree must have unique external IDs");
+    }
+    if (values.some((value) => value.sourceID !== sourceID)) {
+      throw new Error("A source session tree must belong to one source");
+    }
+    const roots = values.filter((value) =>
+      value.parentExternalID === undefined
+    );
+    if (roots.length !== 1) {
+      throw new Error("A source session tree must have exactly one root");
+    }
+    for (const value of values) {
+      if (
+        value.parentExternalID !== undefined &&
+        !externalIDs.has(value.parentExternalID)
+      ) {
+        throw new Error(`Unknown tree parent: ${value.parentExternalID}`);
+      }
+    }
+
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const upsertIdentity = this.db.prepare(`
         INSERT INTO source_sessions (
-          source_id, external_id, parent_id, artifact_path, availability,
+          source_id, external_id, public_id, artifact_path, availability,
           first_seen_at, last_seen_at
         ) VALUES (?, ?, ?, ?, 'available', ?, ?)
         ON CONFLICT (source_id, external_id) DO UPDATE SET
+          public_id = excluded.public_id,
+          artifact_path = excluded.artifact_path,
+          availability = 'available',
+          last_seen_at = excluded.last_seen_at
+      `);
+      for (const value of values) {
+        upsertIdentity.run(
+          value.sourceID,
+          value.externalID,
+          value.publicID ?? value.externalID,
+          value.artifactPath ?? null,
+          value.observedAt,
+          value.observedAt,
+        );
+      }
+
+      const rootID = this.#sourceSessionID(sourceID, roots[0].externalID);
+      for (const value of values) {
+        const parentID = value.parentExternalID === undefined
+          ? null
+          : this.#sourceSessionID(sourceID, value.parentExternalID);
+        this.db.prepare(`
+          UPDATE source_sessions SET parent_id = ?, tree_root_id = ?
+          WHERE source_id = ? AND external_id = ?
+        `).run(parentID, rootID, sourceID, value.externalID);
+      }
+
+      for (const value of values) {
+        this.#replaceSourceSession(value, rootID);
+      }
+
+      const currentIDs = values.map((value) =>
+        this.#sourceSessionID(sourceID, value.externalID)
+      );
+      this.db.prepare(`
+        DELETE FROM source_sessions
+        WHERE tree_root_id = ? AND id NOT IN (${
+        currentIDs.map(() => "?").join(",")
+      })
+      `).run(rootID, ...currentIDs);
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  #replaceSourceSession(
+    value: SourceSessionImport,
+    treeRootID: number | null,
+  ): void {
+    const parentID = value.parentExternalID === undefined
+      ? null
+      : this.#sourceSessionID(value.sourceID, value.parentExternalID);
+    const sourceSessionID = Number(
+      (this.db.prepare(`
+        INSERT INTO source_sessions (
+          source_id, external_id, public_id, parent_id, tree_root_id,
+          artifact_path, availability, first_seen_at, last_seen_at
+        ) VALUES (?, ?, ?, ?, ?, ?, 'available', ?, ?)
+        ON CONFLICT (source_id, external_id) DO UPDATE SET
+          public_id = excluded.public_id,
           parent_id = excluded.parent_id,
+          tree_root_id = excluded.tree_root_id,
           artifact_path = excluded.artifact_path,
           availability = 'available',
           last_seen_at = excluded.last_seen_at
         RETURNING id
       `).get(
-            value.sourceID,
-            value.externalID,
-            parentID,
-            value.artifactPath ?? null,
-            value.observedAt,
-            value.observedAt,
-          ) as { id: number }).id,
-      );
+        value.sourceID,
+        value.externalID,
+        value.publicID ?? value.externalID,
+        parentID,
+        treeRootID,
+        value.artifactPath ?? null,
+        value.observedAt,
+        value.observedAt,
+      ) as { id: number }).id,
+    );
 
-      this.db.prepare("DELETE FROM sessions WHERE source_session_id = ?").run(
-        sourceSessionID,
-      );
-      const session = value.session;
-      const tokenValues = this.#tokenValues(session.tokens);
-      this.db.prepare(`
+    this.db.prepare("DELETE FROM sessions WHERE source_session_id = ?").run(
+      sourceSessionID,
+    );
+    const session = value.session;
+    const tokenValues = this.#tokenValues(session.tokens);
+    this.db.prepare(`
         INSERT INTO sessions (
           source_session_id, title, agent, updated_at, started_at, ended_at,
           providers_json, models_json, user_turns, model_calls, reported_cost,
@@ -477,39 +583,39 @@ export class SessionRepository {
           output_tokens, reasoning_tokens, processed_tokens
         ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
       `).run(
-        sourceSessionID,
-        session.title,
-        session.agent ?? null,
-        session.updatedAt,
-        session.startedAt ?? null,
-        session.endedAt ?? null,
-        JSON.stringify(session.providers),
-        JSON.stringify(session.models),
-        session.userTurns,
-        session.modelCalls,
-        session.reportedCost ?? null,
-        ...tokenValues,
-      );
+      sourceSessionID,
+      session.title,
+      session.agent ?? null,
+      session.updatedAt,
+      session.startedAt ?? null,
+      session.endedAt ?? null,
+      JSON.stringify(session.providers),
+      JSON.stringify(session.models),
+      session.userTurns,
+      session.modelCalls,
+      session.reportedCost ?? null,
+      ...tokenValues,
+    );
 
-      for (const turn of session.turns) {
-        const turnID = Number(
-          (this.db.prepare(`
+    for (const turn of session.turns) {
+      const turnID = Number(
+        (this.db.prepare(`
           INSERT INTO turns (session_id, ordinal, started_at)
           VALUES (?, ?, ?) RETURNING id
         `).get(sourceSessionID, turn.number, turn.startedAt) as { id: number })
-            .id,
-        );
-        this.#insertContent(
-          "turn_inputs",
-          "turn_id",
-          turnID,
-          turn.inputs ?? [],
-        );
+          .id,
+      );
+      this.#insertContent(
+        "turn_inputs",
+        "turn_id",
+        turnID,
+        turn.inputs ?? [],
+      );
 
-        for (const call of turn.calls) {
-          const modelID = this.#modelID(call.provider, call.model);
-          const callID = Number(
-            (this.db.prepare(`
+      for (const call of turn.calls) {
+        const modelID = this.#modelID(call.provider, call.model);
+        const callID = Number(
+          (this.db.prepare(`
             INSERT INTO model_calls (
               turn_id, source_call_id, ordinal, model_id, started_at,
               completed_at, reported_cost, uncached_input_tokens,
@@ -520,31 +626,31 @@ export class SessionRepository {
             ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             RETURNING id
           `).get(
-                turnID,
-                call.id,
-                call.callWithinTurn,
-                modelID,
-                call.startedAt,
-                call.completedAt ?? null,
-                call.reportedCost ?? null,
-                ...this.#tokenValues(call.tokens),
-                call.activity.finishReason ?? null,
-                call.activity.images ?? null,
-                Number(call.activity.hasText),
-                Number(call.activity.hasReasoning),
-              ) as { id: number }).id,
-          );
-          this.#insertContent(
-            "call_content",
-            "model_call_id",
-            callID,
-            call.content ?? [],
-          );
-          call.activity.tools.forEach((tool, index) => {
-            const childID = tool.childExternalID === undefined
-              ? null
-              : this.#sourceSessionID(value.sourceID, tool.childExternalID);
-            this.db.prepare(`
+            turnID,
+            call.id,
+            call.callWithinTurn,
+            modelID,
+            call.startedAt,
+            call.completedAt ?? null,
+            call.reportedCost ?? null,
+            ...this.#tokenValues(call.tokens),
+            call.activity.finishReason ?? null,
+            call.activity.images ?? null,
+            Number(call.activity.hasText),
+            Number(call.activity.hasReasoning),
+          ) as { id: number }).id,
+        );
+        this.#insertContent(
+          "call_content",
+          "model_call_id",
+          callID,
+          call.content ?? [],
+        );
+        call.activity.tools.forEach((tool, index) => {
+          const childID = tool.childExternalID === undefined
+            ? null
+            : this.#sourceSessionID(value.sourceID, tool.childExternalID);
+          this.db.prepare(`
               INSERT INTO tool_events (
                 model_call_id, source_tool_id, ordinal, name, status,
                 started_at, completed_at, child_source_session_id,
@@ -552,44 +658,39 @@ export class SessionRepository {
                 output_preview, output_original_length, output_truncated
               ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             `).run(
-              callID,
-              tool.sourceID ?? null,
-              index + 1,
-              tool.name,
-              tool.status,
-              tool.startedAt ?? null,
-              tool.completedAt ?? null,
-              childID,
-              tool.input?.preview ?? null,
-              tool.input?.originalLength ?? null,
-              Number(tool.input?.truncated ?? false),
-              tool.output?.preview ?? null,
-              tool.output?.originalLength ?? null,
-              Number(tool.output?.truncated ?? false),
-            );
-          });
-        }
+            callID,
+            tool.sourceID ?? null,
+            index + 1,
+            tool.name,
+            tool.status,
+            tool.startedAt ?? null,
+            tool.completedAt ?? null,
+            childID,
+            tool.input?.preview ?? null,
+            tool.input?.originalLength ?? null,
+            Number(tool.input?.truncated ?? false),
+            tool.output?.preview ?? null,
+            tool.output?.originalLength ?? null,
+            Number(tool.output?.truncated ?? false),
+          );
+        });
       }
+    }
 
-      const checkpoint = value.checkpoint;
-      this.db.prepare(`
+    const checkpoint = value.checkpoint;
+    this.db.prepare(`
         UPDATE source_sessions SET
           source_size = ?, source_modified_at = ?, checksum = ?,
           parser_version = ?, imported_at = ?, last_error = NULL
         WHERE id = ?
       `).run(
-        checkpoint.sourceSize ?? null,
-        checkpoint.sourceModifiedAt ?? null,
-        checkpoint.checksum ?? null,
-        checkpoint.parserVersion ?? null,
-        checkpoint.importedAt ?? Date.now(),
-        sourceSessionID,
-      );
-      this.db.exec("COMMIT");
-    } catch (error) {
-      this.db.exec("ROLLBACK");
-      throw error;
-    }
+      checkpoint.sourceSize ?? null,
+      checkpoint.sourceModifiedAt ?? null,
+      checkpoint.checksum ?? null,
+      checkpoint.parserVersion ?? null,
+      checkpoint.importedAt ?? Date.now(),
+      sourceSessionID,
+    );
   }
 
   #detail(row: SummaryRow, visited: Set<number>): SessionDetail {
@@ -597,7 +698,7 @@ export class SessionRepository {
     if (visited.has(row.source_session_id)) {
       return {
         ...base,
-        parentID: optional(row.parent_external_id),
+        parentID: optional(row.parent_public_id),
         turns: [],
         subagents: [],
       };
@@ -619,7 +720,8 @@ export class SessionRepository {
       `).all(turn.id) as CallRow[];
       const tools = calls.length === 0 ? [] : this.db.prepare(`
         SELECT te.model_call_id, te.name, te.status, te.started_at,
-          te.completed_at, child.external_id AS child_external_id
+          te.completed_at,
+          COALESCE(child.public_id, child.external_id) AS child_public_id
         FROM tool_events te
         LEFT JOIN source_sessions child ON child.id = te.child_source_session_id
         WHERE te.model_call_id IN (${calls.map(() => "?").join(",")})
@@ -648,7 +750,7 @@ export class SessionRepository {
               status: tool.status,
               startedAt: optional(tool.started_at),
               completedAt: optional(tool.completed_at),
-              childSessionID: optional(tool.child_external_id),
+              childSessionID: optional(tool.child_public_id),
             })),
           },
         })),
@@ -666,7 +768,7 @@ export class SessionRepository {
 
     return {
       ...base,
-      parentID: optional(row.parent_external_id),
+      parentID: optional(row.parent_public_id),
       agent: optional(row.agent),
       turns,
       subagents: children.map((child) => this.#detail(child, nextVisited)),

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -1,0 +1,733 @@
+import type { DatabaseSync } from "node:sqlite";
+import {
+  type ModelCall,
+  type SessionDetail,
+  sessionDetailSchema,
+  type SessionListResponse,
+  sessionListResponseSchema,
+  type SessionSummary,
+  type TokenUsage,
+} from "../shared/sessionSchemas.ts";
+import type { UsageCall } from "./usage.ts";
+
+type Harness = SessionSummary["harness"];
+
+export type SourceSessionCheckpoint = {
+  sourceSize?: number;
+  sourceModifiedAt?: number;
+  checksum?: string;
+  parserVersion?: string;
+};
+
+export type SessionContentImport = {
+  kind: string;
+  preview?: string;
+  originalLength?: number;
+  truncated?: boolean;
+  mimeType?: string;
+  contentHash?: string;
+};
+
+export type SessionToolImport =
+  & Omit<
+    ModelCall["activity"]["tools"][number],
+    "childSessionID"
+  >
+  & {
+    sourceID?: string;
+    childExternalID?: string;
+    input?: Omit<SessionContentImport, "kind" | "mimeType" | "contentHash">;
+    output?: Omit<SessionContentImport, "kind" | "mimeType" | "contentHash">;
+  };
+
+export type SessionCallImport = Omit<ModelCall, "activity"> & {
+  activity: Omit<ModelCall["activity"], "tools"> & {
+    tools: SessionToolImport[];
+  };
+  content?: SessionContentImport[];
+};
+
+export type SessionTurnImport = {
+  number: number;
+  startedAt: number;
+  inputs?: SessionContentImport[];
+  calls: SessionCallImport[];
+};
+
+/** A complete, already-normalized source session ready for canonical storage. */
+export type SourceSessionImport = {
+  sourceID: number;
+  externalID: string;
+  parentExternalID?: string;
+  artifactPath?: string;
+  observedAt: number;
+  checkpoint: {
+    sourceSize?: number;
+    sourceModifiedAt?: number;
+    checksum?: string;
+    parserVersion?: string;
+    importedAt?: number;
+  };
+  session: {
+    title: string;
+    agent?: string;
+    updatedAt: number;
+    startedAt?: number;
+    endedAt?: number;
+    providers: string[];
+    models: string[];
+    userTurns: number;
+    modelCalls: number;
+    reportedCost?: number;
+    tokens: TokenUsage;
+    turns: SessionTurnImport[];
+  };
+};
+
+type SummaryRow = {
+  source_session_id: number;
+  external_id: string;
+  harness: Harness;
+  title: string;
+  agent: string | null;
+  updated_at: number;
+  started_at: number | null;
+  ended_at: number | null;
+  providers_json: string;
+  models_json: string;
+  user_turns: number;
+  model_calls: number;
+  reported_cost: number | null;
+  uncached_input_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number | null;
+  cache_write_5m_tokens: number | null;
+  cache_write_1h_tokens: number | null;
+  fresh_prompt_tokens: number;
+  output_tokens: number;
+  reasoning_tokens: number;
+  processed_tokens: number;
+  parent_external_id: string | null;
+};
+
+type CallRow = {
+  id: number;
+  source_call_id: string | null;
+  ordinal: number;
+  provider: string;
+  model: string;
+  started_at: number;
+  completed_at: number | null;
+  reported_cost: number | null;
+  uncached_input_tokens: number;
+  cache_read_tokens: number;
+  cache_write_tokens: number | null;
+  cache_write_5m_tokens: number | null;
+  cache_write_1h_tokens: number | null;
+  fresh_prompt_tokens: number;
+  output_tokens: number;
+  reasoning_tokens: number;
+  processed_tokens: number;
+  finish_reason: string | null;
+  images: number | null;
+  has_text: number;
+  has_reasoning: number;
+};
+
+type ToolRow = {
+  model_call_id: number;
+  name: string;
+  status: string;
+  started_at: number | null;
+  completed_at: number | null;
+  child_external_id: string | null;
+};
+
+const summaryColumns = `
+  ss.id AS source_session_id, ss.external_id, so.harness,
+  s.title, s.agent, s.updated_at, s.started_at, s.ended_at,
+  s.providers_json, s.models_json, s.user_turns, s.model_calls,
+  s.reported_cost, s.uncached_input_tokens, s.cache_read_tokens,
+  s.cache_write_tokens, s.cache_write_5m_tokens,
+  s.cache_write_1h_tokens, s.fresh_prompt_tokens, s.output_tokens,
+  s.reasoning_tokens, s.processed_tokens,
+  parent.external_id AS parent_external_id
+`;
+
+const callColumns = `
+  mc.id, mc.source_call_id, mc.ordinal, m.provider, m.name AS model,
+  mc.started_at, mc.completed_at, mc.reported_cost,
+  mc.uncached_input_tokens, mc.cache_read_tokens, mc.cache_write_tokens,
+  mc.cache_write_5m_tokens, mc.cache_write_1h_tokens,
+  mc.fresh_prompt_tokens, mc.output_tokens, mc.reasoning_tokens,
+  mc.processed_tokens, mc.finish_reason, mc.images, mc.has_text,
+  mc.has_reasoning
+`;
+
+function optional<T>(value: T | null): T | undefined {
+  return value === null ? undefined : value;
+}
+
+function tokens(row: SummaryRow | CallRow): TokenUsage {
+  return {
+    uncachedInput: row.uncached_input_tokens,
+    cacheRead: row.cache_read_tokens,
+    cacheWrite: optional(row.cache_write_tokens),
+    cacheWrite5m: optional(row.cache_write_5m_tokens),
+    cacheWrite1h: optional(row.cache_write_1h_tokens),
+    freshPrompt: row.fresh_prompt_tokens,
+    output: row.output_tokens,
+    reasoning: row.reasoning_tokens,
+    processed: row.processed_tokens,
+  };
+}
+
+function summary(row: SummaryRow): SessionSummary {
+  return {
+    id: row.external_id,
+    harness: row.harness,
+    title: row.title,
+    updatedAt: row.updated_at,
+    startedAt: optional(row.started_at),
+    endedAt: optional(row.ended_at),
+    providers: JSON.parse(row.providers_json),
+    models: JSON.parse(row.models_json),
+    userTurns: row.user_turns,
+    modelCalls: row.model_calls,
+    reportedCost: optional(row.reported_cost),
+    tokens: tokens(row),
+  };
+}
+
+export class SessionRepository {
+  constructor(private db: DatabaseSync) {}
+
+  ensureSource(
+    harness: Harness,
+    kind: string,
+    label: string,
+    location: string,
+  ) {
+    return Number(
+      (this.db.prepare(`
+      INSERT INTO sources (harness, kind, label, location, created_at)
+      VALUES (?, ?, ?, ?, ?)
+      ON CONFLICT (harness, location) DO UPDATE SET
+        kind = excluded.kind, label = excluded.label, enabled = 1
+      RETURNING id
+    `).get(harness, kind, label, location, Date.now()) as { id: number }).id,
+    );
+  }
+
+  checkpoint(
+    sourceID: number,
+    externalID: string,
+  ): SourceSessionCheckpoint | undefined {
+    const row = this.db.prepare(`
+      SELECT source_size, source_modified_at, checksum, parser_version
+      FROM source_sessions WHERE source_id = ? AND external_id = ?
+    `).get(sourceID, externalID) as {
+      source_size: number | null;
+      source_modified_at: number | null;
+      checksum: string | null;
+      parser_version: string | null;
+    } | undefined;
+    return row && {
+      sourceSize: optional(row.source_size),
+      sourceModifiedAt: optional(row.source_modified_at),
+      checksum: optional(row.checksum),
+      parserVersion: optional(row.parser_version),
+    };
+  }
+
+  recordUnchangedSourceSession(
+    sourceID: number,
+    externalID: string,
+    artifactPath: string,
+    observedAt: number,
+    checkpoint?: SourceSessionCheckpoint,
+  ) {
+    this.db.prepare(`
+      INSERT INTO source_sessions (
+        source_id, external_id, artifact_path, availability, source_size,
+        source_modified_at, checksum, parser_version, first_seen_at,
+        last_seen_at, last_error
+      ) VALUES (?, ?, ?, 'available', ?, ?, ?, ?, ?, ?, NULL)
+      ON CONFLICT (source_id, external_id) DO UPDATE SET
+        artifact_path = excluded.artifact_path,
+        availability = 'available',
+        source_size = COALESCE(excluded.source_size, source_sessions.source_size),
+        source_modified_at = COALESCE(
+          excluded.source_modified_at, source_sessions.source_modified_at
+        ),
+        checksum = COALESCE(excluded.checksum, source_sessions.checksum),
+        parser_version = COALESCE(
+          excluded.parser_version, source_sessions.parser_version
+        ),
+        last_seen_at = excluded.last_seen_at,
+        last_error = NULL
+    `).run(
+      sourceID,
+      externalID,
+      artifactPath,
+      checkpoint?.sourceSize ?? null,
+      checkpoint?.sourceModifiedAt ?? null,
+      checkpoint?.checksum ?? null,
+      checkpoint?.parserVersion ?? null,
+      observedAt,
+      observedAt,
+    );
+  }
+
+  recordSourceSessionError(
+    sourceID: number,
+    externalID: string,
+    artifactPath: string,
+    observedAt: number,
+    error: unknown,
+  ) {
+    this.db.prepare(`
+      INSERT INTO source_sessions (
+        source_id, external_id, artifact_path, availability, first_seen_at,
+        last_seen_at, last_error
+      ) VALUES (?, ?, ?, 'available', ?, ?, ?)
+      ON CONFLICT (source_id, external_id) DO UPDATE SET
+        artifact_path = excluded.artifact_path,
+        availability = 'available',
+        last_seen_at = excluded.last_seen_at,
+        last_error = excluded.last_error
+    `).run(
+      sourceID,
+      externalID,
+      artifactPath,
+      observedAt,
+      observedAt,
+      error instanceof Error ? error.message : String(error),
+    );
+  }
+
+  markMissingSourceSessions(sourceID: number, observedAt: number) {
+    this.db.prepare(`
+      UPDATE source_sessions SET availability = 'missing'
+      WHERE source_id = ? AND last_seen_at <> ?
+    `).run(sourceID, observedAt);
+  }
+
+  listSessions(
+    page: number,
+    pageSize: number,
+    harness?: Harness,
+  ): SessionListResponse {
+    if (
+      !Number.isInteger(page) || page < 1 || !Number.isInteger(pageSize) ||
+      pageSize < 1
+    ) {
+      throw new RangeError("page and pageSize must be positive integers");
+    }
+    const filter = harness === undefined ? "" : " AND so.harness = ?";
+    const parameters = harness === undefined ? [] : [harness];
+    const totalItems = Number(
+      (this.db.prepare(`
+      SELECT COUNT(*) AS count
+      FROM sessions s
+      JOIN source_sessions ss ON ss.id = s.source_session_id
+      JOIN sources so ON so.id = ss.source_id
+      WHERE ss.parent_id IS NULL${filter}
+    `).get(...parameters) as { count: number }).count,
+    );
+    const rows = this.db.prepare(`
+      SELECT ${summaryColumns}
+      FROM sessions s
+      JOIN source_sessions ss ON ss.id = s.source_session_id
+      JOIN sources so ON so.id = ss.source_id
+      LEFT JOIN source_sessions parent ON parent.id = ss.parent_id
+      WHERE ss.parent_id IS NULL${filter}
+      ORDER BY s.updated_at DESC, ss.id DESC
+      LIMIT ? OFFSET ?
+    `).all(...parameters, pageSize, (page - 1) * pageSize) as SummaryRow[];
+
+    return sessionListResponseSchema.parse({
+      items: rows.map(summary),
+      pagination: {
+        page,
+        pageSize,
+        totalItems,
+        totalPages: Math.ceil(totalItems / pageSize),
+      },
+    });
+  }
+
+  getSession(harness: Harness, id: string): SessionDetail | undefined {
+    const row = this.db.prepare(`
+      SELECT ${summaryColumns}
+      FROM sessions s
+      JOIN source_sessions ss ON ss.id = s.source_session_id
+      JOIN sources so ON so.id = ss.source_id
+      LEFT JOIN source_sessions parent ON parent.id = ss.parent_id
+      WHERE so.harness = ? AND ss.external_id = ?
+      ORDER BY ss.id
+      LIMIT 1
+    `).get(harness, id) as SummaryRow | undefined;
+    if (!row) return undefined;
+    return sessionDetailSchema.parse(this.#detail(row, new Set()));
+  }
+
+  listUsageCalls(startedAt?: number, harness?: Harness): UsageCall[] {
+    type UsageRow = CallRow & {
+      harness: Harness;
+      external_id: string;
+      root_external_id: string;
+      parent_external_id: string | null;
+      root_started_at: number | null;
+      root_updated_at: number;
+    };
+    const rows = this.db.prepare(`
+      WITH RECURSIVE session_tree(id, root_id) AS (
+        SELECT ss.id, ss.id
+        FROM source_sessions ss
+        JOIN sessions s ON s.source_session_id = ss.id
+        WHERE ss.parent_id IS NULL
+        UNION ALL
+        SELECT child.id, session_tree.root_id
+        FROM source_sessions child
+        JOIN sessions child_session ON child_session.source_session_id = child.id
+        JOIN session_tree ON session_tree.id = child.parent_id
+      )
+      SELECT ${callColumns}, so.harness, ss.external_id,
+        root.external_id AS root_external_id,
+        parent.external_id AS parent_external_id,
+        root_session.started_at AS root_started_at,
+        root_session.updated_at AS root_updated_at
+      FROM model_calls mc
+      JOIN turns t ON t.id = mc.turn_id
+      JOIN sessions s ON s.source_session_id = t.session_id
+      JOIN source_sessions ss ON ss.id = s.source_session_id
+      JOIN sources so ON so.id = ss.source_id
+      JOIN models m ON m.id = mc.model_id
+      JOIN session_tree tree ON tree.id = ss.id
+      JOIN source_sessions root ON root.id = tree.root_id
+      JOIN sessions root_session ON root_session.source_session_id = root.id
+      LEFT JOIN source_sessions parent ON parent.id = ss.parent_id
+      WHERE (? IS NULL OR mc.started_at >= ?)
+        AND (? IS NULL OR so.harness = ?)
+      ORDER BY mc.started_at, mc.id
+    `).all(
+      startedAt ?? null,
+      startedAt ?? null,
+      harness ?? null,
+      harness ?? null,
+    ) as UsageRow[];
+
+    return rows.map((row) => ({
+      harness: row.harness,
+      session: {
+        id: row.external_id,
+        rootID: row.root_external_id,
+        parentID: optional(row.parent_external_id),
+      },
+      cacheChainID: row.external_id,
+      sessionStartedAt: row.root_started_at ?? row.root_updated_at,
+      provider: row.provider,
+      model: row.model,
+      startedAt: row.started_at,
+      tokens: tokens(row),
+      reportedCost: optional(row.reported_cost),
+    }));
+  }
+
+  replaceSourceSession(value: SourceSessionImport): void {
+    this.db.exec("BEGIN IMMEDIATE");
+    try {
+      const parentID = value.parentExternalID === undefined
+        ? null
+        : this.#sourceSessionID(value.sourceID, value.parentExternalID);
+      const sourceSessionID = Number(
+        (this.db.prepare(`
+        INSERT INTO source_sessions (
+          source_id, external_id, parent_id, artifact_path, availability,
+          first_seen_at, last_seen_at
+        ) VALUES (?, ?, ?, ?, 'available', ?, ?)
+        ON CONFLICT (source_id, external_id) DO UPDATE SET
+          parent_id = excluded.parent_id,
+          artifact_path = excluded.artifact_path,
+          availability = 'available',
+          last_seen_at = excluded.last_seen_at
+        RETURNING id
+      `).get(
+            value.sourceID,
+            value.externalID,
+            parentID,
+            value.artifactPath ?? null,
+            value.observedAt,
+            value.observedAt,
+          ) as { id: number }).id,
+      );
+
+      this.db.prepare("DELETE FROM sessions WHERE source_session_id = ?").run(
+        sourceSessionID,
+      );
+      const session = value.session;
+      const tokenValues = this.#tokenValues(session.tokens);
+      this.db.prepare(`
+        INSERT INTO sessions (
+          source_session_id, title, agent, updated_at, started_at, ended_at,
+          providers_json, models_json, user_turns, model_calls, reported_cost,
+          uncached_input_tokens, cache_read_tokens, cache_write_tokens,
+          cache_write_5m_tokens, cache_write_1h_tokens, fresh_prompt_tokens,
+          output_tokens, reasoning_tokens, processed_tokens
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+      `).run(
+        sourceSessionID,
+        session.title,
+        session.agent ?? null,
+        session.updatedAt,
+        session.startedAt ?? null,
+        session.endedAt ?? null,
+        JSON.stringify(session.providers),
+        JSON.stringify(session.models),
+        session.userTurns,
+        session.modelCalls,
+        session.reportedCost ?? null,
+        ...tokenValues,
+      );
+
+      for (const turn of session.turns) {
+        const turnID = Number(
+          (this.db.prepare(`
+          INSERT INTO turns (session_id, ordinal, started_at)
+          VALUES (?, ?, ?) RETURNING id
+        `).get(sourceSessionID, turn.number, turn.startedAt) as { id: number })
+            .id,
+        );
+        this.#insertContent(
+          "turn_inputs",
+          "turn_id",
+          turnID,
+          turn.inputs ?? [],
+        );
+
+        for (const call of turn.calls) {
+          const modelID = this.#modelID(call.provider, call.model);
+          const callID = Number(
+            (this.db.prepare(`
+            INSERT INTO model_calls (
+              turn_id, source_call_id, ordinal, model_id, started_at,
+              completed_at, reported_cost, uncached_input_tokens,
+              cache_read_tokens, cache_write_tokens, cache_write_5m_tokens,
+              cache_write_1h_tokens, fresh_prompt_tokens, output_tokens,
+              reasoning_tokens, processed_tokens, finish_reason, images,
+              has_text, has_reasoning
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            RETURNING id
+          `).get(
+                turnID,
+                call.id,
+                call.callWithinTurn,
+                modelID,
+                call.startedAt,
+                call.completedAt ?? null,
+                call.reportedCost ?? null,
+                ...this.#tokenValues(call.tokens),
+                call.activity.finishReason ?? null,
+                call.activity.images ?? null,
+                Number(call.activity.hasText),
+                Number(call.activity.hasReasoning),
+              ) as { id: number }).id,
+          );
+          this.#insertContent(
+            "call_content",
+            "model_call_id",
+            callID,
+            call.content ?? [],
+          );
+          call.activity.tools.forEach((tool, index) => {
+            const childID = tool.childExternalID === undefined
+              ? null
+              : this.#sourceSessionID(value.sourceID, tool.childExternalID);
+            this.db.prepare(`
+              INSERT INTO tool_events (
+                model_call_id, source_tool_id, ordinal, name, status,
+                started_at, completed_at, child_source_session_id,
+                input_preview, input_original_length, input_truncated,
+                output_preview, output_original_length, output_truncated
+              ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            `).run(
+              callID,
+              tool.sourceID ?? null,
+              index + 1,
+              tool.name,
+              tool.status,
+              tool.startedAt ?? null,
+              tool.completedAt ?? null,
+              childID,
+              tool.input?.preview ?? null,
+              tool.input?.originalLength ?? null,
+              Number(tool.input?.truncated ?? false),
+              tool.output?.preview ?? null,
+              tool.output?.originalLength ?? null,
+              Number(tool.output?.truncated ?? false),
+            );
+          });
+        }
+      }
+
+      const checkpoint = value.checkpoint;
+      this.db.prepare(`
+        UPDATE source_sessions SET
+          source_size = ?, source_modified_at = ?, checksum = ?,
+          parser_version = ?, imported_at = ?, last_error = NULL
+        WHERE id = ?
+      `).run(
+        checkpoint.sourceSize ?? null,
+        checkpoint.sourceModifiedAt ?? null,
+        checkpoint.checksum ?? null,
+        checkpoint.parserVersion ?? null,
+        checkpoint.importedAt ?? Date.now(),
+        sourceSessionID,
+      );
+      this.db.exec("COMMIT");
+    } catch (error) {
+      this.db.exec("ROLLBACK");
+      throw error;
+    }
+  }
+
+  #detail(row: SummaryRow, visited: Set<number>): SessionDetail {
+    const base = summary(row);
+    if (visited.has(row.source_session_id)) {
+      return {
+        ...base,
+        parentID: optional(row.parent_external_id),
+        turns: [],
+        subagents: [],
+      };
+    }
+    const nextVisited = new Set(visited).add(row.source_session_id);
+    const turns = (this.db.prepare(`
+      SELECT id, ordinal, started_at FROM turns
+      WHERE session_id = ? ORDER BY ordinal
+    `).all(row.source_session_id) as Array<{
+      id: number;
+      ordinal: number;
+      started_at: number;
+    }>).map((turn) => {
+      const calls = this.db.prepare(`
+        SELECT ${callColumns}
+        FROM model_calls mc
+        JOIN models m ON m.id = mc.model_id
+        WHERE mc.turn_id = ? ORDER BY mc.ordinal
+      `).all(turn.id) as CallRow[];
+      const tools = calls.length === 0 ? [] : this.db.prepare(`
+        SELECT te.model_call_id, te.name, te.status, te.started_at,
+          te.completed_at, child.external_id AS child_external_id
+        FROM tool_events te
+        LEFT JOIN source_sessions child ON child.id = te.child_source_session_id
+        WHERE te.model_call_id IN (${calls.map(() => "?").join(",")})
+        ORDER BY te.model_call_id, te.ordinal
+      `).all(...calls.map((call) => call.id)) as ToolRow[];
+      const toolsByCall = Map.groupBy(tools, (tool) => tool.model_call_id);
+      return {
+        number: turn.ordinal,
+        startedAt: turn.started_at,
+        calls: calls.map((call) => ({
+          id: call.source_call_id ?? String(call.id),
+          callWithinTurn: call.ordinal,
+          provider: call.provider,
+          model: call.model,
+          startedAt: call.started_at,
+          completedAt: optional(call.completed_at),
+          reportedCost: optional(call.reported_cost),
+          tokens: tokens(call),
+          activity: {
+            finishReason: optional(call.finish_reason),
+            images: optional(call.images),
+            hasText: Boolean(call.has_text),
+            hasReasoning: Boolean(call.has_reasoning),
+            tools: (toolsByCall.get(call.id) ?? []).map((tool) => ({
+              name: tool.name,
+              status: tool.status,
+              startedAt: optional(tool.started_at),
+              completedAt: optional(tool.completed_at),
+              childSessionID: optional(tool.child_external_id),
+            })),
+          },
+        })),
+      };
+    });
+    const children = this.db.prepare(`
+      SELECT ${summaryColumns}
+      FROM sessions s
+      JOIN source_sessions ss ON ss.id = s.source_session_id
+      JOIN sources so ON so.id = ss.source_id
+      LEFT JOIN source_sessions parent ON parent.id = ss.parent_id
+      WHERE ss.parent_id = ?
+      ORDER BY s.updated_at, ss.id
+    `).all(row.source_session_id) as SummaryRow[];
+
+    return {
+      ...base,
+      parentID: optional(row.parent_external_id),
+      agent: optional(row.agent),
+      turns,
+      subagents: children.map((child) => this.#detail(child, nextVisited)),
+    };
+  }
+
+  #sourceSessionID(sourceID: number, externalID: string): number {
+    const row = this.db.prepare(`
+      SELECT id FROM source_sessions WHERE source_id = ? AND external_id = ?
+    `).get(sourceID, externalID) as { id: number } | undefined;
+    if (!row) throw new Error(`Unknown source session: ${externalID}`);
+    return Number(row.id);
+  }
+
+  #modelID(provider: string, name: string): number {
+    return Number(
+      (this.db.prepare(`
+      INSERT INTO models (provider, name) VALUES (?, ?)
+      ON CONFLICT (provider, name) DO UPDATE SET name = excluded.name
+      RETURNING id
+    `).get(provider, name) as { id: number }).id,
+    );
+  }
+
+  #tokenValues(value: TokenUsage) {
+    return [
+      value.uncachedInput,
+      value.cacheRead,
+      value.cacheWrite ?? null,
+      value.cacheWrite5m ?? null,
+      value.cacheWrite1h ?? null,
+      value.freshPrompt,
+      value.output,
+      value.reasoning,
+      value.processed,
+    ];
+  }
+
+  #insertContent(
+    table: "turn_inputs" | "call_content",
+    foreignKey: "turn_id" | "model_call_id",
+    ownerID: number,
+    content: SessionContentImport[],
+  ) {
+    const statement = this.db.prepare(`
+      INSERT INTO ${table} (
+        ${foreignKey}, ordinal, kind, preview, original_length, truncated,
+        mime_type, content_hash
+      ) VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+    `);
+    content.forEach((item, index) =>
+      statement.run(
+        ownerID,
+        index + 1,
+        item.kind,
+        item.preview ?? null,
+        item.originalLength ?? null,
+        Number(item.truncated ?? false),
+        item.mimeType ?? null,
+        item.contentHash ?? null,
+      )
+    );
+  }
+}

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -13,6 +13,7 @@ import type { UsageCall } from "./usage.ts";
 type Harness = SessionSummary["harness"];
 
 export type SourceSessionCheckpoint = {
+  changeHint?: string;
   sourceSize?: number;
   sourceModifiedAt?: number;
   checksum?: string;
@@ -63,6 +64,7 @@ export type SourceSessionImport = {
   artifactPath?: string;
   observedAt: number;
   checkpoint: {
+    changeHint?: string;
     sourceSize?: number;
     sourceModifiedAt?: number;
     checksum?: string;
@@ -227,15 +229,17 @@ export class SessionRepository {
     externalID: string,
   ): SourceSessionCheckpoint | undefined {
     const row = this.db.prepare(`
-      SELECT source_size, source_modified_at, checksum, parser_version
+      SELECT change_hint, source_size, source_modified_at, checksum, parser_version
       FROM source_sessions WHERE source_id = ? AND external_id = ?
     `).get(sourceID, externalID) as {
+      change_hint: string | null;
       source_size: number | null;
       source_modified_at: number | null;
       checksum: string | null;
       parser_version: string | null;
     } | undefined;
     return row && {
+      changeHint: optional(row.change_hint),
       sourceSize: optional(row.source_size),
       sourceModifiedAt: optional(row.source_modified_at),
       checksum: optional(row.checksum),
@@ -252,13 +256,14 @@ export class SessionRepository {
   ) {
     this.db.prepare(`
       INSERT INTO source_sessions (
-        source_id, external_id, public_id, artifact_path, availability, source_size,
-        source_modified_at, checksum, parser_version, first_seen_at,
-        last_seen_at, last_error
-      ) VALUES (?, ?, ?, ?, 'available', ?, ?, ?, ?, ?, ?, NULL)
+        source_id, external_id, public_id, artifact_path, availability,
+        change_hint, source_size, source_modified_at, checksum, parser_version,
+        first_seen_at, last_seen_at, last_error
+      ) VALUES (?, ?, ?, ?, 'available', ?, ?, ?, ?, ?, ?, ?, NULL)
       ON CONFLICT (source_id, external_id) DO UPDATE SET
         artifact_path = excluded.artifact_path,
         availability = 'available',
+        change_hint = COALESCE(excluded.change_hint, source_sessions.change_hint),
         source_size = COALESCE(excluded.source_size, source_sessions.source_size),
         source_modified_at = COALESCE(
           excluded.source_modified_at, source_sessions.source_modified_at
@@ -274,6 +279,7 @@ export class SessionRepository {
       externalID,
       externalID,
       artifactPath,
+      checkpoint?.changeHint ?? null,
       checkpoint?.sourceSize ?? null,
       checkpoint?.sourceModifiedAt ?? null,
       checkpoint?.checksum ?? null,
@@ -316,6 +322,20 @@ export class SessionRepository {
       UPDATE source_sessions SET availability = 'missing'
       WHERE source_id = ? AND last_seen_at <> ?
     `).run(sourceID, observedAt);
+  }
+
+  markSourceSessionsSeen(
+    sourceID: number,
+    externalIDs: string[],
+    observedAt: number,
+  ) {
+    if (externalIDs.length === 0) return;
+    this.db.prepare(`
+      UPDATE source_sessions SET availability = 'available', last_seen_at = ?
+      WHERE source_id = ? AND external_id IN (${
+      externalIDs.map(() => "?").join(", ")
+    })
+    `).run(observedAt, sourceID, ...externalIDs);
   }
 
   listSessions(
@@ -680,10 +700,11 @@ export class SessionRepository {
     const checkpoint = value.checkpoint;
     this.db.prepare(`
         UPDATE source_sessions SET
-          source_size = ?, source_modified_at = ?, checksum = ?,
+          change_hint = ?, source_size = ?, source_modified_at = ?, checksum = ?,
           parser_version = ?, imported_at = ?, last_error = NULL
         WHERE id = ?
       `).run(
+      checkpoint.changeHint ?? null,
       checkpoint.sourceSize ?? null,
       checkpoint.sourceModifiedAt ?? null,
       checkpoint.checksum ?? null,

--- a/src/server/usageAnalytics.test.ts
+++ b/src/server/usageAnalytics.test.ts
@@ -1,6 +1,6 @@
 import { deepStrictEqual } from "node:assert/strict";
-import { aggregateUsage } from "../src/server/usageAnalytics.ts";
-import type { UsageCall } from "../src/server/usage.ts";
+import { aggregateUsage } from "./usageAnalytics.ts";
+import type { UsageCall } from "./usage.ts";
 
 function usageCall(
   session: string,


### PR DESCRIPTION
- Add an application-owned SQLite archive with dbmate migrations
- Incrementally import OpenCode, Claude Code, PI, and Codex sessions
- Use checksums and change hints to skip unchanged sessions
- Atomically replace session trees while preserving archived history
- Serve unified session and usage queries from SQLite
- Store normalized turns, calls, content previews, tools, models, and tokens
- Add sync and API timing diagnostics
- Colocate tests with server modules
- Add coverage for imports, replacement, pagination, filtering, and rollback safety