### PR TITLE
Accept array-shaped toolUseResult in Claude Code records

### DIFF
--- a/src/server/claudeCodeRepository.ts
+++ b/src/server/claudeCodeRepository.ts
@@ -58,6 +58,7 @@ const recordSchema = z.object({
   }).passthrough().optional(),
   toolUseResult: z.union([
     z.string(),
+    z.array(contentBlockSchema),
     z.object({
       agentId: z.string().optional(),
     }).passthrough(),
@@ -249,6 +250,7 @@ function decodeRecords(records: Record[]) {
               tool.completedAt = timestamp;
               if (
                 typeof record.toolUseResult === "object" &&
+                !Array.isArray(record.toolUseResult) &&
                 record.toolUseResult.agentId
               ) {
                 (tool as SessionToolImport & { childSessionID?: string })


### PR DESCRIPTION
## Problem

Session sync failed with a `ZodError` on transcripts containing array-shaped `toolUseResult` values:

```
[sync] harness=claude-code ... failed ZodError
  path: ["toolUseResult"]
  Invalid input: expected string, received array
  Invalid input: expected object, received array
```

The `toolUseResult` field in Claude Code records was typed as a `string | object` union, but some tool results (e.g. content-block arrays returned by MCP tools) serialize it as an array. `normalizeClaudeCodeSessionTree` parses transcripts in strict mode, so the whole session sync threw instead of importing.

## Fix

- Add a `z.array(contentBlockSchema)` branch to the `toolUseResult` union so array-shaped results parse.
- Guard the `agentId` narrowing with `!Array.isArray(...)`, since `typeof array === "object"` in JS and TypeScript otherwise keeps the array branch when accessing `.agentId`.

## Verification

- `deno check src/server/main.ts` passes clean.
