### PR TITLE
Add cross-harness compaction tracking

### DIFF
--- a/db/migrations/20260715120000_add_context_events.sql
+++ b/db/migrations/20260715120000_add_context_events.sql
@@ -1,0 +1,20 @@
+-- migrate:up
+CREATE TABLE context_events (
+  id INTEGER PRIMARY KEY,
+  session_id INTEGER NOT NULL
+    REFERENCES sessions(source_session_id) ON DELETE CASCADE,
+  event_type TEXT NOT NULL CHECK (length(event_type) > 0),
+  source_order INTEGER NOT NULL CHECK (source_order > 0),
+  occurred_at INTEGER,
+  affected_model_call_id INTEGER
+    REFERENCES model_calls(id) ON DELETE SET NULL,
+  UNIQUE (session_id, source_order)
+);
+
+CREATE INDEX context_events_affected_call_idx
+  ON context_events(affected_model_call_id)
+  WHERE affected_model_call_id IS NOT NULL;
+
+-- migrate:down
+DROP INDEX context_events_affected_call_idx;
+DROP TABLE context_events;

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -59,6 +59,7 @@ are not available for the sessions inspected.
 | `message.data.role = "user"` | User-turn boundary |
 | Assistant message with non-zero usage | Model call |
 | `part.data.type = "tool"` | Tool event |
+| `part.data.type = "compaction"` | Context-transition event |
 | Session with `parent_id` | Subagent session |
 | `task` part metadata `sessionId` | Link from tool event to subagent |
 
@@ -67,6 +68,34 @@ assistant calls belong to that turn until the next user message. One turn may
 contain many calls because each tool-use loop invokes the model again.
 
 Ignore assistant records whose reported token usage is entirely zero.
+
+### Compaction
+
+OpenCode records a durable compaction signal as a synthetic user message with a
+part whose `data.type` is `compaction`. The following assistant call generates
+the compacted summary. Frugal Tokens preserves that call's usage and cost but
+does not retain its generated summary text.
+
+The normalized context event is attached immediately before the first later
+model call whose provider request uses the compacted context. This may be in
+the same turn or a later user turn. If the session ends before another model
+call, the event remains session-level with no inferred boundary. Token changes
+alone never create a compaction event or establish its boundary.
+
+Cache hit, partial-miss, and full-miss outcomes remain token-derived. A partial
+or full miss on the explicitly affected call is additionally classified as
+compaction-related; an unbounded event cannot explain a specific miss.
+
+The normalized event contract is harness-independent: event type, session
+ownership, source order, optional timestamp, and optional affected model call.
+Current source support is:
+
+| Harness | Compaction support |
+|---|---|
+| OpenCode | Explicit `compaction` part; affected call resolved when present |
+| Claude Code | Source signal and ordering not yet investigated |
+| Codex | Source signal and ordering not yet investigated |
+| PI | Source signal and ordering not yet investigated |
 
 ### Usage And Cost
 
@@ -127,7 +156,7 @@ counting child sessions that also appear in the session list.
 ### Other Metadata
 
 Useful but not currently required fields include session directory, project
-worktree, VCS, harness version, agent, compaction events, retries, errors, and
+worktree, VCS, harness version, agent, retries, errors, and
 Git tree snapshots. A snapshot is a Git tree object, not a commit or branch.
 
 Absolute paths, branch names, filenames, URLs, prompts, reasoning, patches,

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -94,7 +94,7 @@ Current source support is:
 |---|---|
 | OpenCode | Explicit `compaction` part; affected call resolved when present |
 | Claude Code | Explicit `system/compact_boundary`; affected call resolved when present |
-| Codex | Source signal and ordering not yet investigated |
+| Codex | Explicit `event_msg/context_compacted`; affected call resolved when present |
 | PI | Explicit JSONL `compaction` record; affected call resolved when present |
 
 PI compaction support currently follows the importer's existing linear,
@@ -114,6 +114,14 @@ a later synthetic user record that does not start a normalized turn and is not
 retained. The first later assistant message with usage is the affected provider
 request. `/compact` command text and cache-token changes are not detection
 signals.
+
+Codex writes a large top-level `compacted` record containing replacement
+history and encrypted compaction material, followed by an explicit
+`event_msg` whose payload type is `context_compacted`. Historical fixtures
+consistently contain the small explicit event, so it is the normalized signal
+and the adjacent records are not double-counted. Replacement history and
+encrypted content are not retained. The first later nonzero `token_count`
+model call is the affected provider request.
 
 ### Usage And Cost
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -93,7 +93,7 @@ Current source support is:
 | Harness | Compaction support |
 |---|---|
 | OpenCode | Explicit `compaction` part; affected call resolved when present |
-| Claude Code | Source signal and ordering not yet investigated |
+| Claude Code | Explicit `system/compact_boundary`; affected call resolved when present |
 | Codex | Source signal and ordering not yet investigated |
 | PI | Explicit JSONL `compaction` record; affected call resolved when present |
 
@@ -105,6 +105,15 @@ The summary is not retained. Because PI does not persist a separate assistant
 usage record for summary generation in this fixture, the first later assistant
 call with usage is the affected provider request. Branch reconstruction remains
 out of scope.
+
+Claude Code records a compaction as a system entry with subtype
+`compact_boundary`. A verified manual event included optional metadata such as
+pre/post token counts and preserved-message UUIDs, but normalized detection
+uses only the explicit type/subtype and record order. The generated summary is
+a later synthetic user record that does not start a normalized turn and is not
+retained. The first later assistant message with usage is the affected provider
+request. `/compact` command text and cache-token changes are not detection
+signals.
 
 ### Usage And Cost
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -95,7 +95,16 @@ Current source support is:
 | OpenCode | Explicit `compaction` part; affected call resolved when present |
 | Claude Code | Source signal and ordering not yet investigated |
 | Codex | Source signal and ordering not yet investigated |
-| PI | Source signal and ordering not yet investigated |
+| PI | Explicit JSONL `compaction` record; affected call resolved when present |
+
+PI compaction support currently follows the importer's existing linear,
+append-order interpretation of a session file. A verified persisted event had
+`type`, `id`, `parentId`, `timestamp`, and `summary`; optional fields described
+elsewhere such as `firstKeptEntryId`, `tokensBefore`, and `fromHook` were absent.
+The summary is not retained. Because PI does not persist a separate assistant
+usage record for summary generation in this fixture, the first later assistant
+call with usage is the affected provider request. Branch reconstruction remains
+out of scope.
 
 ### Usage And Cost
 

--- a/docs/harnesses.md
+++ b/docs/harnesses.md
@@ -123,6 +123,13 @@ and the adjacent records are not double-counted. Replacement history and
 encrypted content are not retained. The first later nonzero `token_count`
 model call is the affected provider request.
 
+Codex also persists compaction machinery as an opaque total-only model call.
+The importer gives only that confirmed operation call a
+`context-operation:` source-call prefix. SQLite retains its turn and call, but
+Codex detail hydration filters the tagged call and any turn left empty, then
+renumbers visible turns. Other harnesses never apply this filter. Replacement
+history and encrypted content remain only in the source JSONL.
+
 ### Usage And Cost
 
 Assistant message JSON supplies:

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -78,7 +78,9 @@ function ContextMetric({
   if (value === undefined) return <span className="muted">-</span>;
   return (
     <span className="metric-stack context-metric" title={title}>
-      <strong><TokenValue value={value} /></strong>
+      <strong>
+        <TokenValue value={value} />
+      </strong>
       {secondary !== undefined && secondary !== value && secondaryLabel && (
         <small>
           <TokenValue value={secondary} /> {secondaryLabel}
@@ -202,12 +204,13 @@ function SessionInputMetric({
       </small>
       {showWriteTtl &&
         (tokens.cacheWrite5m !== undefined ||
-          tokens.cacheWrite1h !== undefined) && (
-        <small>
-          writes: <TokenValue value={tokens.cacheWrite5m ?? 0} /> at 5m ·{"  "}
-          <TokenValue value={tokens.cacheWrite1h ?? 0} /> at 1h
-        </small>
-      )}
+          tokens.cacheWrite1h !== undefined) &&
+        (
+          <small>
+            writes: <TokenValue value={tokens.cacheWrite5m ?? 0} /> at 5m ·
+            {"  "}<TokenValue value={tokens.cacheWrite1h ?? 0} /> at 1h
+          </small>
+        )}
       <small className={reused === undefined ? "muted" : undefined}>
         {reused === undefined
           ? "Reuse unavailable"
@@ -233,20 +236,21 @@ function CacheAssessmentBadge(
     !assessment ||
     (assessment.status !== "partial-hit" && assessment.status !== "full-miss")
   ) return null;
-  const title = providedTitle ?? (assessment.reason !== undefined
-    ? cacheAssessmentReasonLabels[assessment.reason]
-    : assessment.retainedRatio === undefined ||
-        assessment.previousReusableTokens === undefined
-    ? "No comparable preceding call"
-    : `Retained ${(assessment.retainedRatio * 100).toFixed(1)}% · Read ${
-      integer.format(
-        Math.round(
-          assessment.retainedRatio * assessment.previousReusableTokens,
-        ),
-      )
-    } of ${
-      integer.format(assessment.previousReusableTokens)
-    } previously reusable tokens`);
+  const title = providedTitle ??
+    (assessment.reason !== undefined
+      ? cacheAssessmentReasonLabels[assessment.reason]
+      : assessment.retainedRatio === undefined ||
+          assessment.previousReusableTokens === undefined
+      ? "No comparable preceding call"
+      : `Retained ${(assessment.retainedRatio * 100).toFixed(1)}% · Read ${
+        integer.format(
+          Math.round(
+            assessment.retainedRatio * assessment.previousReusableTokens,
+          ),
+        )
+      } of ${
+        integer.format(assessment.previousReusableTokens)
+      } previously reusable tokens`);
   const label = assessment.status === "full-miss"
     ? "Full miss"
     : "Partial miss";
@@ -261,7 +265,19 @@ function CacheAssessmentBadge(
 }
 
 function cacheSummaryTitle(summary: CacheSummary) {
-  return `${summary.hits} hits · ${summary.partialHits} partial hits · ${summary.fullMisses} full misses · ${summary.baseline} baseline · ${summary.notComparable} not comparable · ${summary.unknown} unavailable`;
+  return `${summary.hits} hits · ${summary.partialHits} partial hits · ${summary.fullMisses} full misses · ${summary.compactionRelatedMisses} compaction-related misses · ${summary.unexpectedMisses} unexpected misses · ${summary.baseline} baseline · ${summary.notComparable} not comparable · ${summary.unknown} unavailable`;
+}
+
+function CompactionBadge({ count = 1 }: { count?: number }) {
+  if (count === 0) return null;
+  return (
+    <span
+      className="cache-issue-badge compaction-badge"
+      title={`${count} context compaction${count === 1 ? "" : "s"}`}
+    >
+      Compacted
+    </span>
+  );
 }
 
 function hasCacheOutcome(summary?: CacheSummary) {
@@ -316,14 +332,19 @@ function cacheIssueLabel(issue: CacheIssue) {
 function SessionCacheStatus({
   summary,
   issues,
+  compactionCount,
 }: {
   summary?: CacheSummary;
   issues?: CacheIssue[];
+  compactionCount?: number;
 }) {
   const full = issues?.filter((issue) => issue.status === "full-miss") ?? [];
   const partial = issues?.filter((issue) => issue.status === "partial-hit") ??
     [];
-  if (!summary || (full.length === 0 && partial.length === 0)) {
+  if (
+    !summary ||
+    (full.length === 0 && partial.length === 0 && !compactionCount)
+  ) {
     return null;
   }
   const title = [
@@ -353,6 +374,12 @@ function SessionCacheStatus({
           <span className="session-cache-count">x{partial.length}</span>
         </>
       )}
+      {!!compactionCount && (
+        <>
+          <CompactionBadge count={compactionCount} />
+          <span className="session-cache-count">x{compactionCount}</span>
+        </>
+      )}
     </span>
   );
 }
@@ -363,6 +390,14 @@ function TurnCacheStatus({ turn }: { turn: SessionDetail["turns"][number] }) {
   );
   const partial = turn.calls.filter((call) =>
     call.cacheAssessment?.status === "partial-hit"
+  );
+  const compactions = turn.calls.reduce(
+    (total, call) =>
+      total +
+      (call.contextEventsBefore ?? []).filter((event) =>
+        event.type === "compaction"
+      ).length,
+    0,
   );
   const title = [
     full.length > 0
@@ -379,7 +414,9 @@ function TurnCacheStatus({ turn }: { turn: SessionDetail["turns"][number] }) {
       ? undefined
       : `Call totals: ${cacheSummaryTitle(turn.cacheSummary)}`,
   ].filter(Boolean).join("\n");
-  if (full.length === 0 && partial.length === 0) return null;
+  if (full.length === 0 && partial.length === 0 && compactions === 0) {
+    return null;
+  }
   return (
     <span className="cache-issue-group">
       {full.length > 0 && (
@@ -394,6 +431,7 @@ function TurnCacheStatus({ turn }: { turn: SessionDetail["turns"][number] }) {
           title={title}
         />
       )}
+      <CompactionBadge count={compactions} />
     </span>
   );
 }
@@ -1074,7 +1112,9 @@ function CallTable({
                   <td>
                     <ContextMetric
                       value={callContext}
-                      title={`${integer.format(callContext)} tokens in this request`}
+                      title={`${
+                        integer.format(callContext)
+                      } tokens in this request`}
                     />
                   </td>
                   <td>
@@ -1086,7 +1126,14 @@ function CallTable({
                       : `${(reused * 100).toFixed(1)}%`}
                   </td>
                   <td>
-                    <CacheAssessmentBadge assessment={call.cacheAssessment} />
+                    <span className="cache-issue-group">
+                      <CacheAssessmentBadge assessment={call.cacheAssessment} />
+                      <CompactionBadge
+                        count={(call.contextEventsBefore ?? []).filter((
+                          event,
+                        ) => event.type === "compaction").length}
+                      />
+                    </span>
                   </td>
                   <td>
                     <TokenValue
@@ -1677,10 +1724,10 @@ export function SessionsPage() {
                         >
                           <td className="session-cell">
                             <div className="session-identity">
-                                <button
-                                  type="button"
-                                  className="session-expand"
-                                  aria-expanded={expanded}
+                              <button
+                                type="button"
+                                className="session-expand"
+                                aria-expanded={expanded}
                                 aria-label={`${
                                   expanded ? "Collapse" : "Expand"
                                 } ${session.title}`}
@@ -1736,9 +1783,9 @@ export function SessionsPage() {
                               {(session.subagentCount ?? 0) > 0 && (
                                 <small>
                                   {session.subagentCount}{" "}
-                                  subagent{
-                                    session.subagentCount === 1 ? "" : "s"
-                                  }
+                                  subagent{session.subagentCount === 1
+                                    ? ""
+                                    : "s"}
                                 </small>
                               )}
                             </span>
@@ -1773,6 +1820,7 @@ export function SessionsPage() {
                             <SessionCacheStatus
                               summary={session.cacheSummary}
                               issues={session.cacheIssues}
+                              compactionCount={session.compactionCount}
                             />
                           </td>
                           <td>
@@ -1820,7 +1868,9 @@ export function SessionsPage() {
               {loadMoreError && (
                 <>
                   <span className="session-load-error">{loadMoreError}</span>
-                  <button type="button" onClick={loadNextPage}>Try again</button>
+                  <button type="button" onClick={loadNextPage}>
+                    Try again
+                  </button>
                 </>
               )}
               {!loadingMore && !loadMoreError &&

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -777,6 +777,10 @@ table.data-table {
   color: #9a6415;
 }
 
+.compaction-badge {
+  color: #5868a6;
+}
+
 .session-model-summary {
   display: inline-flex;
   align-items: baseline;

--- a/src/server/cacheAnalysis.test.ts
+++ b/src/server/cacheAnalysis.test.ts
@@ -109,6 +109,8 @@ Deno.test("tracks an OpenAI miss and implicit cache recovery across turns", () =
     fullMisses: 1,
     notComparable: 0,
     unknown: 0,
+    compactionRelatedMisses: 0,
+    unexpectedMisses: 1,
     totalCacheRead: 107_520,
     peakCacheRead: 54_272,
     totalNewInput: 55_906,
@@ -169,9 +171,34 @@ Deno.test("summarizes turns and includes independently analyzed subagents", () =
     fullMisses: 2,
     notComparable: 0,
     unknown: 0,
+    compactionRelatedMisses: 0,
+    unexpectedMisses: 3,
   });
   deepStrictEqual(sessionCacheIssues(actual), [
     { status: "full-miss", turn: 1, scope: undefined },
     { status: "full-miss", turn: 1, scope: "child" },
   ]);
+});
+
+Deno.test("classifies a miss after a bounded compaction without changing status", () => {
+  const previous = call("previous", 80_000, 20_000);
+  const compacted = call("compacted", 50_000);
+  compacted.contextEventsBefore = [{
+    type: "compaction",
+    sourceOrder: 2,
+    occurredAt: 2,
+  }];
+  const actual = analyzeSessionCache(session("compaction", [
+    previous,
+    compacted,
+  ]));
+
+  deepStrictEqual(actual.turns[0].calls[1].cacheAssessment, {
+    status: "partial-hit",
+    retainedRatio: 0.5,
+    previousReusableTokens: 100_000,
+    cause: "compaction",
+  });
+  strictEqual(actual.turns[0].cacheSummary?.compactionRelatedMisses, 1);
+  strictEqual(actual.turns[0].cacheSummary?.unexpectedMisses, 0);
 });

--- a/src/server/cacheAnalysis.ts
+++ b/src/server/cacheAnalysis.ts
@@ -52,6 +52,8 @@ export function summarizeTurnCache(calls: ModelCall[]): TurnCacheSummary {
     fullMisses: 0,
     notComparable: 0,
     unknown: 0,
+    compactionRelatedMisses: 0,
+    unexpectedMisses: 0,
     totalCacheRead: 0,
     peakCacheRead: 0,
     totalNewInput: 0,
@@ -82,6 +84,14 @@ export function summarizeTurnCache(calls: ModelCall[]): TurnCacheSummary {
       default:
         summary.unknown++;
     }
+    if (call.cacheAssessment?.cause === "compaction") {
+      summary.compactionRelatedMisses++;
+    } else if (
+      call.cacheAssessment?.status === "partial-hit" ||
+      call.cacheAssessment?.status === "full-miss"
+    ) {
+      summary.unexpectedMisses++;
+    }
   }
   const totalInput = summary.totalCacheRead + summary.totalNewInput;
   if (totalInput > 0) {
@@ -94,7 +104,14 @@ export function analyzeSessionCache(session: SessionDetail): SessionDetail {
   let previous: ModelCall | undefined;
   const turns = session.turns.map((turn) => {
     const calls = turn.calls.map((call) => {
-      const cacheAssessment = assessCache(previous, call);
+      const rawAssessment = assessCache(previous, call);
+      const cacheAssessment = (call.contextEventsBefore ?? []).some((event) =>
+          event.type === "compaction"
+        ) &&
+          (rawAssessment.status === "partial-hit" ||
+            rawAssessment.status === "full-miss")
+        ? { ...rawAssessment, cause: "compaction" as const }
+        : rawAssessment;
       previous = call;
       return { ...call, cacheAssessment };
     });
@@ -116,8 +133,6 @@ export function analyzeSessionCache(session: SessionDetail): SessionDetail {
   return {
     ...session,
     turns,
-    // Future source compaction events can explain drops without changing the
-    // token-based classification itself.
     subagents: session.subagents.map(analyzeSessionCache),
   };
 }
@@ -130,6 +145,8 @@ export function summarizeSessionCache(session: SessionDetail): CacheSummary {
     fullMisses: 0,
     notComparable: 0,
     unknown: 0,
+    compactionRelatedMisses: 0,
+    unexpectedMisses: 0,
   };
   for (const turn of session.turns) {
     for (const call of turn.calls) {
@@ -152,6 +169,14 @@ export function summarizeSessionCache(session: SessionDetail): CacheSummary {
         default:
           summary.unknown++;
       }
+      if (call.cacheAssessment?.cause === "compaction") {
+        summary.compactionRelatedMisses++;
+      } else if (
+        call.cacheAssessment?.status === "partial-hit" ||
+        call.cacheAssessment?.status === "full-miss"
+      ) {
+        summary.unexpectedMisses++;
+      }
     }
   }
   for (const subagent of session.subagents) {
@@ -162,6 +187,8 @@ export function summarizeSessionCache(session: SessionDetail): CacheSummary {
     summary.fullMisses += nested.fullMisses;
     summary.notComparable += nested.notComparable;
     summary.unknown += nested.unknown;
+    summary.compactionRelatedMisses += nested.compactionRelatedMisses;
+    summary.unexpectedMisses += nested.unexpectedMisses;
   }
   return summary;
 }
@@ -171,15 +198,20 @@ export function sessionCacheIssues(
   nested = false,
 ): CacheIssue[] {
   const scope = nested
-    ? session.agent
-      ? `${session.agent}: ${session.title}`
-      : session.title
+    ? session.agent ? `${session.agent}: ${session.title}` : session.title
     : undefined;
   return [
     ...session.turns.flatMap((turn) =>
       turn.cacheAssessment?.status === "full-miss" ||
         turn.cacheAssessment?.status === "partial-hit"
-        ? [{ status: turn.cacheAssessment.status, turn: turn.number, scope }]
+        ? [{
+          status: turn.cacheAssessment.status,
+          ...(turn.cacheAssessment.cause === undefined
+            ? {}
+            : { cause: turn.cacheAssessment.cause }),
+          turn: turn.number,
+          scope,
+        }]
         : []
     ),
     ...session.subagents.flatMap((subagent) =>

--- a/src/server/claudeCodeImporter.test.ts
+++ b/src/server/claudeCodeImporter.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert/strict";
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
 import { syncClaudeCodeSessions } from "./claudeCodeImporter.ts";
 import { openArchiveDatabase } from "./database.ts";
 import { migrateTestDatabase } from "./databaseTestUtils.ts";
@@ -21,6 +21,10 @@ Deno.test("imports a Claude Code root and namespaced child tree", async () => {
 {"type":"assistant","timestamp":"2026-07-14T10:00:01Z","message":{"id":"root-call","model":"claude-opus","stop_reason":"tool_use","content":[{"type":"thinking","thinking":"secret reasoning"},{"type":"text","text":"Calling child"},{"type":"tool_use","id":"tool-1","name":"Agent","input":{"prompt":"investigate"}}],"usage":{"input_tokens":2,"cache_read_input_tokens":3,"cache_creation_input_tokens":4,"output_tokens":5}}}
 {"type":"user","timestamp":"2026-07-14T10:00:02Z","message":{"content":[{"type":"tool_result","tool_use_id":"tool-1","content":"child output"}]},"toolUseResult":{"agentId":"child"}}
 {"type":"user","timestamp":"2026-07-14T10:00:03Z","message":{"content":[{"type":"tool_result","tool_use_id":"unknown","content":"plain output"}]},"toolUseResult":"plain output"}
+{"type":"system","subtype":"compact_boundary","timestamp":"2026-07-14T10:00:04Z","content":"Conversation compacted","compactMetadata":{"trigger":"manual","preTokens":48059,"postTokens":5625}}
+{"type":"user","timestamp":"2026-07-14T10:00:04Z","message":{"content":"Sensitive generated summary"}}
+{"type":"user","timestamp":"2026-07-14T10:00:05Z","promptSource":"typed","origin":{"kind":"human"},"message":{"content":"Continue"}}
+{"type":"assistant","timestamp":"2026-07-14T10:00:06Z","message":{"id":"post-compact-call","model":"claude-opus","stop_reason":"end_turn","content":[{"type":"text","text":"Continued"}],"usage":{"input_tokens":2,"cache_read_input_tokens":1,"cache_creation_input_tokens":8,"output_tokens":5}}}
   `,
   );
   write(
@@ -87,6 +91,18 @@ Deno.test("imports a Claude Code root and namespaced child tree", async () => {
     `).get()!;
     strictEqual(tool.input_preview, '{"prompt":"investigate"}');
     strictEqual(tool.output_preview, "child output");
+    deepStrictEqual(detail.turns[1].calls[0].contextEventsBefore, [{
+      type: "compaction",
+      sourceOrder: 5,
+      occurredAt: Date.parse("2026-07-14T10:00:04Z"),
+    }]);
+    strictEqual(
+      db.prepare(`
+        SELECT COUNT(*) AS count FROM turn_inputs
+        WHERE preview LIKE '%Sensitive generated summary%'
+      `).get()!.count,
+      0,
+    );
   } finally {
     db.close();
     Deno.removeSync(directory, { recursive: true });

--- a/src/server/claudeCodeImporter.ts
+++ b/src/server/claudeCodeImporter.ts
@@ -5,7 +5,7 @@ import {
 } from "./claudeCodeRepository.ts";
 import { SessionRepository } from "./sessionRepository.ts";
 
-const parserVersion = "claude-code-1";
+const parserVersion = "claude-code-2";
 
 function externalID(
   candidate: ClaudeCodeSessionCandidate,

--- a/src/server/claudeCodeRepository.ts
+++ b/src/server/claudeCodeRepository.ts
@@ -9,6 +9,7 @@ import { usageCallsFromSession } from "./usage.ts";
 import type {
   SessionCallImport,
   SessionContentImport,
+  SessionContextEventImport,
   SessionToolImport,
   SessionTurnImport,
   SourceSessionCheckpoint,
@@ -31,6 +32,7 @@ const contentBlockSchema = z.object({
 
 const recordSchema = z.object({
   type: z.string(),
+  subtype: z.string().optional(),
   uuid: z.string().optional(),
   timestamp: z.string().optional(),
   aiTitle: z.string().optional(),
@@ -224,9 +226,24 @@ function decodeRecords(records: Record[]) {
   const tokens = emptyTokens();
   const providers = new Set<string>();
   const models = new Set<string>();
+  type PendingContextEvent = SessionContextEventImport & {
+    affectedCallReference?: SessionCallImport;
+  };
+  const contextEvents: PendingContextEvent[] = [];
+  const pendingContextEvents: PendingContextEvent[] = [];
 
-  for (const record of records) {
+  for (const [recordIndex, record] of records.entries()) {
     const timestamp = Date.parse(record.timestamp ?? "") || 0;
+    if (record.type === "system" && record.subtype === "compact_boundary") {
+      const event: PendingContextEvent = {
+        type: "compaction",
+        sourceOrder: recordIndex + 1,
+        ...(timestamp === 0 ? {} : { occurredAt: timestamp }),
+      };
+      contextEvents.push(event);
+      pendingContextEvents.push(event);
+      continue;
+    }
     if (record.type === "user") {
       const content = record.message?.content;
       const text = userText(record);
@@ -306,6 +323,10 @@ function decodeRecords(records: Record[]) {
         content: [],
       };
       turn.calls.push(call);
+      for (const event of pendingContextEvents) {
+        event.affectedCallReference = call;
+      }
+      pendingContextEvents.length = 0;
       decoded = { call, blocks: [] };
       calls.set(id, decoded);
       providers.add("anthropic");
@@ -356,7 +377,29 @@ function decodeRecords(records: Record[]) {
   const nonEmptyTurns = turns
     .filter((turn) => turn.calls.length > 0)
     .map((turn, index) => ({ ...turn, number: index + 1 }));
-  return { turns: nonEmptyTurns, tokens, providers, models };
+  const normalizedContextEvents: SessionContextEventImport[] = contextEvents
+    .map(
+      ({ affectedCallReference, ...event }) => {
+        if (affectedCallReference === undefined) return event;
+        const turn = nonEmptyTurns.find((candidate) =>
+          candidate.calls.includes(affectedCallReference)
+        );
+        return turn === undefined ? event : {
+          ...event,
+          affectedCall: {
+            turn: turn.number,
+            call: affectedCallReference.callWithinTurn,
+          },
+        };
+      },
+    );
+  return {
+    turns: nonEmptyTurns,
+    contextEvents: normalizedContextEvents,
+    tokens,
+    providers,
+    models,
+  };
 }
 
 function dependency(path: string, artifactPath: string): ClaudeCodeDependency {
@@ -608,6 +651,7 @@ export function normalizeClaudeCodeSessionTree(options: {
         ),
         tokens: decoded.tokens,
         turns: decoded.turns,
+        contextEvents: decoded.contextEvents,
       },
     };
   });
@@ -761,6 +805,22 @@ export class ClaudeCodeRepository {
     const records = readRecords(path);
     const decoded = decodeRecords(records);
     const summary = this.#summary(id, path, updatedAt);
+    const turns = decoded.turns.map((turn) => ({
+      ...turn,
+      calls: turn.calls.map((call) => {
+        const contextEventsBefore = decoded.contextEvents.filter((event) =>
+          event.affectedCall?.turn === turn.number &&
+          event.affectedCall.call === call.callWithinTurn
+        ).map(({ affectedCall: _affectedCall, ...event }) => event);
+        return {
+          ...call,
+          ...(contextEventsBefore.length === 0 ? {} : { contextEventsBefore }),
+        };
+      }),
+    }));
+    const contextEvents = decoded.contextEvents.filter((event) =>
+      event.affectedCall === undefined
+    );
     const subagentDirectory = `${path.slice(0, -6)}/subagents`;
     let subagents: unknown[] = [];
     try {
@@ -798,7 +858,8 @@ export class ClaudeCodeRepository {
       ...summary,
       title: title ?? summary.title,
       parentID,
-      turns: decoded.turns,
+      turns,
+      ...(contextEvents.length === 0 ? {} : { contextEvents }),
       subagents,
     };
   }

--- a/src/server/codexImporter.test.ts
+++ b/src/server/codexImporter.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert/strict";
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
 import { syncCodexSessions } from "./codexImporter.ts";
 import { openArchiveDatabase } from "./database.ts";
 import { migrateTestDatabase } from "./databaseTestUtils.ts";
@@ -15,6 +15,12 @@ const transcript = `
 {"timestamp":"2026-07-11T14:00:04.000Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-1","output":"ok"}}
 {"timestamp":"2026-07-11T14:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Imported"}]}}
 {"timestamp":"2026-07-11T14:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":25,"output_tokens":10,"reasoning_output_tokens":2}}}}
+{"timestamp":"2026-07-11T14:00:07.000Z","type":"compacted","payload":{"message":"","replacement_history":[{"type":"compaction","id":"cmp-1","encrypted_content":"sensitive-summary"}]}}
+{"timestamp":"2026-07-11T14:00:07.001Z","type":"event_msg","payload":{"type":"context_compacted"}}
+{"timestamp":"2026-07-11T14:00:08.000Z","type":"event_msg","payload":{"type":"task_started"}}
+{"timestamp":"2026-07-11T14:00:09.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"Continue"}]}}
+{"timestamp":"2026-07-11T14:00:10.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Continued"}]}}
+{"timestamp":"2026-07-11T14:00:11.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":90,"cached_input_tokens":20,"output_tokens":8,"reasoning_output_tokens":0}}}}
 `.trim();
 
 Deno.test("imports Codex sessions for SQLite reads", async () => {
@@ -37,7 +43,7 @@ Deno.test("imports Codex sessions for SQLite reads", async () => {
     const id = "2026/07/11/rollout-session";
     strictEqual(repository.listSessions(1, 10, "codex").items[0].id, id);
     strictEqual(repository.getSession("codex", id)?.title, "Import Codex");
-    strictEqual(repository.listUsageCalls(undefined, "codex").length, 1);
+    strictEqual(repository.listUsageCalls(undefined, "codex").length, 2);
     strictEqual(
       (db.prepare("SELECT preview FROM turn_inputs").get() as {
         preview: string;
@@ -57,6 +63,22 @@ Deno.test("imports Codex sessions for SQLite reads", async () => {
     `).get()!;
     strictEqual(tool.input_preview, "ls");
     strictEqual(tool.output_preview, "ok");
+    deepStrictEqual(
+      repository.getSession("codex", id)?.turns[1].calls[0]
+        .contextEventsBefore,
+      [{
+        type: "compaction",
+        sourceOrder: 12,
+        occurredAt: Date.parse("2026-07-11T14:00:07.001Z"),
+      }],
+    );
+    strictEqual(
+      db.prepare(`
+        SELECT COUNT(*) AS count FROM call_content
+        WHERE preview LIKE '%sensitive-summary%'
+      `).get()!.count,
+      0,
+    );
   } finally {
     db.close();
     Deno.removeSync(directory, { recursive: true });

--- a/src/server/codexImporter.test.ts
+++ b/src/server/codexImporter.test.ts
@@ -3,6 +3,7 @@ import { syncCodexSessions } from "./codexImporter.ts";
 import { openArchiveDatabase } from "./database.ts";
 import { migrateTestDatabase } from "./databaseTestUtils.ts";
 import { SessionRepository } from "./sessionRepository.ts";
+import { analyzeSessionCache } from "./cacheAnalysis.ts";
 
 const transcript = `
 {"id":"session","timestamp":"2026-07-11T13:59:59.000Z","instructions":null,"git":null}
@@ -15,6 +16,8 @@ const transcript = `
 {"timestamp":"2026-07-11T14:00:04.000Z","type":"response_item","payload":{"type":"custom_tool_call_output","call_id":"call-1","output":"ok"}}
 {"timestamp":"2026-07-11T14:00:05.000Z","type":"response_item","payload":{"type":"message","role":"assistant","phase":"final_answer","content":[{"type":"output_text","text":"Imported"}]}}
 {"timestamp":"2026-07-11T14:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":25,"output_tokens":10,"reasoning_output_tokens":2}}}}
+{"timestamp":"2026-07-11T14:00:06.500Z","type":"event_msg","payload":{"type":"task_started"}}
+{"timestamp":"2026-07-11T14:00:06.900Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":0,"cached_input_tokens":0,"output_tokens":0,"reasoning_output_tokens":0,"total_tokens":4291}}}}
 {"timestamp":"2026-07-11T14:00:07.000Z","type":"compacted","payload":{"message":"","replacement_history":[{"type":"compaction","id":"cmp-1","encrypted_content":"sensitive-summary"}]}}
 {"timestamp":"2026-07-11T14:00:07.001Z","type":"event_msg","payload":{"type":"context_compacted"}}
 {"timestamp":"2026-07-11T14:00:08.000Z","type":"event_msg","payload":{"type":"task_started"}}
@@ -68,9 +71,34 @@ Deno.test("imports Codex sessions for SQLite reads", async () => {
         .contextEventsBefore,
       [{
         type: "compaction",
-        sourceOrder: 12,
+        sourceOrder: 14,
         occurredAt: Date.parse("2026-07-11T14:00:07.001Z"),
       }],
+    );
+    strictEqual(
+      (db.prepare("SELECT COUNT(*) AS count FROM turns").get() as {
+        count: number;
+      }).count,
+      3,
+    );
+    strictEqual(
+      db.prepare(`
+        SELECT source_call_id FROM model_calls
+        WHERE source_call_id LIKE 'context-operation:%'
+      `).get()!.source_call_id,
+      "context-operation:2-1",
+    );
+    strictEqual(repository.getSession("codex", id)?.turns.length, 2);
+    strictEqual(repository.getSession("codex", id)?.userTurns, 2);
+    strictEqual(repository.getSession("codex", id)?.modelCalls, 2);
+    const analyzed = analyzeSessionCache(repository.getSession("codex", id)!);
+    strictEqual(
+      analyzed.turns[1].calls[0].cacheAssessment?.status,
+      "partial-hit",
+    );
+    strictEqual(
+      analyzed.turns[1].calls[0].cacheAssessment?.cause,
+      "compaction",
     );
     strictEqual(
       db.prepare(`

--- a/src/server/codexImporter.ts
+++ b/src/server/codexImporter.ts
@@ -13,7 +13,7 @@ export async function syncCodexSessions(
     harness: "codex",
     label: "Codex",
     directory,
-    parserVersion: "codex-3",
+    parserVersion: "codex-4",
     repository,
     discover: discoverCodexSessions,
     normalize: normalizeCodexSession,

--- a/src/server/codexImporter.ts
+++ b/src/server/codexImporter.ts
@@ -13,7 +13,7 @@ export async function syncCodexSessions(
     harness: "codex",
     label: "Codex",
     directory,
-    parserVersion: "codex-4",
+    parserVersion: "codex-5",
     repository,
     discover: discoverCodexSessions,
     normalize: normalizeCodexSession,

--- a/src/server/codexRepository.ts
+++ b/src/server/codexRepository.ts
@@ -9,6 +9,7 @@ import { usageCallsFromSession } from "./usage.ts";
 import type {
   SessionCallImport,
   SessionContentImport,
+  SessionContextEventImport,
   SessionToolImport,
   SessionTurnImport,
 } from "./sessionRepository.ts";
@@ -197,10 +198,26 @@ function decodeRecords(records: Record[]) {
   let pendingHasText = false;
   let pendingTools: SessionToolImport[] = [];
   let pendingContent: SessionContentImport[] = [];
+  type PendingContextEvent = SessionContextEventImport & {
+    affectedCallReference?: SessionCallImport;
+  };
+  const contextEvents: PendingContextEvent[] = [];
+  const pendingContextEvents: PendingContextEvent[] = [];
 
-  for (const record of records) {
+  for (const [recordIndex, record] of records.entries()) {
     const payload = record.payload;
     const time = timestamp(record);
+
+    if (record.type === "event_msg" && payload?.type === "context_compacted") {
+      const event: PendingContextEvent = {
+        type: "compaction",
+        sourceOrder: recordIndex + 1,
+        ...(time === 0 ? {} : { occurredAt: time }),
+      };
+      contextEvents.push(event);
+      pendingContextEvents.push(event);
+      continue;
+    }
 
     if (record.type === "turn_context" && payload?.model) {
       currentModel = payload.model;
@@ -324,6 +341,10 @@ function decodeRecords(records: Record[]) {
     models.add(currentModel);
     addTokens(tokens, callTokens);
     turn.calls.push(call);
+    for (const event of pendingContextEvents) {
+      event.affectedCallReference = call;
+    }
+    pendingContextEvents.length = 0;
     pendingHasText = false;
     pendingTools = [];
     pendingContent = [];
@@ -332,7 +353,29 @@ function decodeRecords(records: Record[]) {
   const nonEmptyTurns = turns
     .filter((turn) => turn.calls.length > 0)
     .map((turn, index) => ({ ...turn, number: index + 1 }));
-  return { turns: nonEmptyTurns, tokens, providers, models };
+  const normalizedContextEvents: SessionContextEventImport[] = contextEvents
+    .map(
+      ({ affectedCallReference, ...event }) => {
+        if (affectedCallReference === undefined) return event;
+        const turn = nonEmptyTurns.find((candidate) =>
+          candidate.calls.includes(affectedCallReference)
+        );
+        return turn === undefined ? event : {
+          ...event,
+          affectedCall: {
+            turn: turn.number,
+            call: affectedCallReference.callWithinTurn,
+          },
+        };
+      },
+    );
+  return {
+    turns: nonEmptyTurns,
+    contextEvents: normalizedContextEvents,
+    tokens,
+    providers,
+    models,
+  };
 }
 
 export class CodexRepository {
@@ -383,10 +426,27 @@ export class CodexRepository {
       file.id,
       file.updatedAt,
     );
+    const turns = normalized.turns.map((turn) => ({
+      ...turn,
+      calls: turn.calls.map((call) => {
+        const contextEventsBefore = normalized.contextEvents.filter((event) =>
+          event.affectedCall?.turn === turn.number &&
+          event.affectedCall.call === call.callWithinTurn
+        ).map(({ affectedCall: _affectedCall, ...event }) => event);
+        return {
+          ...call,
+          ...(contextEventsBefore.length === 0 ? {} : { contextEventsBefore }),
+        };
+      }),
+    }));
+    const contextEvents = normalized.contextEvents.filter((event) =>
+      event.affectedCall === undefined
+    );
     return {
       ...normalized.summary,
       parentID: undefined,
-      turns: normalized.turns,
+      turns,
+      ...(contextEvents.length === 0 ? {} : { contextEvents }),
       subagents: [],
     };
   }
@@ -461,7 +521,11 @@ function codexSession(records: Record[], id: string, updatedAt: number) {
     ),
     tokens: decoded.tokens,
   };
-  return { summary, turns: decoded.turns };
+  return {
+    summary,
+    turns: decoded.turns,
+    contextEvents: decoded.contextEvents,
+  };
 }
 
 export function normalizeCodexSession(

--- a/src/server/codexRepository.ts
+++ b/src/server/codexRepository.ts
@@ -203,12 +203,23 @@ function decodeRecords(records: Record[]) {
   };
   const contextEvents: PendingContextEvent[] = [];
   const pendingContextEvents: PendingContextEvent[] = [];
+  let lastCall: SessionCallImport | undefined;
 
   for (const [recordIndex, record] of records.entries()) {
     const payload = record.payload;
     const time = timestamp(record);
 
     if (record.type === "event_msg" && payload?.type === "context_compacted") {
+      if (
+        lastCall && lastCall.tokens.uncachedInput === 0 &&
+        lastCall.tokens.cacheRead === 0 && lastCall.tokens.output === 0 &&
+        lastCall.tokens.reasoning === 0 && lastCall.tokens.processed > 0 &&
+        !lastCall.activity.hasText && lastCall.activity.tools.length === 0
+      ) {
+        // Codex emits this opaque total-only call for compaction itself. Keep
+        // it canonical, but tag it so only Codex hydration hides the machinery.
+        lastCall.id = `context-operation:${lastCall.id}`;
+      }
       const event: PendingContextEvent = {
         type: "compaction",
         sourceOrder: recordIndex + 1,
@@ -341,6 +352,7 @@ function decodeRecords(records: Record[]) {
     models.add(currentModel);
     addTokens(tokens, callTokens);
     turn.calls.push(call);
+    lastCall = call;
     for (const event of pendingContextEvents) {
       event.affectedCallReference = call;
     }
@@ -428,7 +440,9 @@ export class CodexRepository {
     );
     const turns = normalized.turns.map((turn) => ({
       ...turn,
-      calls: turn.calls.map((call) => {
+      calls: turn.calls.filter((call) =>
+        !call.id.startsWith("context-operation:")
+      ).map((call) => {
         const contextEventsBefore = normalized.contextEvents.filter((event) =>
           event.affectedCall?.turn === turn.number &&
           event.affectedCall.call === call.callWithinTurn
@@ -438,12 +452,17 @@ export class CodexRepository {
           ...(contextEventsBefore.length === 0 ? {} : { contextEventsBefore }),
         };
       }),
+    })).filter((turn) => turn.calls.length > 0).map((turn, index) => ({
+      ...turn,
+      number: index + 1,
     }));
     const contextEvents = normalized.contextEvents.filter((event) =>
       event.affectedCall === undefined
     );
     return {
       ...normalized.summary,
+      userTurns: turns.length,
+      modelCalls: turns.reduce((total, turn) => total + turn.calls.length, 0),
       parentID: undefined,
       turns,
       ...(contextEvents.length === 0 ? {} : { contextEvents }),

--- a/src/server/database.test.ts
+++ b/src/server/database.test.ts
@@ -21,10 +21,11 @@ Deno.test("opens an archive database with the required SQLite settings", () => {
           'models',
           'model_calls',
           'call_content',
-          'tool_events'
+          'tool_events',
+          'context_events'
         )
     `).get() as { count: number };
-    strictEqual(tables.count, 9);
+    strictEqual(tables.count, 10);
     strictEqual(first.prepare("PRAGMA foreign_keys").get()!.foreign_keys, 1);
     first.close();
   } finally {

--- a/src/server/databaseTestUtils.ts
+++ b/src/server/databaseTestUtils.ts
@@ -4,6 +4,7 @@ const migrations = [
   "../../db/migrations/20260714120000_create_initial_archive.sql",
   "../../db/migrations/20260714130000_add_source_session_public_and_tree_ids.sql",
   "../../db/migrations/20260714140000_add_source_session_change_hint.sql",
+  "../../db/migrations/20260715120000_add_context_events.sql",
 ].map((path) => new URL(path, import.meta.url));
 
 export function migrateTestDatabase(db: DatabaseSync) {

--- a/src/server/fileSessionImporter.ts
+++ b/src/server/fileSessionImporter.ts
@@ -1,4 +1,5 @@
 import type {
+  SessionContextEventImport,
   SessionRepository,
   SessionTurnImport,
 } from "./sessionRepository.ts";
@@ -15,6 +16,7 @@ export type FileSessionCandidate = {
 type NormalizedFileSession = {
   summary: SessionSummary;
   turns: SessionTurnImport[];
+  contextEvents?: SessionContextEventImport[];
 };
 
 function checksum(bytes: Uint8Array) {
@@ -141,6 +143,7 @@ export async function syncFileSessions(options: {
           reportedCost: normalized.summary.reportedCost,
           tokens: normalized.summary.tokens,
           turns: normalized.turns,
+          contextEvents: normalized.contextEvents,
         },
       });
       imported++;

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -321,6 +321,8 @@ function priceSummaries(items: SessionSummary[]) {
     );
     return {
       ...item,
+      userTurns: priced.userTurns,
+      modelCalls: priced.modelCalls,
       computedCost: priced.computedCost,
       cacheSummary: summarizeSessionCache(analyzed),
       cacheIssues: sessionCacheIssues(analyzed),

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -280,6 +280,27 @@ function subagentTotals(
   );
 }
 
+function compactionCount(session: SessionDetail): number {
+  return (session.contextEvents ?? []).filter((event) =>
+    event.type === "compaction"
+  )
+    .length +
+    session.turns.reduce(
+      (total, turn) =>
+        total + turn.calls.reduce(
+          (callTotal, call) =>
+            callTotal + (call.contextEventsBefore ?? []).filter((event) =>
+              event.type === "compaction"
+            ).length,
+          0,
+        ),
+      0,
+    ) + session.subagents.reduce(
+      (total, subagent) => total + compactionCount(subagent),
+      0,
+    );
+}
+
 function priceSummaries(items: SessionSummary[]) {
   return items.map((item) => {
     const detail = repositoryForHarness(item.harness)?.getSession(item.id);
@@ -288,19 +309,22 @@ function priceSummaries(items: SessionSummary[]) {
     const analyzed = analyzeSessionCache(priced);
     const subagents = subagentTotals(priced.subagents);
     const inclusive = sessionTreeMetrics(priced);
-    const context = contextRange(priced.turns.flatMap((turn) =>
-      turn.calls.map((call) => ({
-        startedAt: call.startedAt,
-        tokens: call.tokens,
-        turn: turn.number,
-        call: call.callWithinTurn,
-      }))
-    ));
+    const context = contextRange(
+      priced.turns.flatMap((turn) =>
+        turn.calls.map((call) => ({
+          startedAt: call.startedAt,
+          tokens: call.tokens,
+          turn: turn.number,
+          call: call.callWithinTurn,
+        }))
+      ),
+    );
     return {
       ...item,
       computedCost: priced.computedCost,
       cacheSummary: summarizeSessionCache(analyzed),
       cacheIssues: sessionCacheIssues(analyzed),
+      compactionCount: compactionCount(analyzed),
       contextLatest: context.latest?.size,
       contextPeak: context.peak?.size,
       contextPeakTurn: context.peak?.call.turn,

--- a/src/server/openCodeImporter.test.ts
+++ b/src/server/openCodeImporter.test.ts
@@ -1,9 +1,10 @@
-import { strictEqual } from "node:assert/strict";
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
 import { DatabaseSync } from "node:sqlite";
 import { migrateTestDatabase } from "./databaseTestUtils.ts";
 import { openArchiveDatabase } from "./database.ts";
 import { syncOpenCodeSessions } from "./openCodeImporter.ts";
 import { SessionRepository } from "./sessionRepository.ts";
+import { analyzeSessionCache } from "./cacheAnalysis.ts";
 
 function sourceDatabase(path: string) {
   const db = new DatabaseSync(path);
@@ -65,6 +66,57 @@ Deno.test("incrementally imports OpenCode session trees", () => {
         output: 3,
         reasoning: 0,
         cache: { read: 4, write: 0 },
+      },
+    }),
+  );
+  insertMessage.run(
+    "compaction-user",
+    "root",
+    5,
+    5,
+    JSON.stringify({ role: "user" }),
+  );
+  insertMessage.run(
+    "compaction-summary",
+    "root",
+    6,
+    6,
+    JSON.stringify({
+      role: "assistant",
+      summary: true,
+      providerID: "anthropic",
+      modelID: "claude",
+      cost: 0.2,
+      tokens: {
+        input: 100,
+        output: 10,
+        reasoning: 0,
+        cache: { read: 100, write: 0 },
+      },
+    }),
+  );
+  insertMessage.run(
+    "post-user",
+    "root",
+    7,
+    7,
+    JSON.stringify({ role: "user" }),
+  );
+  insertMessage.run(
+    "post-assistant",
+    "root",
+    8,
+    8,
+    JSON.stringify({
+      role: "assistant",
+      providerID: "anthropic",
+      modelID: "claude",
+      cost: 0.1,
+      tokens: {
+        input: 80,
+        output: 5,
+        reasoning: 0,
+        cache: { read: 20, write: 0 },
       },
     }),
   );
@@ -147,6 +199,26 @@ Deno.test("incrementally imports OpenCode session trees", () => {
       },
     }),
   );
+  insertPart.run(
+    "compaction",
+    "compaction-user",
+    "root",
+    5,
+    5,
+    JSON.stringify({
+      type: "compaction",
+      auto: false,
+      tail_start_id: "assistant",
+    }),
+  );
+  insertPart.run(
+    "summary-text",
+    "compaction-summary",
+    "root",
+    6,
+    6,
+    JSON.stringify({ type: "text", text: "Sensitive generated summary" }),
+  );
 
   const archive = openArchiveDatabase(`${directory}/archive.sqlite`);
   migrateTestDatabase(archive);
@@ -173,6 +245,26 @@ Deno.test("incrementally imports OpenCode session trees", () => {
     `).get()!;
     strictEqual(tool.input_preview, '{"prompt":"inspect"}');
     strictEqual(tool.output_preview, "done");
+    const compacted = detail.turns[2].calls[0];
+    strictEqual(compacted.id, "post-assistant");
+    deepStrictEqual(compacted.contextEventsBefore, [{
+      type: "compaction",
+      sourceOrder: 4,
+      occurredAt: 5,
+    }]);
+    strictEqual(
+      analyzeSessionCache(detail).turns[2].calls[0].cacheAssessment?.cause,
+      "compaction",
+    );
+    strictEqual(detail.contextEvents?.length, 0);
+    strictEqual(
+      archive.prepare(`
+        SELECT COUNT(*) AS count FROM call_content cc
+        JOIN model_calls mc ON mc.id = cc.model_call_id
+        WHERE mc.source_call_id = 'compaction-summary'
+      `).get()!.count,
+      0,
+    );
 
     source.prepare(`
       UPDATE message SET data = json_set(

--- a/src/server/openCodeImporter.ts
+++ b/src/server/openCodeImporter.ts
@@ -11,7 +11,7 @@ import {
   type SourceSessionCheckpoint,
 } from "./sessionRepository.ts";
 
-const parserVersion = "opencode-2";
+const parserVersion = "opencode-3";
 
 type AggregateRow = {
   session_id: string;

--- a/src/server/opencodeRepository.ts
+++ b/src/server/opencodeRepository.ts
@@ -10,6 +10,7 @@ import type { UsageCall } from "./usage.ts";
 import type {
   SessionCallImport,
   SessionContentImport,
+  SessionContextEventImport,
   SessionToolImport,
   SessionTurnImport,
   SourceSessionCheckpoint,
@@ -101,6 +102,7 @@ type PartRow = OpenCodePartRow;
 type DecodedParts = {
   activity: SessionCallImport["activity"];
   content: SessionContentImport[];
+  compaction: boolean;
 };
 
 const emptyTokens = (): TokenUsage => ({
@@ -177,6 +179,7 @@ function decodeParts(rows: OpenCodePartRow[], strict = false) {
         tools: [],
       },
       content: [],
+      compaction: false,
     };
     if (part.type === "text") {
       current.activity.hasText = true;
@@ -216,6 +219,7 @@ function decodeParts(rows: OpenCodePartRow[], strict = false) {
           : { outputPreview: output.preview }),
       });
     }
+    if (part.type === "compaction") current.compaction = true;
     decoded.set(row.message_id, current);
   }
   return decoded;
@@ -232,8 +236,14 @@ function decodeMessages(
   const tokens = emptyTokens();
   let reportedCost = 0;
   let pendingImages = 0;
+  type PendingContextEvent = SessionContextEventImport & {
+    operationSeen: boolean;
+    affectedCallReference?: SessionCallImport;
+  };
+  const contextEvents: PendingContextEvent[] = [];
+  const pendingContextEvents: PendingContextEvent[] = [];
 
-  for (const row of rows) {
+  for (const [messageIndex, row] of rows.entries()) {
     let raw: unknown;
     try {
       raw = JSON.parse(row.data);
@@ -253,6 +263,16 @@ function decodeMessages(
 
     if (message.role === "user") {
       const parts = partsByMessage.get(row.id);
+      if (parts?.compaction) {
+        const event: PendingContextEvent = {
+          type: "compaction",
+          sourceOrder: messageIndex + 1,
+          occurredAt: row.time_created,
+          operationSeen: false,
+        };
+        contextEvents.push(event);
+        pendingContextEvents.push(event);
+      }
       pendingImages = parts?.activity.images ?? 0;
       turns.push({
         number: turns.length + 1,
@@ -283,6 +303,12 @@ function decodeMessages(
     const cost = message.cost ?? 0;
     if (callTokens.processed === 0 && cost === 0) continue;
 
+    const operationEvents = pendingContextEvents.filter((event) =>
+      !event.operationSeen
+    );
+    const compactionOperation = operationEvents.length > 0;
+    operationEvents.forEach((event) => event.operationSeen = true);
+
     const turn = turns.at(-1)!;
     const provider = message.providerID ?? "unknown";
     const model = message.modelID ?? "unknown";
@@ -302,17 +328,13 @@ function decodeMessages(
     models.add(model);
     addTokens(tokens, callTokens);
     reportedCost += cost;
+    const textPreview = compactionOperation
+      ? undefined
+      : decodedParts?.content.find((item) => item.kind === "text")?.preview;
     const call: SessionCallImport = {
       id: row.id,
       callWithinTurn: turn.calls.length + 1,
-      ...(decodedParts?.content.find((item) => item.kind === "text")
-          ?.preview ===
-          undefined
-        ? {}
-        : {
-          preview: decodedParts.content.find((item) => item.kind === "text")!
-            .preview,
-        }),
+      ...(textPreview === undefined ? {} : { preview: textPreview }),
       provider,
       model,
       startedAt: message.time?.created ?? row.time_created,
@@ -320,16 +342,41 @@ function decodeMessages(
       reportedCost: cost,
       tokens: callTokens,
       activity,
-      content: decodedParts?.content ?? [],
+      content: compactionOperation ? [] : decodedParts?.content ?? [],
     };
     turn.calls.push(call);
+    if (!compactionOperation) {
+      for (let index = pendingContextEvents.length - 1; index >= 0; index--) {
+        const event = pendingContextEvents[index];
+        if (!event.operationSeen) continue;
+        event.affectedCallReference = call;
+        pendingContextEvents.splice(index, 1);
+      }
+    }
   }
 
   const nonEmptyTurns = turns
     .filter((turn) => turn.calls.length > 0)
     .map((turn, index) => ({ ...turn, number: index + 1 }));
+  const normalizedContextEvents: SessionContextEventImport[] = contextEvents
+    .map(
+      ({ operationSeen: _operationSeen, affectedCallReference, ...event }) => {
+        if (affectedCallReference === undefined) return event;
+        const turn = nonEmptyTurns.find((candidate) =>
+          candidate.calls.includes(affectedCallReference)
+        );
+        return turn === undefined ? event : {
+          ...event,
+          affectedCall: {
+            turn: turn.number,
+            call: affectedCallReference.callWithinTurn,
+          },
+        };
+      },
+    );
   return {
     turns: nonEmptyTurns,
+    contextEvents: normalizedContextEvents,
     providers,
     models,
     tokens,
@@ -497,6 +544,7 @@ export function normalizeOpenCodeSessionTree(options: {
         reportedCost: summary.reportedCost,
         tokens: summary.tokens,
         turns: decoded.turns,
+        contextEvents: decoded.contextEvents,
       },
     };
   });
@@ -633,11 +681,24 @@ export class OpenCodeRepository {
       WHERE parent_id = ?
       ORDER BY time_created, id
     `).all(row.id) as SessionRow[];
+    const turns = decoded.turns.map((turn) => ({
+      ...turn,
+      calls: turn.calls.map((call) => ({
+        ...call,
+        contextEventsBefore: decoded.contextEvents.filter((event) =>
+          event.affectedCall?.turn === turn.number &&
+          event.affectedCall.call === call.callWithinTurn
+        ).map(({ affectedCall: _affectedCall, ...event }) => event),
+      })),
+    }));
     return {
       ...this.#toSummary(row, decoded),
       parentID: row.parent_id ?? undefined,
       agent: row.agent ?? undefined,
-      turns: decoded.turns,
+      turns,
+      contextEvents: decoded.contextEvents.filter((event) =>
+        event.affectedCall === undefined
+      ),
       subagents: children
         .filter((child) => !visited.has(child.id))
         .map((child) => this.#detail(child, new Set(visited))),

--- a/src/server/piImporter.test.ts
+++ b/src/server/piImporter.test.ts
@@ -1,4 +1,4 @@
-import { strictEqual } from "node:assert/strict";
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
 import { openArchiveDatabase } from "./database.ts";
 import { syncPiSessions } from "./piImporter.ts";
 import { SessionRepository } from "./sessionRepository.ts";
@@ -9,6 +9,9 @@ function transcript(prompt: string) {
 {"type":"session","version":3,"id":"session","timestamp":"2026-07-11T13:36:32.689Z","cwd":"/Users/test/project"}
 {"type":"message","id":"user-1","timestamp":"2026-07-11T13:36:55.000Z","message":{"role":"user","content":[{"type":"text","text":"${prompt}"}]}}
 {"type":"message","id":"assistant-1","timestamp":"2026-07-11T13:36:59.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Stored answer"}],"provider":"anthropic","model":"claude-opus","usage":{"input":2,"output":3,"cacheRead":0,"cacheWrite":0,"reasoning":0,"cost":{"total":0.01}},"stopReason":"stop"}}
+{"type":"compaction","id":"compact-1","parentId":"assistant-1","timestamp":"2026-07-11T13:37:00.000Z","summary":"Sensitive generated summary"}
+{"type":"message","id":"user-2","parentId":"compact-1","timestamp":"2026-07-11T13:37:01.000Z","message":{"role":"user","content":[{"type":"text","text":"Continue"}]}}
+{"type":"message","id":"assistant-2","parentId":"user-2","timestamp":"2026-07-11T13:37:02.000Z","message":{"role":"assistant","content":[{"type":"text","text":"Continued answer"}],"provider":"anthropic","model":"claude-opus","usage":{"input":4,"output":3,"cacheRead":1,"cacheWrite":0,"reasoning":0,"cost":{"total":0.01}},"stopReason":"stop"}}
 `.trim();
 }
 
@@ -34,13 +37,29 @@ Deno.test("incrementally imports PI sessions and preserves the last good archive
       (db.prepare("SELECT COUNT(*) AS count FROM turn_inputs").get() as {
         count: number;
       }).count,
-      1,
+      2,
     );
     strictEqual(
       (db.prepare("SELECT COUNT(*) AS count FROM call_content").get() as {
         count: number;
       }).count,
-      1,
+      2,
+    );
+    deepStrictEqual(
+      repository.getSession("pi", "project/session")?.turns[1].calls[0]
+        .contextEventsBefore,
+      [{
+        type: "compaction",
+        sourceOrder: 4,
+        occurredAt: Date.parse("2026-07-11T13:37:00.000Z"),
+      }],
+    );
+    strictEqual(
+      db.prepare(`
+        SELECT COUNT(*) AS count FROM call_content
+        WHERE preview LIKE '%Sensitive generated summary%'
+      `).get()!.count,
+      0,
     );
 
     const unchanged = await syncPiSessions(sessions, repository);

--- a/src/server/piImporter.ts
+++ b/src/server/piImporter.ts
@@ -10,7 +10,7 @@ export async function syncPiSessions(
     harness: "pi",
     label: "PI",
     directory,
-    parserVersion: "pi-1",
+    parserVersion: "pi-2",
     repository,
     discover: discoverPiSessions,
     normalize: normalizePiSession,

--- a/src/server/piRepository.test.ts
+++ b/src/server/piRepository.test.ts
@@ -86,6 +86,7 @@ Deno.test("normalizes PI JSONL sessions with tool activity and reported cost", (
               outputPreview: "ok",
             }],
           },
+          contextEventsBefore: [],
         },
         {
           id: "assistant-2",
@@ -113,9 +114,11 @@ Deno.test("normalizes PI JSONL sessions with tool activity and reported cost", (
             hasReasoning: true,
             tools: [],
           },
+          contextEventsBefore: [],
         },
       ],
     }],
+    contextEvents: [],
     subagents: [],
   };
 

--- a/src/server/piRepository.ts
+++ b/src/server/piRepository.ts
@@ -9,6 +9,7 @@ import { usageCallsFromSession } from "./usage.ts";
 import type {
   SessionCallImport,
   SessionContentImport,
+  SessionContextEventImport,
   SessionToolImport,
   SessionTurnImport,
 } from "./sessionRepository.ts";
@@ -208,9 +209,24 @@ function decodeRecords(records: Record[]) {
   const models = new Set<string>();
   const tools = new Map<string, SessionToolImport>();
   let reportedCost = 0;
+  type PendingContextEvent = SessionContextEventImport & {
+    affectedCallReference?: SessionCallImport;
+  };
+  const contextEvents: PendingContextEvent[] = [];
+  const pendingContextEvents: PendingContextEvent[] = [];
 
-  for (const record of records) {
+  for (const [recordIndex, record] of records.entries()) {
     const timestamp = Date.parse(record.timestamp ?? "") || 0;
+    if (record.type === "compaction") {
+      const event: PendingContextEvent = {
+        type: "compaction",
+        sourceOrder: recordIndex + 1,
+        ...(timestamp === 0 ? {} : { occurredAt: timestamp }),
+      };
+      contextEvents.push(event);
+      pendingContextEvents.push(event);
+      continue;
+    }
     const message = record.message;
     if (record.type !== "message" || !message?.role) continue;
 
@@ -326,12 +342,39 @@ function decodeRecords(records: Record[]) {
     addTokens(tokens, callTokens);
     reportedCost += cost;
     turn.calls.push(call);
+    for (const event of pendingContextEvents) {
+      event.affectedCallReference = call;
+    }
+    pendingContextEvents.length = 0;
   }
 
   const nonEmptyTurns = turns
     .filter((turn) => turn.calls.length > 0)
     .map((turn, index) => ({ ...turn, number: index + 1 }));
-  return { turns: nonEmptyTurns, tokens, providers, models, reportedCost };
+  const normalizedContextEvents: SessionContextEventImport[] = contextEvents
+    .map(
+      ({ affectedCallReference, ...event }) => {
+        if (affectedCallReference === undefined) return event;
+        const turn = nonEmptyTurns.find((candidate) =>
+          candidate.calls.includes(affectedCallReference)
+        );
+        return turn === undefined ? event : {
+          ...event,
+          affectedCall: {
+            turn: turn.number,
+            call: affectedCallReference.callWithinTurn,
+          },
+        };
+      },
+    );
+  return {
+    turns: nonEmptyTurns,
+    contextEvents: normalizedContextEvents,
+    tokens,
+    providers,
+    models,
+    reportedCost,
+  };
 }
 
 export class PiRepository {
@@ -382,10 +425,23 @@ export class PiRepository {
       file.id,
       file.updatedAt,
     );
+    const turns = normalized.turns.map((turn) => ({
+      ...turn,
+      calls: turn.calls.map((call) => ({
+        ...call,
+        contextEventsBefore: normalized.contextEvents.filter((event) =>
+          event.affectedCall?.turn === turn.number &&
+          event.affectedCall.call === call.callWithinTurn
+        ).map(({ affectedCall: _affectedCall, ...event }) => event),
+      })),
+    }));
     return {
       ...normalized.summary,
       parentID: undefined,
-      turns: normalized.turns,
+      turns,
+      contextEvents: normalized.contextEvents.filter((event) =>
+        event.affectedCall === undefined
+      ),
       subagents: [],
     };
   }
@@ -451,7 +507,11 @@ function piSession(records: Record[], id: string, updatedAt: number) {
     reportedCost: decoded.reportedCost,
     tokens: decoded.tokens,
   };
-  return { summary, turns: decoded.turns };
+  return {
+    summary,
+    turns: decoded.turns,
+    contextEvents: decoded.contextEvents,
+  };
 }
 
 export function normalizePiSession(

--- a/src/server/sessionRepository.test.ts
+++ b/src/server/sessionRepository.test.ts
@@ -71,6 +71,12 @@ function importedSession(
           },
         }],
       }],
+      contextEvents: [{
+        type: "compaction",
+        sourceOrder: 2,
+        occurredAt: 12,
+        affectedCall: { turn: 1, call: 1 },
+      }],
     },
   };
 }
@@ -116,6 +122,12 @@ Deno.test("stores and reads canonical sessions atomically", () => {
       "child",
     );
     strictEqual(detail.turns[0].calls[0].preview, "answer");
+    deepStrictEqual(detail.turns[0].calls[0].contextEventsBefore, [{
+      type: "compaction",
+      sourceOrder: 2,
+      occurredAt: 12,
+    }]);
+    deepStrictEqual(detail.contextEvents, []);
     strictEqual(
       detail.turns[0].calls[0].activity.tools[0].inputPreview,
       '{"path":"src/schema.ts"}',

--- a/src/server/sessionRepository.test.ts
+++ b/src/server/sessionRepository.test.ts
@@ -309,3 +309,36 @@ Deno.test("atomically replaces trees with root-scoped public child IDs", () => {
     Deno.removeSync(directory, { recursive: true });
   }
 });
+
+Deno.test("hides tagged context operations for Codex only", () => {
+  const directory = Deno.makeTempDirSync();
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  try {
+    migrateTestDatabase(db);
+    const repository = new SessionRepository(db);
+    const source = (harness: "pi" | "codex") =>
+      Number(
+        (db.prepare(`
+          INSERT INTO sources (harness, kind, label, location, created_at)
+          VALUES (?, 'directory', ?, ?, 1) RETURNING id
+        `).get(harness, harness, `/${harness}`) as { id: number }).id,
+      );
+    const pi = importedSession(source("pi"), "pi-operation");
+    const codex = importedSession(source("codex"), "codex-operation");
+    pi.session.turns[0].calls[0].id = "context-operation:1-1";
+    codex.session.turns[0].calls[0].id = "context-operation:1-1";
+    repository.replaceSourceSession(pi);
+    repository.replaceSourceSession(codex);
+
+    strictEqual(repository.getSession("pi", pi.externalID)?.turns.length, 1);
+    strictEqual(
+      repository.getSession("codex", codex.externalID)?.turns.length,
+      0,
+    );
+    strictEqual(repository.listUsageCalls(undefined, "pi").length, 1);
+    strictEqual(repository.listUsageCalls(undefined, "codex").length, 0);
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -1,5 +1,6 @@
 import type { DatabaseSync } from "node:sqlite";
 import {
+  type ContextEvent,
   type ModelCall,
   type SessionDetail,
   sessionDetailSchema,
@@ -41,11 +42,23 @@ export type SessionToolImport =
     output?: Omit<SessionContentImport, "kind" | "mimeType" | "contentHash">;
   };
 
-export type SessionCallImport = Omit<ModelCall, "activity"> & {
-  activity: Omit<ModelCall["activity"], "tools"> & {
-    tools: SessionToolImport[];
+export type SessionCallImport =
+  & Omit<
+    ModelCall,
+    "activity" | "contextEventsBefore"
+  >
+  & {
+    activity: Omit<ModelCall["activity"], "tools"> & {
+      tools: SessionToolImport[];
+    };
+    content?: SessionContentImport[];
   };
-  content?: SessionContentImport[];
+
+export type SessionContextEventImport = ContextEvent & {
+  affectedCall?: {
+    turn: number;
+    call: number;
+  };
 };
 
 export type SessionTurnImport = {
@@ -84,6 +97,7 @@ export type SourceSessionImport = {
     reportedCost?: number;
     tokens: TokenUsage;
     turns: SessionTurnImport[];
+    contextEvents?: SessionContextEventImport[];
   };
 };
 
@@ -153,6 +167,13 @@ type ContentRow = {
   model_call_id: number;
   kind: string;
   preview: string | null;
+};
+
+type ContextEventRow = {
+  event_type: string;
+  source_order: number;
+  occurred_at: number | null;
+  affected_model_call_id: number | null;
 };
 
 const summaryColumns = `
@@ -673,6 +694,7 @@ export class SessionRepository {
       ...tokenValues,
     );
 
+    const callIDs = new Map<string, number>();
     for (const turn of session.turns) {
       const turnID = Number(
         (this.db.prepare(`
@@ -716,6 +738,7 @@ export class SessionRepository {
             Number(call.activity.hasReasoning),
           ) as { id: number }).id,
         );
+        callIDs.set(`${turn.number}:${call.callWithinTurn}`, callID);
         this.#insertContent(
           "call_content",
           "model_call_id",
@@ -753,6 +776,32 @@ export class SessionRepository {
       }
     }
 
+    const insertContextEvent = this.db.prepare(`
+      INSERT INTO context_events (
+        session_id, event_type, source_order, occurred_at,
+        affected_model_call_id
+      ) VALUES (?, ?, ?, ?, ?)
+    `);
+    for (const event of session.contextEvents ?? []) {
+      const affectedCallID = event.affectedCall === undefined
+        ? null
+        : callIDs.get(
+          `${event.affectedCall.turn}:${event.affectedCall.call}`,
+        );
+      if (event.affectedCall !== undefined && affectedCallID === undefined) {
+        throw new Error(
+          `Unknown affected call: turn ${event.affectedCall.turn}, call ${event.affectedCall.call}`,
+        );
+      }
+      insertContextEvent.run(
+        sourceSessionID,
+        event.type,
+        event.sourceOrder,
+        event.occurredAt ?? null,
+        affectedCallID ?? null,
+      );
+    }
+
     const checkpoint = value.checkpoint;
     this.db.prepare(`
         UPDATE source_sessions SET
@@ -777,10 +826,26 @@ export class SessionRepository {
         ...base,
         parentID: optional(row.parent_public_id),
         turns: [],
+        contextEvents: [],
         subagents: [],
       };
     }
     const nextVisited = new Set(visited).add(row.source_session_id);
+    const contextEventRows = this.db.prepare(`
+      SELECT event_type, source_order, occurred_at, affected_model_call_id
+      FROM context_events
+      WHERE session_id = ?
+      ORDER BY source_order
+    `).all(row.source_session_id) as ContextEventRow[];
+    const contextEventsByCall = Map.groupBy(
+      contextEventRows.filter((event) => event.affected_model_call_id !== null),
+      (event) => event.affected_model_call_id!,
+    );
+    const contextEvent = (event: ContextEventRow): ContextEvent => ({
+      type: event.event_type,
+      sourceOrder: event.source_order,
+      occurredAt: optional(event.occurred_at),
+    });
     const turns = (this.db.prepare(`
       SELECT id, ordinal, started_at FROM turns
       WHERE session_id = ? ORDER BY ordinal
@@ -846,6 +911,9 @@ export class SessionRepository {
                 outputPreview: optional(tool.output_preview),
               })),
             },
+            contextEventsBefore: (contextEventsByCall.get(call.id) ?? []).map(
+              contextEvent,
+            ),
           };
         }),
       };
@@ -865,6 +933,9 @@ export class SessionRepository {
       parentID: optional(row.parent_public_id),
       agent: optional(row.agent),
       turns,
+      contextEvents: contextEventRows.filter((event) =>
+        event.affected_model_call_id === null
+      ).map(contextEvent),
       subagents: children.map((child) => this.#detail(child, nextVisited)),
     };
   }

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -515,6 +515,10 @@ export class SessionRepository {
       LEFT JOIN source_sessions parent ON parent.id = ss.parent_id
       WHERE (? IS NULL OR mc.started_at >= ?)
         AND (? IS NULL OR so.harness = ?)
+        AND NOT (
+          so.harness = 'codex' AND
+          mc.source_call_id LIKE 'context-operation:%'
+        )
       ORDER BY mc.started_at, mc.id
     `).all(
       startedAt ?? null,
@@ -854,12 +858,17 @@ export class SessionRepository {
       ordinal: number;
       started_at: number;
     }>).map((turn) => {
-      const calls = this.db.prepare(`
+      const calls = (this.db.prepare(`
         SELECT ${callColumns}
         FROM model_calls mc
         JOIN models m ON m.id = mc.model_id
         WHERE mc.turn_id = ? ORDER BY mc.ordinal
-      `).all(turn.id) as CallRow[];
+      `).all(turn.id) as CallRow[]).filter((call) => {
+        // Codex persists compaction machinery as an opaque model call. Its
+        // importer tags only that call; all other calls hydrate normally.
+        return row.harness !== "codex" ||
+          !call.source_call_id?.startsWith("context-operation:");
+      });
       const tools = calls.length === 0 ? [] : this.db.prepare(`
         SELECT te.model_call_id, te.name, te.status, te.started_at,
           te.completed_at,
@@ -917,7 +926,10 @@ export class SessionRepository {
           };
         }),
       };
-    });
+    }).filter((turn) => turn.calls.length > 0).map((turn, index) => ({
+      ...turn,
+      number: index + 1,
+    }));
     const children = this.db.prepare(`
       SELECT ${summaryColumns}
       FROM sessions s
@@ -932,6 +944,8 @@ export class SessionRepository {
       ...base,
       parentID: optional(row.parent_public_id),
       agent: optional(row.agent),
+      userTurns: turns.length,
+      modelCalls: turns.reduce((total, turn) => total + turn.calls.length, 0),
       turns,
       contextEvents: contextEventRows.filter((event) =>
         event.affected_model_call_id === null

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -50,6 +50,7 @@ export const cacheAssessmentReasonSchema = z.enum([
 export const cacheAssessmentSchema = z.object({
   status: cacheStatusSchema,
   reason: cacheAssessmentReasonSchema.optional(),
+  cause: z.enum(["compaction"]).optional(),
   retainedRatio: z.number().nonnegative().optional(),
   previousReusableTokens: z.number().int().positive().optional(),
 });
@@ -61,10 +62,13 @@ export const cacheSummarySchema = z.object({
   fullMisses: z.number().int().nonnegative(),
   notComparable: z.number().int().nonnegative(),
   unknown: z.number().int().nonnegative(),
+  compactionRelatedMisses: z.number().int().nonnegative(),
+  unexpectedMisses: z.number().int().nonnegative(),
 });
 
 export const cacheIssueSchema = z.object({
   status: z.enum(["partial-hit", "full-miss"]),
+  cause: z.enum(["compaction"]).optional(),
   turn: z.number().int().positive(),
   scope: z.string().optional(),
 });
@@ -98,11 +102,18 @@ export const sessionSummarySchema = z.object({
   computedCost: z.number().nonnegative().optional(),
   cacheSummary: cacheSummarySchema.optional(),
   cacheIssues: z.array(cacheIssueSchema).optional(),
+  compactionCount: z.number().int().nonnegative().optional(),
   contextLatest: z.number().int().nonnegative().optional(),
   contextPeak: z.number().int().nonnegative().optional(),
   contextPeakTurn: z.number().int().positive().optional(),
   contextPeakCall: z.number().int().positive().optional(),
   tokens: tokenUsageSchema,
+});
+
+export const contextEventSchema = z.object({
+  type: z.string().min(1),
+  sourceOrder: z.number().int().positive(),
+  occurredAt: z.number().optional(),
 });
 
 export const modelCallSchema = z.object({
@@ -117,6 +128,7 @@ export const modelCallSchema = z.object({
   computedCost: z.number().nonnegative().optional(),
   tokens: tokenUsageSchema,
   activity: callActivitySchema,
+  contextEventsBefore: z.array(contextEventSchema).optional(),
   cacheAssessment: cacheAssessmentSchema.optional(),
 });
 
@@ -132,6 +144,7 @@ const sessionDetailBaseSchema = sessionSummarySchema.extend({
   parentID: z.string().optional(),
   agent: z.string().optional(),
   turns: z.array(userTurnSchema),
+  contextEvents: z.array(contextEventSchema).optional(),
 });
 
 export type SessionDetail = z.infer<typeof sessionDetailBaseSchema> & {
@@ -218,6 +231,7 @@ export const usageResponseSchema = z.object({
 });
 
 export type ModelCall = z.infer<typeof modelCallSchema>;
+export type ContextEvent = z.infer<typeof contextEventSchema>;
 export type CacheAssessment = z.infer<typeof cacheAssessmentSchema>;
 export type CacheSummary = z.infer<typeof cacheSummarySchema>;
 export type CacheIssue = z.infer<typeof cacheIssueSchema>;


### PR DESCRIPTION
- Add normalized context events and SQLite migration.
- Detect compactions in OpenCode, PI, Claude Code, and Codex.
- Associate compactions with the first affected model call.
- Separate compaction-related cache misses from unexpected misses.
- Show compaction badges at session, turn, and call levels.
- Preserve Codex compaction-operation rows while hiding them from hydrated views and cache analytics.
- Avoid storing generated compaction summaries.