### PR TITLE
Improve cache diagnostics and expanded session tables

### DIFF
--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -234,6 +234,7 @@ function CacheAssessmentBadge(
 ) {
   if (
     !assessment ||
+    assessment.cause === "compaction" ||
     (assessment.status !== "partial-hit" && assessment.status !== "full-miss")
   ) return null;
   const title = providedTitle ??
@@ -338,9 +339,12 @@ function SessionCacheStatus({
   issues?: CacheIssue[];
   compactionCount?: number;
 }) {
-  const full = issues?.filter((issue) => issue.status === "full-miss") ?? [];
-  const partial = issues?.filter((issue) => issue.status === "partial-hit") ??
-    [];
+  const full = issues?.filter((issue) =>
+    issue.status === "full-miss" && issue.cause !== "compaction"
+  ) ?? [];
+  const partial = issues?.filter((issue) =>
+    issue.status === "partial-hit" && issue.cause !== "compaction"
+  ) ?? [];
   if (
     !summary ||
     (full.length === 0 && partial.length === 0 && !compactionCount)
@@ -386,10 +390,12 @@ function SessionCacheStatus({
 
 function TurnCacheStatus({ turn }: { turn: SessionDetail["turns"][number] }) {
   const full = turn.calls.filter((call) =>
-    call.cacheAssessment?.status === "full-miss"
+    call.cacheAssessment?.status === "full-miss" &&
+    call.cacheAssessment.cause !== "compaction"
   );
   const partial = turn.calls.filter((call) =>
-    call.cacheAssessment?.status === "partial-hit"
+    call.cacheAssessment?.status === "partial-hit" &&
+    call.cacheAssessment.cause !== "compaction"
   );
   const compactions = turn.calls.reduce(
     (total, call) =>

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -234,7 +234,7 @@ function CacheAssessmentBadge(
 ) {
   if (
     !assessment ||
-    assessment.cause === "compaction" ||
+    assessment.cause !== undefined ||
     (assessment.status !== "partial-hit" && assessment.status !== "full-miss")
   ) return null;
   const title = providedTitle ??
@@ -266,7 +266,7 @@ function CacheAssessmentBadge(
 }
 
 function cacheSummaryTitle(summary: CacheSummary) {
-  return `${summary.hits} hits · ${summary.partialHits} partial hits · ${summary.fullMisses} full misses · ${summary.compactionRelatedMisses} compaction-related misses · ${summary.unexpectedMisses} unexpected misses · ${summary.baseline} baseline · ${summary.notComparable} not comparable · ${summary.unknown} unavailable`;
+  return `${summary.hits} hits · ${summary.partialHits} partial hits · ${summary.fullMisses} full misses · ${summary.compactionRelatedMisses} compaction-related misses · ${summary.ttlRelatedMisses} TTL misses · ${summary.unexpectedMisses} unexpected misses · ${summary.baseline} baseline · ${summary.notComparable} not comparable · ${summary.unknown} unavailable`;
 }
 
 function CompactionBadge({ count = 1 }: { count?: number }) {
@@ -277,6 +277,18 @@ function CompactionBadge({ count = 1 }: { count?: number }) {
       title={`${count} context compaction${count === 1 ? "" : "s"}`}
     >
       Compacted
+    </span>
+  );
+}
+
+function TtlMissBadge({ count = 1 }: { count?: number }) {
+  if (count === 0) return null;
+  return (
+    <span
+      className="cache-issue-badge ttl-miss-badge"
+      title={`${count} cache miss${count === 1 ? "" : "es"} after TTL expiry`}
+    >
+      TTL miss
     </span>
   );
 }
@@ -340,14 +352,16 @@ function SessionCacheStatus({
   compactionCount?: number;
 }) {
   const full = issues?.filter((issue) =>
-    issue.status === "full-miss" && issue.cause !== "compaction"
+    issue.status === "full-miss" && issue.cause === undefined
   ) ?? [];
   const partial = issues?.filter((issue) =>
-    issue.status === "partial-hit" && issue.cause !== "compaction"
+    issue.status === "partial-hit" && issue.cause === undefined
   ) ?? [];
+  const ttl = issues?.filter((issue) => issue.cause === "ttl") ?? [];
   if (
     !summary ||
-    (full.length === 0 && partial.length === 0 && !compactionCount)
+    (full.length === 0 && partial.length === 0 && ttl.length === 0 &&
+      !compactionCount)
   ) {
     return null;
   }
@@ -357,6 +371,9 @@ function SessionCacheStatus({
       : undefined,
     partial.length > 0
       ? `Partial hit turns:\n${partial.map(cacheIssueLabel).join("\n")}`
+      : undefined,
+    ttl.length > 0
+      ? `TTL miss turns:\n${ttl.map(cacheIssueLabel).join("\n")}`
       : undefined,
     `Call totals: ${cacheSummaryTitle(summary)}`,
   ].filter(Boolean).join("\n\n");
@@ -378,6 +395,12 @@ function SessionCacheStatus({
           <span className="session-cache-count">x{partial.length}</span>
         </>
       )}
+      {ttl.length > 0 && (
+        <>
+          <TtlMissBadge count={ttl.length} />
+          <span className="session-cache-count">x{ttl.length}</span>
+        </>
+      )}
       {!!compactionCount && (
         <>
           <CompactionBadge count={compactionCount} />
@@ -391,11 +414,14 @@ function SessionCacheStatus({
 function TurnCacheStatus({ turn }: { turn: SessionDetail["turns"][number] }) {
   const full = turn.calls.filter((call) =>
     call.cacheAssessment?.status === "full-miss" &&
-    call.cacheAssessment.cause !== "compaction"
+    call.cacheAssessment.cause === undefined
   );
   const partial = turn.calls.filter((call) =>
     call.cacheAssessment?.status === "partial-hit" &&
-    call.cacheAssessment.cause !== "compaction"
+    call.cacheAssessment.cause === undefined
+  );
+  const ttl = turn.calls.filter((call) =>
+    call.cacheAssessment?.cause === "ttl"
   );
   const compactions = turn.calls.reduce(
     (total, call) =>
@@ -416,11 +442,19 @@ function TurnCacheStatus({ turn }: { turn: SessionDetail["turns"][number] }) {
         partial.map((call) => `#${call.callWithinTurn}`).join(", ")
       }`
       : undefined,
+    ttl.length > 0
+      ? `TTL miss calls: ${
+        ttl.map((call) => `#${call.callWithinTurn}`).join(", ")
+      }`
+      : undefined,
     turn.cacheSummary === undefined
       ? undefined
       : `Call totals: ${cacheSummaryTitle(turn.cacheSummary)}`,
   ].filter(Boolean).join("\n");
-  if (full.length === 0 && partial.length === 0 && compactions === 0) {
+  if (
+    full.length === 0 && partial.length === 0 && ttl.length === 0 &&
+    compactions === 0
+  ) {
     return null;
   }
   return (
@@ -437,6 +471,7 @@ function TurnCacheStatus({ turn }: { turn: SessionDetail["turns"][number] }) {
           title={title}
         />
       )}
+      <TtlMissBadge count={ttl.length} />
       <CompactionBadge count={compactions} />
     </span>
   );
@@ -1041,9 +1076,10 @@ function CallTable({
             const expanded = expandedCallID === call.id;
             const callDuration = duration(call.startedAt, call.completedAt);
             const callContext = contextSize(call.tokens);
-            const cacheMiss = call.cacheAssessment?.cause !== "compaction" &&
+            const cacheMiss = call.cacheAssessment?.cause === undefined &&
               (call.cacheAssessment?.status === "partial-hit" ||
                 call.cacheAssessment?.status === "full-miss");
+            const ttlMiss = call.cacheAssessment?.cause === "ttl";
             const compactions = (call.contextEventsBefore ?? []).filter((
               event,
             ) => event.type === "compaction").length;
@@ -1134,13 +1170,14 @@ function CallTable({
                     <CallInputMetric call={call} />
                   </td>
                   <td>
-                    {(cacheMiss || compactions > 0) && (
+                    {(cacheMiss || ttlMiss || compactions > 0) && (
                       <span className="cache-issue-group">
                         {cacheMiss && (
                           <CacheAssessmentBadge
                             assessment={call.cacheAssessment}
                           />
                         )}
+                        <TtlMissBadge count={ttlMiss ? 1 : 0} />
                         <CompactionBadge count={compactions} />
                       </span>
                     )}

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -361,7 +361,7 @@ function SessionCacheStatus({
     `Call totals: ${cacheSummaryTitle(summary)}`,
   ].filter(Boolean).join("\n\n");
   return (
-    <span className="session-cache-status" title={title}>
+    <span className="cache-issue-counts" title={title}>
       {full.length > 0 && (
         <>
           <span className="cache-issue-badge session-cache-full">
@@ -908,6 +908,7 @@ function toolTargetPreview(value?: string) {
 function CallInputMetric({ call }: { call: ModelCall }) {
   const anthropic = call.provider.toLowerCase().includes("anthropic");
   const total = contextSize(call.tokens);
+  const reused = cacheHitRate(call.tokens);
   const parts = anthropic
     ? [
       call.tokens.cacheRead > 0
@@ -936,6 +937,9 @@ function CallInputMetric({ call }: { call: ModelCall }) {
           writes: {compact.format(call.tokens.cacheWrite5m)} at 5m ·{"  "}
           {compact.format(call.tokens.cacheWrite1h)} at 1h
         </small>
+      )}
+      {reused !== undefined && (
+        <small>{(reused * 100).toFixed(1)}% reused</small>
       )}
     </span>
   );
@@ -1014,7 +1018,6 @@ function CallTable({
           <col className="call-outcome-column" />
           <col className="call-context-column" />
           <col className="call-input-column" />
-          <col className="call-reused-column" />
           <col className="call-cache-column" />
           <col className="call-output-column" />
           <col className="call-cost-column" />
@@ -1028,7 +1031,6 @@ function CallTable({
             <th>Activity</th>
             <th>Context</th>
             <th>Volume</th>
-            <th>Reused</th>
             <th>Cache</th>
             <th>Output</th>
             <th>Cost</th>
@@ -1039,7 +1041,12 @@ function CallTable({
             const expanded = expandedCallID === call.id;
             const callDuration = duration(call.startedAt, call.completedAt);
             const callContext = contextSize(call.tokens);
-            const reused = cacheHitRate(call.tokens);
+            const cacheMiss = call.cacheAssessment?.cause !== "compaction" &&
+              (call.cacheAssessment?.status === "partial-hit" ||
+                call.cacheAssessment?.status === "full-miss");
+            const compactions = (call.contextEventsBefore ?? []).filter((
+              event,
+            ) => event.type === "compaction").length;
             const subagents = callSubagents(call, session);
             const subagentTotals = aggregateSessionTrees(subagents);
             const hasSubagents = subagents.length > 0;
@@ -1126,20 +1133,17 @@ function CallTable({
                   <td>
                     <CallInputMetric call={call} />
                   </td>
-                  <td className={reused === undefined ? "muted" : undefined}>
-                    {reused === undefined
-                      ? "-"
-                      : `${(reused * 100).toFixed(1)}%`}
-                  </td>
                   <td>
-                    <span className="cache-issue-group">
-                      <CacheAssessmentBadge assessment={call.cacheAssessment} />
-                      <CompactionBadge
-                        count={(call.contextEventsBefore ?? []).filter((
-                          event,
-                        ) => event.type === "compaction").length}
-                      />
-                    </span>
+                    {(cacheMiss || compactions > 0) && (
+                      <span className="cache-issue-group">
+                        {cacheMiss && (
+                          <CacheAssessmentBadge
+                            assessment={call.cacheAssessment}
+                          />
+                        )}
+                        <CompactionBadge count={compactions} />
+                      </span>
+                    )}
                   </td>
                   <td>
                     <TokenValue
@@ -1160,7 +1164,7 @@ function CallTable({
                 </tr>
                 {expanded && (
                   <tr className="activity-detail-row">
-                    <td colSpan={11}>
+                    <td colSpan={10}>
                       <div className="activity-detail">
                         {finishWarning && (
                           <div className="activity-warning">

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -781,6 +781,10 @@ table.data-table {
   color: #5868a6;
 }
 
+.ttl-miss-badge {
+  color: #786578;
+}
+
 .session-model-summary {
   display: inline-flex;
   align-items: baseline;

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -747,7 +747,7 @@ table.data-table {
   text-align: center;
 }
 
-.session-cache-status {
+.cache-issue-counts {
   display: inline-grid;
   grid-template-columns: minmax(0, 1fr) 3ch;
   align-items: center;
@@ -758,7 +758,7 @@ table.data-table {
   white-space: nowrap;
 }
 
-.session-cache-status .cache-issue-badge {
+.cache-issue-counts .cache-issue-badge {
   justify-self: start;
 }
 
@@ -922,7 +922,7 @@ table.data-table {
 .breakdown {
   background: var(--surface-1);
   color: var(--ink);
-  padding: 10px 12px 14px;
+  padding: 10px 0 14px 12px;
   border-left: 3px solid var(--rail);
 }
 
@@ -978,27 +978,27 @@ table.data-table {
 }
 
 .turn-table .turn-activity-column {
-  width: 16%;
+  width: auto;
 }
 
 .turn-table .turn-context-column {
-  width: 9%;
+  width: 95px;
 }
 
 .turn-table .turn-input-column {
-  width: 20%;
+  width: clamp(210px, 19vw, 270px);
 }
 
 .turn-table .turn-cache-column {
-  width: 8%;
+  width: 132px;
 }
 
 .turn-table .turn-output-column {
-  width: 8%;
+  width: clamp(65px, 6vw, 78px);
 }
 
 .turn-table .turn-cost-column {
-  width: 13%;
+  width: 100px;
 }
 
 .turn-table td:first-child,
@@ -1089,7 +1089,7 @@ table.data-table {
 }
 
 .call-table .call-outcome-column {
-  width: 22%;
+  width: auto;
 }
 
 .call-table .call-model-column {
@@ -1097,27 +1097,23 @@ table.data-table {
 }
 
 .call-table .call-context-column {
-  width: 8%;
+  width: 95px;
 }
 
 .call-table .call-input-column {
-  width: 14%;
-}
-
-.call-table .call-reused-column {
-  width: 6%;
+  width: clamp(210px, 19vw, 270px);
 }
 
 .call-table .call-cache-column {
-  width: 8%;
+  width: 132px;
 }
 
 .call-table .call-output-column {
-  width: 6%;
+  width: clamp(65px, 6vw, 78px);
 }
 
 .call-table .call-cost-column {
-  width: 7%;
+  width: 100px;
 }
 
 .call-table th:nth-child(4),
@@ -1135,8 +1131,8 @@ table.data-table {
   text-align: left;
 }
 
-.call-table th:nth-child(9),
-.call-table td:nth-child(9) {
+.call-table th:nth-child(8),
+.call-table td:nth-child(8) {
   text-align: center;
 }
 
@@ -1576,9 +1572,10 @@ table.data-table {
 }
 
 .cache-issue-group {
-  display: inline-grid;
+  display: grid;
   justify-items: start;
   gap: 4px;
+  width: 100%;
 }
 
 .cache-assessment-hit {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -1274,7 +1274,7 @@ table.data-table {
 
 .call-table .tool-table th:first-child,
 .call-table .tool-table td:first-child {
-  width: 110px;
+  width: 180px;
   text-align: left;
 }
 

--- a/src/server/cacheAnalysis.test.ts
+++ b/src/server/cacheAnalysis.test.ts
@@ -180,7 +180,7 @@ Deno.test("summarizes turns and includes independently analyzed subagents", () =
   ]);
 });
 
-Deno.test("classifies a miss after a bounded compaction without changing status", () => {
+Deno.test("tracks a partial miss after compaction without counting it as a miss", () => {
   const previous = call("previous", 80_000, 20_000);
   const compacted = call("compacted", 50_000);
   compacted.contextEventsBefore = [{
@@ -188,17 +188,75 @@ Deno.test("classifies a miss after a bounded compaction without changing status"
     sourceOrder: 2,
     occurredAt: 2,
   }];
-  const actual = analyzeSessionCache(session("compaction", [
-    previous,
-    compacted,
-  ]));
+  const base = session("compaction", []);
+  base.userTurns = 2;
+  base.modelCalls = 2;
+  base.turns = [
+    { number: 1, startedAt: 1, calls: [previous] },
+    { number: 2, startedAt: 2, calls: [compacted] },
+  ];
+  const actual = analyzeSessionCache(base);
 
-  deepStrictEqual(actual.turns[0].calls[1].cacheAssessment, {
+  deepStrictEqual(actual.turns[1].calls[0].cacheAssessment, {
     status: "partial-hit",
     retainedRatio: 0.5,
     previousReusableTokens: 100_000,
     cause: "compaction",
   });
-  strictEqual(actual.turns[0].cacheSummary?.compactionRelatedMisses, 1);
-  strictEqual(actual.turns[0].cacheSummary?.unexpectedMisses, 0);
+  deepStrictEqual(actual.turns[1].cacheSummary, {
+    baseline: 0,
+    hits: 0,
+    partialHits: 0,
+    fullMisses: 0,
+    notComparable: 0,
+    unknown: 0,
+    compactionRelatedMisses: 1,
+    unexpectedMisses: 0,
+    totalCacheRead: 50_000,
+    peakCacheRead: 50_000,
+    totalNewInput: 100,
+    cachedInputShare: 50_000 / 50_100,
+  });
+  strictEqual(actual.turns[1].cacheAssessment, undefined);
+  deepStrictEqual(summarizeSessionCache(actual), {
+    baseline: 1,
+    hits: 0,
+    partialHits: 0,
+    fullMisses: 0,
+    notComparable: 0,
+    unknown: 0,
+    compactionRelatedMisses: 1,
+    unexpectedMisses: 0,
+  });
+  deepStrictEqual(sessionCacheIssues(actual), []);
+});
+
+Deno.test("tracks a full miss after compaction without counting it as a miss", () => {
+  const previous = call("previous", 80_000, 20_000);
+  const compacted = call("compacted", 5_000);
+  compacted.contextEventsBefore = [{
+    type: "compaction",
+    sourceOrder: 2,
+    occurredAt: 2,
+  }];
+  const base = session("compaction", []);
+  base.userTurns = 2;
+  base.modelCalls = 2;
+  base.turns = [
+    { number: 1, startedAt: 1, calls: [previous] },
+    { number: 2, startedAt: 2, calls: [compacted] },
+  ];
+  const actual = analyzeSessionCache(base);
+
+  deepStrictEqual(actual.turns[1].calls[0].cacheAssessment, {
+    status: "full-miss",
+    retainedRatio: 0.05,
+    previousReusableTokens: 100_000,
+    cause: "compaction",
+  });
+  strictEqual(actual.turns[1].cacheAssessment, undefined);
+  strictEqual(actual.turns[1].cacheSummary?.fullMisses, 0);
+  strictEqual(actual.turns[1].cacheSummary?.compactionRelatedMisses, 1);
+  strictEqual(summarizeSessionCache(actual).fullMisses, 0);
+  deepStrictEqual(sessionCacheIssues(actual), []);
 });

--- a/src/server/cacheAnalysis.test.ts
+++ b/src/server/cacheAnalysis.test.ts
@@ -2,6 +2,8 @@ import { deepStrictEqual, strictEqual } from "node:assert/strict";
 import {
   analyzeSessionCache,
   assessCache,
+  CACHE_TTL_1H_MS,
+  CACHE_TTL_5M_MS,
   sessionCacheIssues,
   summarizeSessionCache,
   summarizeTurnCache,
@@ -110,6 +112,7 @@ Deno.test("tracks an OpenAI miss and implicit cache recovery across turns", () =
     notComparable: 0,
     unknown: 0,
     compactionRelatedMisses: 0,
+    ttlRelatedMisses: 0,
     unexpectedMisses: 1,
     totalCacheRead: 107_520,
     peakCacheRead: 54_272,
@@ -172,6 +175,7 @@ Deno.test("summarizes turns and includes independently analyzed subagents", () =
     notComparable: 0,
     unknown: 0,
     compactionRelatedMisses: 0,
+    ttlRelatedMisses: 0,
     unexpectedMisses: 3,
   });
   deepStrictEqual(sessionCacheIssues(actual), [
@@ -211,6 +215,7 @@ Deno.test("tracks a partial miss after compaction without counting it as a miss"
     notComparable: 0,
     unknown: 0,
     compactionRelatedMisses: 1,
+    ttlRelatedMisses: 0,
     unexpectedMisses: 0,
     totalCacheRead: 50_000,
     peakCacheRead: 50_000,
@@ -226,9 +231,122 @@ Deno.test("tracks a partial miss after compaction without counting it as a miss"
     notComparable: 0,
     unknown: 0,
     compactionRelatedMisses: 1,
+    ttlRelatedMisses: 0,
     unexpectedMisses: 0,
   });
   deepStrictEqual(sessionCacheIssues(actual), []);
+});
+
+Deno.test("attributes a Claude miss to an expired 5-minute write", () => {
+  const previous = call("previous", 80_000, 20_000);
+  previous.startedAt = 0;
+  previous.tokens.cacheWrite5m = 20_000;
+  previous.tokens.cacheWrite1h = 0;
+  const expired = call("expired", 50_000);
+  expired.startedAt = CACHE_TTL_5M_MS;
+  expired.callWithinTurn = 2;
+
+  const actual = analyzeSessionCache(session("ttl-5m", [previous, expired]));
+
+  deepStrictEqual(actual.turns[0].calls[1].cacheAssessment, {
+    status: "partial-hit",
+    retainedRatio: 0.5,
+    previousReusableTokens: 100_000,
+    cause: "ttl",
+  });
+  strictEqual(actual.turns[0].cacheSummary?.partialHits, 0);
+  strictEqual(actual.turns[0].cacheSummary?.ttlRelatedMisses, 1);
+  strictEqual(actual.turns[0].cacheSummary?.unexpectedMisses, 0);
+  deepStrictEqual(sessionCacheIssues(actual), [{
+    status: "partial-hit",
+    cause: "ttl",
+    turn: 1,
+    scope: undefined,
+  }]);
+});
+
+Deno.test("keeps a Claude miss unexpected before its 5-minute TTL", () => {
+  const previous = call("previous", 80_000, 20_000);
+  previous.startedAt = 0;
+  previous.tokens.cacheWrite5m = 20_000;
+  const early = call("early", 50_000);
+  early.startedAt = CACHE_TTL_5M_MS - 1;
+
+  const actual = analyzeSessionCache(session("before-ttl", [previous, early]));
+
+  strictEqual(actual.turns[0].calls[1].cacheAssessment?.cause, undefined);
+  strictEqual(actual.turns[0].cacheSummary?.partialHits, 1);
+  strictEqual(actual.turns[0].cacheSummary?.ttlRelatedMisses, 0);
+  strictEqual(actual.turns[0].cacheSummary?.unexpectedMisses, 1);
+});
+
+Deno.test("attributes a cross-turn Claude miss to an expired 1-hour write", () => {
+  const previous = call("previous", 80_000, 20_000);
+  previous.startedAt = 0;
+  previous.tokens.cacheWrite5m = 0;
+  previous.tokens.cacheWrite1h = 20_000;
+  const expired = call("expired", 5_000);
+  expired.startedAt = CACHE_TTL_1H_MS;
+  const base = session("ttl-1h", []);
+  base.userTurns = 2;
+  base.modelCalls = 2;
+  base.turns = [
+    { number: 1, startedAt: 0, calls: [previous] },
+    { number: 2, startedAt: CACHE_TTL_1H_MS, calls: [expired] },
+  ];
+
+  const actual = analyzeSessionCache(base);
+
+  strictEqual(actual.turns[1].calls[0].cacheAssessment?.cause, "ttl");
+  strictEqual(actual.turns[1].cacheSummary?.fullMisses, 0);
+  strictEqual(actual.turns[1].cacheSummary?.ttlRelatedMisses, 1);
+  deepStrictEqual(sessionCacheIssues(actual), [{
+    status: "full-miss",
+    cause: "ttl",
+    turn: 2,
+    scope: undefined,
+  }]);
+});
+
+Deno.test("uses a 1-hour TTL fallback for other providers", () => {
+  const previous = call(
+    "previous",
+    80_000,
+    undefined,
+    "gpt-5.5",
+    "openai",
+  );
+  previous.startedAt = 0;
+  const expired = call("expired", 0, undefined, "gpt-5.5", "openai");
+  expired.startedAt = CACHE_TTL_1H_MS;
+
+  const actual = analyzeSessionCache(session("generic-ttl", [
+    previous,
+    expired,
+  ]));
+
+  strictEqual(actual.turns[0].calls[1].cacheAssessment?.cause, "ttl");
+  strictEqual(actual.turns[0].cacheSummary?.fullMisses, 0);
+  strictEqual(actual.turns[0].cacheSummary?.ttlRelatedMisses, 1);
+  strictEqual(actual.turns[0].cacheSummary?.unexpectedMisses, 0);
+});
+
+Deno.test("attributes an expired miss to compaction before TTL", () => {
+  const previous = call("previous", 80_000, 20_000);
+  previous.startedAt = 0;
+  previous.tokens.cacheWrite5m = 20_000;
+  const expired = call("expired", 50_000);
+  expired.startedAt = CACHE_TTL_5M_MS;
+  expired.contextEventsBefore = [{ type: "compaction", sourceOrder: 1 }];
+
+  const actual = analyzeSessionCache(session("compaction-first", [
+    previous,
+    expired,
+  ]));
+
+  strictEqual(actual.turns[0].calls[1].cacheAssessment?.cause, "compaction");
+  strictEqual(actual.turns[0].cacheSummary?.compactionRelatedMisses, 1);
+  strictEqual(actual.turns[0].cacheSummary?.ttlRelatedMisses, 0);
 });
 
 Deno.test("tracks a full miss after compaction without counting it as a miss", () => {

--- a/src/server/cacheAnalysis.ts
+++ b/src/server/cacheAnalysis.ts
@@ -9,6 +9,8 @@ import type {
 
 export const CACHE_HIT_RATIO = 0.9;
 export const CACHE_FULL_MISS_RATIO = 0.1;
+export const CACHE_TTL_5M_MS = 5 * 60 * 1000;
+export const CACHE_TTL_1H_MS = 60 * 60 * 1000;
 
 export function assessCache(
   previous: Pick<ModelCall, "provider" | "model" | "tokens"> | undefined,
@@ -40,12 +42,40 @@ const severity: Record<CacheAssessment["status"], number> = {
   unknown: 0,
   "not-comparable": 0,
   hit: 1,
-  "partial-hit": 2,
-  "full-miss": 3,
+  "partial-hit": 3,
+  "full-miss": 4,
 };
 
 function assessmentSeverity(assessment: CacheAssessment): number {
-  return assessment.cause === "compaction" ? 0 : severity[assessment.status];
+  if (assessment.cause === "compaction") return 0;
+  if (assessment.cause === "ttl") return 2;
+  return severity[assessment.status];
+}
+
+function isMiss(assessment: CacheAssessment | undefined): boolean {
+  return assessment?.status === "partial-hit" ||
+    assessment?.status === "full-miss";
+}
+
+function isClaude(call: Pick<ModelCall, "provider" | "model">): boolean {
+  return call.provider.toLowerCase().includes("anthropic") ||
+    call.model.toLowerCase().includes("claude");
+}
+
+function ttlExpired(previous: ModelCall, current: ModelCall): boolean {
+  const elapsed = current.startedAt - previous.startedAt;
+  if (elapsed < 0) return false;
+  if (isClaude(previous)) {
+    if (
+      (previous.tokens.cacheWrite5m ?? 0) > 0 &&
+      elapsed >= CACHE_TTL_5M_MS
+    ) return true;
+    if (
+      (previous.tokens.cacheWrite1h ?? 0) > 0 &&
+      elapsed >= CACHE_TTL_1H_MS
+    ) return true;
+  }
+  return elapsed >= CACHE_TTL_1H_MS;
 }
 
 export function summarizeTurnCache(calls: ModelCall[]): TurnCacheSummary {
@@ -57,6 +87,7 @@ export function summarizeTurnCache(calls: ModelCall[]): TurnCacheSummary {
     notComparable: 0,
     unknown: 0,
     compactionRelatedMisses: 0,
+    ttlRelatedMisses: 0,
     unexpectedMisses: 0,
     totalCacheRead: 0,
     peakCacheRead: 0,
@@ -71,6 +102,10 @@ export function summarizeTurnCache(calls: ModelCall[]): TurnCacheSummary {
     summary.totalNewInput += call.tokens.freshPrompt;
     if (call.cacheAssessment?.cause === "compaction") {
       summary.compactionRelatedMisses++;
+      continue;
+    }
+    if (call.cacheAssessment?.cause === "ttl") {
+      summary.ttlRelatedMisses++;
       continue;
     }
     switch (call.cacheAssessment?.status) {
@@ -111,12 +146,13 @@ export function analyzeSessionCache(session: SessionDetail): SessionDetail {
   const turns = session.turns.map((turn) => {
     const calls = turn.calls.map((call) => {
       const rawAssessment = assessCache(previous, call);
-      const cacheAssessment = (call.contextEventsBefore ?? []).some((event) =>
+      const followsCompaction = (call.contextEventsBefore ?? []).some((event) =>
           event.type === "compaction"
-        ) &&
-          (rawAssessment.status === "partial-hit" ||
-            rawAssessment.status === "full-miss")
+        );
+      const cacheAssessment = isMiss(rawAssessment) && followsCompaction
         ? { ...rawAssessment, cause: "compaction" as const }
+        : isMiss(rawAssessment) && previous && ttlExpired(previous, call)
+        ? { ...rawAssessment, cause: "ttl" as const }
         : rawAssessment;
       previous = call;
       return { ...call, cacheAssessment };
@@ -156,12 +192,17 @@ export function summarizeSessionCache(session: SessionDetail): CacheSummary {
     notComparable: 0,
     unknown: 0,
     compactionRelatedMisses: 0,
+    ttlRelatedMisses: 0,
     unexpectedMisses: 0,
   };
   for (const turn of session.turns) {
     for (const call of turn.calls) {
       if (call.cacheAssessment?.cause === "compaction") {
         summary.compactionRelatedMisses++;
+        continue;
+      }
+      if (call.cacheAssessment?.cause === "ttl") {
+        summary.ttlRelatedMisses++;
         continue;
       }
       switch (call.cacheAssessment?.status) {
@@ -200,6 +241,7 @@ export function summarizeSessionCache(session: SessionDetail): CacheSummary {
     summary.notComparable += nested.notComparable;
     summary.unknown += nested.unknown;
     summary.compactionRelatedMisses += nested.compactionRelatedMisses;
+    summary.ttlRelatedMisses += nested.ttlRelatedMisses;
     summary.unexpectedMisses += nested.unexpectedMisses;
   }
   return summary;
@@ -213,20 +255,28 @@ export function sessionCacheIssues(
     ? session.agent ? `${session.agent}: ${session.title}` : session.title
     : undefined;
   return [
-    ...session.turns.flatMap((turn) =>
-      turn.cacheAssessment?.cause !== "compaction" &&
-        (turn.cacheAssessment?.status === "full-miss" ||
-          turn.cacheAssessment?.status === "partial-hit")
-        ? [{
-          status: turn.cacheAssessment.status,
-          ...(turn.cacheAssessment.cause === undefined
-            ? {}
-            : { cause: turn.cacheAssessment.cause }),
+    ...session.turns.flatMap((turn) => {
+      const issues: CacheIssue[] = [];
+      for (const cause of [undefined, "ttl"] as const) {
+        const misses = turn.calls.filter((call) =>
+          isMiss(call.cacheAssessment) &&
+          call.cacheAssessment?.cause === cause
+        );
+        if (misses.length === 0) continue;
+        const status = misses.some((call) =>
+            call.cacheAssessment?.status === "full-miss"
+          )
+          ? "full-miss" as const
+          : "partial-hit" as const;
+        issues.push({
+          status,
+          ...(cause ? { cause } : {}),
           turn: turn.number,
           scope,
-        }]
-        : []
-    ),
+        });
+      }
+      return issues;
+    }),
     ...session.subagents.flatMap((subagent) =>
       sessionCacheIssues(subagent, true)
     ),

--- a/src/server/cacheAnalysis.ts
+++ b/src/server/cacheAnalysis.ts
@@ -44,6 +44,10 @@ const severity: Record<CacheAssessment["status"], number> = {
   "full-miss": 3,
 };
 
+function assessmentSeverity(assessment: CacheAssessment): number {
+  return assessment.cause === "compaction" ? 0 : severity[assessment.status];
+}
+
 export function summarizeTurnCache(calls: ModelCall[]): TurnCacheSummary {
   const summary: TurnCacheSummary = {
     baseline: 0,
@@ -65,6 +69,10 @@ export function summarizeTurnCache(calls: ModelCall[]): TurnCacheSummary {
       call.tokens.cacheRead,
     );
     summary.totalNewInput += call.tokens.freshPrompt;
+    if (call.cacheAssessment?.cause === "compaction") {
+      summary.compactionRelatedMisses++;
+      continue;
+    }
     switch (call.cacheAssessment?.status) {
       case "baseline":
         summary.baseline++;
@@ -84,9 +92,7 @@ export function summarizeTurnCache(calls: ModelCall[]): TurnCacheSummary {
       default:
         summary.unknown++;
     }
-    if (call.cacheAssessment?.cause === "compaction") {
-      summary.compactionRelatedMisses++;
-    } else if (
+    if (
       call.cacheAssessment?.status === "partial-hit" ||
       call.cacheAssessment?.status === "full-miss"
     ) {
@@ -116,10 +122,14 @@ export function analyzeSessionCache(session: SessionDetail): SessionDetail {
       return { ...call, cacheAssessment };
     });
     const cacheAssessment = calls.reduce<CacheAssessment | undefined>(
-      (worst, call) =>
-        !worst || severity[call.cacheAssessment.status] > severity[worst.status]
+      (worst, call) => {
+        if (call.cacheAssessment.cause === "compaction") return worst;
+        return !worst ||
+            assessmentSeverity(call.cacheAssessment) >
+              assessmentSeverity(worst)
           ? call.cacheAssessment
-          : worst,
+          : worst;
+      },
       undefined,
     );
     return {
@@ -150,6 +160,10 @@ export function summarizeSessionCache(session: SessionDetail): CacheSummary {
   };
   for (const turn of session.turns) {
     for (const call of turn.calls) {
+      if (call.cacheAssessment?.cause === "compaction") {
+        summary.compactionRelatedMisses++;
+        continue;
+      }
       switch (call.cacheAssessment?.status) {
         case "baseline":
           summary.baseline++;
@@ -169,9 +183,7 @@ export function summarizeSessionCache(session: SessionDetail): CacheSummary {
         default:
           summary.unknown++;
       }
-      if (call.cacheAssessment?.cause === "compaction") {
-        summary.compactionRelatedMisses++;
-      } else if (
+      if (
         call.cacheAssessment?.status === "partial-hit" ||
         call.cacheAssessment?.status === "full-miss"
       ) {
@@ -202,8 +214,9 @@ export function sessionCacheIssues(
     : undefined;
   return [
     ...session.turns.flatMap((turn) =>
-      turn.cacheAssessment?.status === "full-miss" ||
-        turn.cacheAssessment?.status === "partial-hit"
+      turn.cacheAssessment?.cause !== "compaction" &&
+        (turn.cacheAssessment?.status === "full-miss" ||
+          turn.cacheAssessment?.status === "partial-hit")
         ? [{
           status: turn.cacheAssessment.status,
           ...(turn.cacheAssessment.cause === undefined

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -50,7 +50,7 @@ export const cacheAssessmentReasonSchema = z.enum([
 export const cacheAssessmentSchema = z.object({
   status: cacheStatusSchema,
   reason: cacheAssessmentReasonSchema.optional(),
-  cause: z.enum(["compaction"]).optional(),
+  cause: z.enum(["compaction", "ttl"]).optional(),
   retainedRatio: z.number().nonnegative().optional(),
   previousReusableTokens: z.number().int().positive().optional(),
 });
@@ -63,12 +63,13 @@ export const cacheSummarySchema = z.object({
   notComparable: z.number().int().nonnegative(),
   unknown: z.number().int().nonnegative(),
   compactionRelatedMisses: z.number().int().nonnegative(),
+  ttlRelatedMisses: z.number().int().nonnegative(),
   unexpectedMisses: z.number().int().nonnegative(),
 });
 
 export const cacheIssueSchema = z.object({
   status: z.enum(["partial-hit", "full-miss"]),
-  cause: z.enum(["compaction"]).optional(),
+  cause: z.enum(["compaction", "ttl"]).optional(),
   turn: z.number().int().positive(),
   scope: z.string().optional(),
 });


### PR DESCRIPTION
  - Widen the tool-name column to prevent labels from overflowing
  - Treat compaction-related cache resets as expected rather than partial/full misses
  - Detect TTL-related misses using:
      - Claude 5-minute cache writes
      - Claude 1-hour cache writes
      - A generic 1-hour fallback for other providers

  - Display expected TTL failures as TTL MISS
  - Preserve raw cache-retention assessments for diagnostics
  - Exclude compaction and TTL resets from partial/full and unexpected-miss counts
  - Add regression coverage for compaction precedence, TTL boundaries, and same-turn/cross-turn expiry
  - Align Context, Volume, Cache, Output, and Cost across expanded table levels
  - Fold Reused into the model-call Volume metric
  - Standardize cache-badge alignment while keeping counts session-only