### PR TITLE
Add TTL miss cost insights and improve analytics charts

### DIFF
--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -17,6 +17,7 @@ import codexIcon from "./assets/icons/codex-logo-light.svg";
 import openCodeIcon from "./assets/icons/opencode-logo-light.svg";
 import piIcon from "./assets/icons/pi-logo.svg";
 import { UsageChart } from "./UsageChart.tsx";
+import { TtlMissCard } from "./TtlMissCard.tsx";
 
 const route = getRouteApi("/");
 const integer = new Intl.NumberFormat("en-US");
@@ -351,12 +352,14 @@ function SessionCacheStatus({
   issues?: CacheIssue[];
   compactionCount?: number;
 }) {
-  const full = issues?.filter((issue) =>
-    issue.status === "full-miss" && issue.cause === undefined
-  ) ?? [];
-  const partial = issues?.filter((issue) =>
-    issue.status === "partial-hit" && issue.cause === undefined
-  ) ?? [];
+  const full =
+    issues?.filter((issue) =>
+      issue.status === "full-miss" && issue.cause === undefined
+    ) ?? [];
+  const partial =
+    issues?.filter((issue) =>
+      issue.status === "partial-hit" && issue.cause === undefined
+    ) ?? [];
   const ttl = issues?.filter((issue) => issue.cause === "ttl") ?? [];
   if (
     !summary ||
@@ -965,7 +968,9 @@ function CallInputMetric({ call }: { call: ModelCall }) {
       className="metric-stack session-input-metric call-input-metric"
       title={`${integer.format(total)} total input tokens`}
     >
-      <span><TokenValue value={total} /> total input</span>
+      <span>
+        <TokenValue value={total} /> total input
+      </span>
       <small>{parts.filter(Boolean).join(" · ")}</small>
       {call.tokens.cacheWrite5m !== undefined &&
         call.tokens.cacheWrite1h !== undefined && (
@@ -1673,7 +1678,10 @@ export function SessionsPage() {
         </p>
       </header>
 
-      <UsageChart harness={harness} />
+      <div className="homepage-metrics">
+        <TtlMissCard harness={harness} />
+        <UsageChart harness={harness} />
+      </div>
 
       <section className="sessions-panel">
         <div className="panel-heading">

--- a/src/client/TtlMissCard.tsx
+++ b/src/client/TtlMissCard.tsx
@@ -1,0 +1,95 @@
+import { useEffect, useState } from "react";
+import type { TtlMissMetrics } from "../shared/sessionSchemas.ts";
+import { getTtlMissMetrics } from "./api.ts";
+
+const integer = new Intl.NumberFormat();
+const percent = new Intl.NumberFormat(undefined, {
+  style: "percent",
+  maximumFractionDigits: 1,
+});
+
+function share(value: number, total: number) {
+  return percent.format(total === 0 ? 0 : value / total);
+}
+
+export function TtlMissCard({ harness }: { harness: string }) {
+  const [metrics, setMetrics] = useState<TtlMissMetrics>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let active = true;
+    setMetrics(undefined);
+    setError(undefined);
+    getTtlMissMetrics(90, harness).then((result) => {
+      if (active) setMetrics(result);
+    }).catch((reason) => {
+      if (active) {
+        setError(
+          reason instanceof Error
+            ? reason.message
+            : "Unable to load TTL metrics",
+        );
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [harness]);
+
+  return (
+    <section className="ttl-miss-card" aria-labelledby="ttl-miss-title">
+      <div className="ttl-miss-heading">
+        <div>
+          <p className="eyebrow">Cache efficiency</p>
+          <h2 id="ttl-miss-title">TTL misses</h2>
+        </div>
+        <span>Last 90 days</span>
+      </div>
+      {!metrics && !error && (
+        <div className="ttl-miss-message">Analyzing session gaps...</div>
+      )}
+      {error && <div className="ttl-miss-message chart-error">{error}</div>}
+      {metrics && (
+        <>
+          <div className="ttl-miss-lead">
+            <strong>{integer.format(metrics.affectedSessions)}</strong>
+            <div>
+              <span>of {integer.format(metrics.sessions)} sessions</span>
+              <b>
+                {share(metrics.affectedSessions, metrics.sessions)} affected
+              </b>
+            </div>
+          </div>
+          <div className="ttl-miss-breakdown">
+            <div className="ttl-miss-breakdown-title">
+              <span>Root-session gap</span>
+              <strong>{integer.format(metrics.misses.total)} misses</strong>
+            </div>
+            {([
+              ["Under 2 hours", metrics.misses.underTwoHours],
+              ["2 to 8 hours", metrics.misses.twoToEightHours],
+              ["8 hours or more", metrics.misses.eightHoursOrMore],
+            ] as const).map(([label, count]) => (
+              <div className="ttl-miss-row" key={label}>
+                <span>{label}</span>
+                <i />
+                <strong>{integer.format(count)}</strong>
+                <small>{share(count, metrics.misses.total)}</small>
+              </div>
+            ))}
+          </div>
+          <div className="ttl-subagent-summary">
+            <div>
+              <span>Subagent TTL misses</span>
+              <small>Reported separately from user-session resumptions</small>
+            </div>
+            <strong>{integer.format(metrics.subagents.misses)} misses</strong>
+            <span>
+              {integer.format(metrics.subagents.affectedSessions)} sessions
+            </span>
+          </div>
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/client/TtlMissCard.tsx
+++ b/src/client/TtlMissCard.tsx
@@ -7,6 +7,12 @@ const percent = new Intl.NumberFormat(undefined, {
   style: "percent",
   maximumFractionDigits: 1,
 });
+const money = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
 
 function share(value: number, total: number) {
   return percent.format(total === 0 ? 0 : value / total);
@@ -60,24 +66,76 @@ export function TtlMissCard({ harness }: { harness: string }) {
               </b>
             </div>
           </div>
+          <div className="ttl-cost-summary">
+            <div>
+              <span>All root-session spend</span>
+              <strong>{money.format(metrics.totalSessionCost)}</strong>
+              {metrics.hasUnpricedSessionCost && (
+                <small>Known prices only</small>
+              )}
+            </div>
+            <div>
+              <span>Affected root-session spend</span>
+              <strong>{money.format(metrics.affectedSessionCost)}</strong>
+              <small>
+                {share(metrics.affectedSessionCost, metrics.totalSessionCost)}
+                {" "}
+                of all spend
+                {metrics.hasUnpricedAffectedSessionCost
+                  ? " · known prices only"
+                  : ""}
+              </small>
+            </div>
+            <div>
+              <span>Estimated TTL-attributed cost</span>
+              <strong>{money.format(metrics.misses.attributedCost)}</strong>
+              <small>
+                {share(
+                  metrics.misses.attributedCost,
+                  metrics.affectedSessionCost,
+                )} of affected spend
+              </small>
+            </div>
+          </div>
           <div className="ttl-miss-breakdown">
             <div className="ttl-miss-breakdown-title">
               <span>Root-session gap</span>
               <strong>{integer.format(metrics.misses.total)} misses</strong>
             </div>
             {([
-              ["Under 2 hours", metrics.misses.underTwoHours],
-              ["2 to 8 hours", metrics.misses.twoToEightHours],
-              ["8 hours or more", metrics.misses.eightHoursOrMore],
-            ] as const).map(([label, count]) => (
+              [
+                "Quick return (<2 hours)",
+                metrics.misses.underTwoHours,
+                metrics.misses.underTwoHoursCost,
+              ],
+              [
+                "Later return (2–8 hours)",
+                metrics.misses.twoToEightHours,
+                metrics.misses.twoToEightHoursCost,
+              ],
+              [
+                "Long-gap return (8+ hours)",
+                metrics.misses.eightHoursOrMore,
+                metrics.misses.eightHoursOrMoreCost,
+              ],
+            ] as const).map(([label, count, cost]) => (
               <div className="ttl-miss-row" key={label}>
                 <span>{label}</span>
                 <i />
-                <strong>{integer.format(count)}</strong>
-                <small>{share(count, metrics.misses.total)}</small>
+                <strong>{money.format(cost)}</strong>
+                <small>
+                  {integer.format(count)} · {share(count, metrics.misses.total)}
+                </small>
               </div>
             ))}
           </div>
+          {metrics.misses.unpriced > 0 && (
+            <p className="ttl-pricing-note">
+              {integer.format(metrics.misses.unpriced)}{" "}
+              miss{metrics.misses.unpriced === 1 ? "" : "es"}{" "}
+              could not be priced.
+            </p>
+          )}
           <div className="ttl-subagent-summary">
             <div>
               <span>Subagent TTL misses</span>

--- a/src/client/UsageChart.tsx
+++ b/src/client/UsageChart.tsx
@@ -7,7 +7,7 @@ import { SpendInputChart } from "./analytics/SpendInputChart.tsx";
 import { SubagentChart } from "./analytics/SubagentChart.tsx";
 
 type View = "spend" | "input" | "session-input" | "cache" | "subagents";
-type Range = 7 | 30 | "all";
+type Range = 7 | 30 | 90 | "all";
 
 const views: Array<{ value: View; label: string }> = [
   { value: "spend", label: "Spend" },
@@ -59,7 +59,7 @@ export function UsageChart({ harness }: { harness: string }) {
           ))}
         </div>
         <div className="segmented" aria-label="Chart range">
-          {([7, 30, "all"] as const).map((value) => (
+          {([7, 30, 90, "all"] as const).map((value) => (
             <button
               key={value}
               type="button"

--- a/src/client/analytics/CacheMissChart.tsx
+++ b/src/client/analytics/CacheMissChart.tsx
@@ -39,7 +39,7 @@ function CacheTooltip({ active, label, payload }: {
 
 export function CacheMissChart({ usage, range }: {
   usage: UsageResponse;
-  range: 7 | 30 | "all";
+  range: 7 | 30 | 90 | "all";
 }) {
   const total = usage.cacheDays.reduce(
     (sum, entry) => sum + entry.clean + entry.partial + entry.fullMiss + entry.notComparable,

--- a/src/client/analytics/SessionInputChart.tsx
+++ b/src/client/analytics/SessionInputChart.tsx
@@ -70,7 +70,7 @@ function SessionInputTooltip({ active, payload }: {
 
 export function SessionInputChart({ usage, range }: {
   usage: UsageResponse;
-  range: 7 | 30 | "all";
+  range: 7 | 30 | 90 | "all";
 }) {
   const [bucket, setBucket] = useState<"day" | "week">("week");
   const cohorts = bucket === "day"

--- a/src/client/analytics/SpendInputChart.tsx
+++ b/src/client/analytics/SpendInputChart.tsx
@@ -19,6 +19,7 @@ const money = new Intl.NumberFormat("en-US", {
   maximumFractionDigits: 4,
 });
 const day = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
+const DAY_MS = 86_400_000;
 const colors = ["#b4522d", "#466244", "#c18a3d", "#637b86", "#786578", "#8c7658", "#78916c", "#b46f62"];
 const visibleModels = 5;
 
@@ -38,7 +39,7 @@ function UsageTooltip({ active, label, payload, metric }: {
   const total = items.reduce((sum, item) => sum + item.value!, 0);
   return (
     <div className="usage-tooltip">
-      <p>{day.format(new Date(`${String(label)}T00:00:00`))}</p>
+      <p>{day.format(new Date(Number(label)))}</p>
       <strong>{formatValue(metric, total)} total</strong>
       <div className="usage-tooltip-models">
         {items.map((item) => (
@@ -55,7 +56,7 @@ function UsageTooltip({ active, label, payload, metric }: {
 export function SpendInputChart({ usage, metric, range }: {
   usage: UsageResponse;
   metric: Metric;
-  range: 7 | 30 | "all";
+  range: 7 | 30 | 90 | "all";
 }) {
   const models = [...new Set(usage.days.flatMap((entry) => entry.models.map(({ model }) => model)))].sort();
   const series = models.map((model, index) => ({
@@ -66,7 +67,9 @@ export function SpendInputChart({ usage, metric, range }: {
       .reduce((sum, item) => sum + (item[metric] ?? 0), 0),
   })).sort((a, b) => b.total - a.total || a.model.localeCompare(b.model));
   const data = usage.days.map((entry) => {
-    const row: Record<string, string | number | undefined> = { date: entry.date };
+    const row: Record<string, string | number | undefined> = {
+      timestamp: new Date(`${entry.date}T00:00:00`).getTime(),
+    };
     for (const item of entry.models) {
       const key = series.find(({ model }) => model === item.model)?.key;
       if (key) row[key] = item[metric];
@@ -96,7 +99,19 @@ export function SpendInputChart({ usage, metric, range }: {
             <ResponsiveContainer width="100%" height="100%">
               <BarChart data={data} margin={{ top: 8, right: 8, left: 4, bottom: 0 }}>
                 <CartesianGrid vertical={false} stroke="#dfdbd1" strokeDasharray="3 5" />
-                <XAxis dataKey="date" tickFormatter={(value: string) => day.format(new Date(`${value}T00:00:00`))} tickLine={false} axisLine={false} minTickGap={24} />
+                <XAxis
+                  dataKey="timestamp"
+                  type="number"
+                  scale="time"
+                  domain={[
+                    (minimum: number) => minimum - DAY_MS / 2,
+                    (maximum: number) => maximum + DAY_MS / 2,
+                  ]}
+                  tickFormatter={(value: number) => day.format(new Date(value))}
+                  tickLine={false}
+                  axisLine={false}
+                  minTickGap={24}
+                />
                 <YAxis tickFormatter={(value: number) => metric === "cost" ? `$${compact.format(value)}` : compact.format(value)} tickLine={false} axisLine={false} width={54} />
                 <Tooltip cursor={{ fill: "rgba(70, 98, 68, .07)" }} content={(props) => (
                   <UsageTooltip active={props.active} label={props.label} payload={props.payload as Array<{ color?: string; name?: string; value?: number }>} metric={metric} />

--- a/src/client/analytics/SubagentChart.tsx
+++ b/src/client/analytics/SubagentChart.tsx
@@ -145,7 +145,7 @@ function SubagentTooltip({ active, payload }: {
 
 export function SubagentChart({ usage, range }: {
   usage: UsageResponse;
-  range: 7 | 30 | "all";
+  range: 7 | 30 | 90 | "all";
 }) {
   const [bucket, setBucket] = useState<"day" | "week">("week");
   const allCohorts = bucket === "day"

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,6 +1,7 @@
 import {
   sessionDetailSchema,
   sessionListResponseSchema,
+  ttlMissMetricsSchema,
   usageResponseSchema,
 } from "../shared/sessionSchemas.ts";
 
@@ -9,7 +10,9 @@ async function getJson(path: string) {
   if (!response.ok) throw new Error(`Request failed (${response.status})`);
   const contentType = response.headers.get("content-type");
   if (!contentType?.includes("application/json")) {
-    throw new Error(`API returned ${contentType ?? "unknown content"} for ${path}`);
+    throw new Error(
+      `API returned ${contentType ?? "unknown content"} for ${path}`,
+    );
   }
   return response.json();
 }
@@ -17,6 +20,12 @@ async function getJson(path: string) {
 export async function getUsage(range: number | "all", harness: string) {
   return usageResponseSchema.parse(
     await getJson(`/api/usage?range=${range}&harness=${harness}`),
+  );
+}
+
+export async function getTtlMissMetrics(range: number, harness: string) {
+  return ttlMissMetricsSchema.parse(
+    await getJson(`/api/ttl-misses?range=${range}&harness=${harness}`),
   );
 }
 

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -230,6 +230,35 @@ h1 {
   font-size: 13px;
 }
 
+.ttl-cost-summary {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  margin: 0 28px 18px;
+  border: 1px solid var(--row-border);
+  background: var(--surface-1);
+}
+
+.ttl-cost-summary > div {
+  display: grid;
+  gap: 3px;
+  padding: 12px 14px;
+  font-family: var(--mono);
+}
+
+.ttl-cost-summary > div + div {
+  border-left: 1px solid var(--row-border);
+}
+
+.ttl-cost-summary span,
+.ttl-cost-summary small {
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.ttl-cost-summary strong {
+  font-size: 17px;
+}
+
 .ttl-miss-breakdown {
   margin: 0 28px;
   border-top: 1px solid var(--row-border);
@@ -269,14 +298,20 @@ h1 {
 }
 
 .ttl-miss-row strong {
-  min-width: 28px;
+  min-width: 64px;
   text-align: right;
 }
 
 .ttl-miss-row small {
-  width: 44px;
+  width: 70px;
   color: var(--muted);
   text-align: right;
+}
+
+.ttl-pricing-note {
+  margin: 8px 28px 0;
+  color: var(--muted);
+  font: 9px var(--mono);
 }
 
 .ttl-subagent-summary {
@@ -1881,6 +1916,44 @@ table.data-table {
 
   .usage-chart-heading {
     padding: 18px 18px 10px;
+  }
+
+  .ttl-miss-heading {
+    padding: 18px;
+  }
+
+  .ttl-miss-lead {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .ttl-cost-summary {
+    grid-template-columns: 1fr;
+    margin-right: 18px;
+    margin-left: 18px;
+  }
+
+  .ttl-cost-summary > div + div {
+    border-top: 1px solid var(--row-border);
+    border-left: 0;
+  }
+
+  .ttl-miss-breakdown,
+  .ttl-subagent-summary {
+    margin-right: 18px;
+    margin-left: 18px;
+  }
+
+  .ttl-miss-row {
+    gap: 6px;
+  }
+
+  .ttl-miss-row small {
+    width: 62px;
+  }
+
+  .ttl-pricing-note {
+    margin-left: 18px;
   }
 
   .analytics-toolbar {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -147,6 +147,170 @@ h1 {
   box-shadow: 0 18px 60px rgba(57, 51, 40, .08);
 }
 
+.homepage-metrics {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+.homepage-metrics .usage-chart {
+  min-width: 0;
+  margin-bottom: 0;
+}
+
+.ttl-miss-card {
+  min-height: 454px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel);
+  box-shadow: 0 18px 60px rgba(57, 51, 40, .08);
+}
+
+.ttl-miss-heading {
+  display: flex;
+  min-height: 96px;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 28px 18px;
+  border-bottom: 1px solid var(--panel-border);
+  background: var(--surface-1);
+}
+
+.ttl-miss-heading .eyebrow {
+  margin-bottom: 5px;
+}
+
+.ttl-miss-heading h2 {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: -.02em;
+}
+
+.ttl-miss-heading > span {
+  color: var(--muted);
+  font: 10px var(--mono);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.ttl-miss-message {
+  display: grid;
+  min-height: 356px;
+  place-items: center;
+  color: var(--muted);
+  font: 11px var(--mono);
+}
+
+.ttl-miss-lead {
+  display: flex;
+  align-items: center;
+  gap: 18px;
+  padding: 25px 28px 20px;
+}
+
+.ttl-miss-lead > strong {
+  color: var(--accent);
+  font: 600 52px/.9 var(--mono);
+  letter-spacing: -.08em;
+}
+
+.ttl-miss-lead div {
+  display: grid;
+  gap: 4px;
+  font-family: var(--mono);
+}
+
+.ttl-miss-lead span {
+  color: var(--muted);
+  font-size: 11px;
+}
+
+.ttl-miss-lead b {
+  font-size: 13px;
+}
+
+.ttl-miss-breakdown {
+  margin: 0 28px;
+  border-top: 1px solid var(--row-border);
+  border-bottom: 1px solid var(--row-border);
+  font-family: var(--mono);
+}
+
+.ttl-miss-breakdown-title,
+.ttl-miss-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+}
+
+.ttl-miss-breakdown-title {
+  justify-content: space-between;
+  padding: 14px 0 10px;
+  color: var(--muted);
+  font-size: 10px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.ttl-miss-breakdown-title strong {
+  color: var(--ink);
+  font-size: 11px;
+}
+
+.ttl-miss-row {
+  padding: 8px 0;
+  font-size: 11px;
+}
+
+.ttl-miss-row i {
+  flex: 1;
+  border-bottom: 1px dotted #c8c3b9;
+}
+
+.ttl-miss-row strong {
+  min-width: 28px;
+  text-align: right;
+}
+
+.ttl-miss-row small {
+  width: 44px;
+  color: var(--muted);
+  text-align: right;
+}
+
+.ttl-subagent-summary {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) max-content;
+  gap: 3px 16px;
+  align-items: baseline;
+  margin: 18px 28px 22px;
+  font: 11px var(--mono);
+}
+
+.ttl-subagent-summary div {
+  display: grid;
+  grid-row: span 2;
+  gap: 3px;
+}
+
+.ttl-subagent-summary small,
+.ttl-subagent-summary > span {
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.ttl-subagent-summary > strong,
+.ttl-subagent-summary > span {
+  text-align: right;
+}
+
+@media (max-width: 1100px) {
+  .homepage-metrics {
+    grid-template-columns: 1fr;
+  }
+}
+
 .analytics-toolbar {
   display: flex;
   justify-content: space-between;

--- a/src/server/cacheAnalysis.ts
+++ b/src/server/cacheAnalysis.ts
@@ -62,7 +62,10 @@ function isClaude(call: Pick<ModelCall, "provider" | "model">): boolean {
     call.model.toLowerCase().includes("claude");
 }
 
-function ttlExpired(previous: ModelCall, current: ModelCall): boolean {
+export function ttlExpired(
+  previous: Pick<ModelCall, "provider" | "model" | "tokens" | "startedAt">,
+  current: Pick<ModelCall, "startedAt">,
+): boolean {
   const elapsed = current.startedAt - previous.startedAt;
   if (elapsed < 0) return false;
   if (isClaude(previous)) {
@@ -147,8 +150,8 @@ export function analyzeSessionCache(session: SessionDetail): SessionDetail {
     const calls = turn.calls.map((call) => {
       const rawAssessment = assessCache(previous, call);
       const followsCompaction = (call.contextEventsBefore ?? []).some((event) =>
-          event.type === "compaction"
-        );
+        event.type === "compaction"
+      );
       const cacheAssessment = isMiss(rawAssessment) && followsCompaction
         ? { ...rawAssessment, cause: "compaction" as const }
         : isMiss(rawAssessment) && previous && ttlExpired(previous, call)

--- a/src/server/cacheMissPricing.test.ts
+++ b/src/server/cacheMissPricing.test.ts
@@ -6,6 +6,7 @@ import {
   estimateCacheMissTokens,
   type InputBillingRates,
 } from "./cacheMissPricing.ts";
+import { estimateModelCacheMissCost } from "./pricing.ts";
 
 function tokens(values: Partial<TokenUsage>): TokenUsage {
   return {
@@ -149,4 +150,53 @@ Deno.test("does not price observed categories with missing rates", () => {
     computeCacheMissCost({ input: 3, cacheRead: 0.3 }, estimate),
     undefined,
   );
+});
+
+Deno.test("uses short-context GPT rates below 272k", () => {
+  const result = estimateModelCacheMissCost(
+    tokens({ cacheRead: 229_000 }),
+    tokens({ uncachedInput: 230_000 }),
+    "gpt-5.6-sol",
+    Date.parse("2026-07-15T00:00:00Z"),
+  );
+  if (!result) throw new Error("Expected a priced estimate");
+
+  closeTo(result.actualMissedCost, 229_000 * 5 / 1_000_000);
+  closeTo(result.expectedReadCost, 229_000 * 0.5 / 1_000_000);
+  closeTo(result.estimatedExtraCost, 229_000 * 4.5 / 1_000_000);
+});
+
+Deno.test("uses long-context GPT rates above 272k", () => {
+  const result = estimateModelCacheMissCost(
+    tokens({ cacheRead: 289_000 }),
+    tokens({ uncachedInput: 290_000 }),
+    "gpt-5.6-sol",
+    Date.parse("2026-07-15T00:00:00Z"),
+  );
+  if (!result) throw new Error("Expected a priced estimate");
+
+  closeTo(result.actualMissedCost, 289_000 * 10 / 1_000_000);
+  closeTo(result.expectedReadCost, 289_000 * 1 / 1_000_000);
+  closeTo(result.estimatedExtraCost, 289_000 * 9 / 1_000_000);
+});
+
+Deno.test("switches cache-miss pricing at exactly 272k current context", () => {
+  const timestamp = Date.parse("2026-07-15T00:00:00Z");
+  const before = tokens({ cacheRead: 271_000 });
+  const below = estimateModelCacheMissCost(
+    before,
+    tokens({ uncachedInput: 271_999 }),
+    "gpt-5.6-sol",
+    timestamp,
+  );
+  const atBoundary = estimateModelCacheMissCost(
+    before,
+    tokens({ uncachedInput: 272_000 }),
+    "gpt-5.6-sol",
+    timestamp,
+  );
+  if (!below || !atBoundary) throw new Error("Expected priced estimates");
+
+  closeTo(below.estimatedExtraCost, 271_000 * 4.5 / 1_000_000);
+  closeTo(atBoundary.estimatedExtraCost, 271_000 * 9 / 1_000_000);
 });

--- a/src/server/cacheMissPricing.test.ts
+++ b/src/server/cacheMissPricing.test.ts
@@ -1,0 +1,152 @@
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
+import type { TokenUsage } from "../shared/sessionSchemas.ts";
+import {
+  computeCacheMissCost,
+  estimateCacheMissCost,
+  estimateCacheMissTokens,
+  type InputBillingRates,
+} from "./cacheMissPricing.ts";
+
+function tokens(values: Partial<TokenUsage>): TokenUsage {
+  return {
+    uncachedInput: 0,
+    cacheRead: 0,
+    freshPrompt: 0,
+    output: 0,
+    reasoning: 0,
+    processed: 0,
+    ...values,
+  };
+}
+
+const billing: InputBillingRates = {
+  input: 3,
+  cacheRead: 0.3,
+  cacheWrite: 4,
+  cacheWrite5m: 3.75,
+  cacheWrite1h: 6,
+};
+
+function closeTo(actual: number, expected: number) {
+  strictEqual(Math.abs(actual - expected) < 1e-12, true);
+}
+
+Deno.test("estimates missed reusable tokens for a partial cache miss", () => {
+  const estimate = estimateCacheMissTokens(
+    tokens({ uncachedInput: 2, cacheRead: 47_000, cacheWrite: 98 }),
+    tokens({
+      uncachedInput: 2,
+      cacheRead: 28_800,
+      cacheWrite: 19_098,
+      cacheWrite5m: 0,
+      cacheWrite1h: 19_098,
+    }),
+  );
+
+  deepStrictEqual(estimate, {
+    previousContext: 47_100,
+    currentContext: 47_900,
+    expectedReusable: 47_100,
+    actualCacheRead: 28_800,
+    missedTokens: 18_300,
+    actualBilling: {
+      uncachedInput: 2,
+      cacheWrite: 0,
+      cacheWrite5m: 0,
+      cacheWrite1h: 19_098,
+    },
+  });
+});
+
+Deno.test("estimates a full uncached miss while excluding net-new context", () => {
+  const estimate = estimateCacheMissTokens(
+    tokens({ uncachedInput: 1_000, cacheRead: 99_800, cacheWrite: 100 }),
+    tokens({ uncachedInput: 101_800, cacheRead: 0 }),
+  );
+
+  strictEqual(estimate.missedTokens, 100_900);
+  strictEqual(estimate.currentContext - estimate.previousContext, 900);
+  deepStrictEqual(estimate.actualBilling, {
+    uncachedInput: 101_800,
+    cacheWrite: 0,
+    cacheWrite5m: 0,
+    cacheWrite1h: 0,
+  });
+});
+
+Deno.test("caps expected reuse when the current context shrinks", () => {
+  const estimate = estimateCacheMissTokens(
+    tokens({ cacheRead: 100 }),
+    tokens({ uncachedInput: 30, cacheRead: 50 }),
+  );
+
+  strictEqual(estimate.expectedReusable, 80);
+  strictEqual(estimate.missedTokens, 30);
+});
+
+Deno.test("returns zero cost when there is no estimated miss", () => {
+  const result = estimateCacheMissCost(
+    billing,
+    tokens({ cacheRead: 100 }),
+    tokens({ uncachedInput: 2, cacheRead: 100 }),
+  );
+
+  strictEqual(result?.missedTokens, 0);
+  strictEqual(result?.actualMissedCost, 0);
+  strictEqual(result?.expectedReadCost, 0);
+  strictEqual(result?.estimatedExtraCost, 0);
+});
+
+Deno.test("prices missed tokens at the observed weighted non-read rate", () => {
+  const result = estimateCacheMissCost(
+    billing,
+    tokens({ cacheRead: 100 }),
+    tokens({ uncachedInput: 2, cacheRead: 80, cacheWrite: 20 }),
+  );
+  if (!result) throw new Error("Expected a priced estimate");
+
+  const actualNonReadCost = (2 * billing.input + 20 * billing.cacheWrite!) /
+    1_000_000;
+  closeTo(result.actualMissedCost, actualNonReadCost * 20 / 22);
+  closeTo(result.expectedReadCost, 20 * billing.cacheRead / 1_000_000);
+  closeTo(
+    result.estimatedExtraCost,
+    result.actualMissedCost - result.expectedReadCost,
+  );
+});
+
+Deno.test("uses detailed write rates only when they reconcile to total writes", () => {
+  const detailed = estimateCacheMissTokens(
+    tokens({ cacheRead: 100 }),
+    tokens({ cacheWrite: 100, cacheWrite5m: 25, cacheWrite1h: 75 }),
+  );
+  deepStrictEqual(detailed.actualBilling, {
+    uncachedInput: 0,
+    cacheWrite: 0,
+    cacheWrite5m: 25,
+    cacheWrite1h: 75,
+  });
+
+  const generic = estimateCacheMissTokens(
+    tokens({ cacheRead: 100 }),
+    tokens({ cacheWrite: 100, cacheWrite5m: 25, cacheWrite1h: 70 }),
+  );
+  deepStrictEqual(generic.actualBilling, {
+    uncachedInput: 0,
+    cacheWrite: 100,
+    cacheWrite5m: 0,
+    cacheWrite1h: 0,
+  });
+});
+
+Deno.test("does not price observed categories with missing rates", () => {
+  const estimate = estimateCacheMissTokens(
+    tokens({ cacheRead: 100 }),
+    tokens({ cacheWrite: 100 }),
+  );
+
+  strictEqual(
+    computeCacheMissCost({ input: 3, cacheRead: 0.3 }, estimate),
+    undefined,
+  );
+});

--- a/src/server/cacheMissPricing.ts
+++ b/src/server/cacheMissPricing.ts
@@ -1,7 +1,7 @@
 import type { TokenUsage } from "../shared/sessionSchemas.ts";
 import { contextSize } from "../shared/contextMetrics.ts";
 
-type CacheMissTokens = Pick<
+export type CacheMissTokens = Pick<
   TokenUsage,
   | "uncachedInput"
   | "cacheRead"

--- a/src/server/cacheMissPricing.ts
+++ b/src/server/cacheMissPricing.ts
@@ -1,0 +1,112 @@
+import type { TokenUsage } from "../shared/sessionSchemas.ts";
+import { contextSize } from "../shared/contextMetrics.ts";
+
+type CacheMissTokens = Pick<
+  TokenUsage,
+  | "uncachedInput"
+  | "cacheRead"
+  | "cacheWrite"
+  | "cacheWrite5m"
+  | "cacheWrite1h"
+>;
+
+export type InputBillingRates = {
+  input: number;
+  cacheRead: number;
+  cacheWrite?: number;
+  cacheWrite5m?: number;
+  cacheWrite1h?: number;
+};
+
+export type CacheMissTokenEstimate = {
+  previousContext: number;
+  currentContext: number;
+  expectedReusable: number;
+  actualCacheRead: number;
+  missedTokens: number;
+  actualBilling: {
+    uncachedInput: number;
+    cacheWrite: number;
+    cacheWrite5m: number;
+    cacheWrite1h: number;
+  };
+};
+
+export type CacheMissCostEstimate = CacheMissTokenEstimate & {
+  actualMissedCost: number;
+  expectedReadCost: number;
+  estimatedExtraCost: number;
+};
+
+export function estimateCacheMissTokens(
+  before: CacheMissTokens,
+  after: CacheMissTokens,
+): CacheMissTokenEstimate {
+  const previousContext = contextSize(before);
+  const currentContext = contextSize(after);
+  const expectedReusable = Math.min(previousContext, currentContext);
+  const actualCacheRead = Math.min(after.cacheRead, expectedReusable);
+  const missedTokens = Math.max(expectedReusable - actualCacheRead, 0);
+  const hasDetailedWrites = after.cacheWrite !== undefined &&
+    after.cacheWrite5m !== undefined && after.cacheWrite1h !== undefined &&
+    after.cacheWrite5m + after.cacheWrite1h === after.cacheWrite;
+
+  return {
+    previousContext,
+    currentContext,
+    expectedReusable,
+    actualCacheRead,
+    missedTokens,
+    actualBilling: {
+      uncachedInput: after.uncachedInput,
+      cacheWrite: hasDetailedWrites ? 0 : after.cacheWrite ?? 0,
+      cacheWrite5m: hasDetailedWrites ? after.cacheWrite5m! : 0,
+      cacheWrite1h: hasDetailedWrites ? after.cacheWrite1h! : 0,
+    },
+  };
+}
+
+export function computeCacheMissCost(
+  billing: InputBillingRates,
+  estimate: CacheMissTokenEstimate,
+): CacheMissCostEstimate | undefined {
+  const { actualBilling, missedTokens } = estimate;
+  if (actualBilling.cacheWrite > 0 && billing.cacheWrite === undefined) {
+    return undefined;
+  }
+  if (actualBilling.cacheWrite5m > 0 && billing.cacheWrite5m === undefined) {
+    return undefined;
+  }
+  if (actualBilling.cacheWrite1h > 0 && billing.cacheWrite1h === undefined) {
+    return undefined;
+  }
+
+  const nonReadTokens = actualBilling.uncachedInput +
+    actualBilling.cacheWrite + actualBilling.cacheWrite5m +
+    actualBilling.cacheWrite1h;
+  const nonReadCost = (
+    actualBilling.uncachedInput * billing.input +
+    actualBilling.cacheWrite * (billing.cacheWrite ?? 0) +
+    actualBilling.cacheWrite5m * (billing.cacheWrite5m ?? 0) +
+    actualBilling.cacheWrite1h * (billing.cacheWrite1h ?? 0)
+  ) / 1_000_000;
+  const actualMissedCost = nonReadTokens === 0
+    ? 0
+    : nonReadCost * missedTokens / nonReadTokens;
+  const expectedReadCost = missedTokens * billing.cacheRead / 1_000_000;
+
+  return {
+    ...estimate,
+    actualMissedCost,
+    expectedReadCost,
+    estimatedExtraCost: actualMissedCost - expectedReadCost,
+  };
+}
+
+export function estimateCacheMissCost(
+  billing: InputBillingRates,
+  before: CacheMissTokens,
+  after: CacheMissTokens,
+) {
+  return computeCacheMissCost(billing, estimateCacheMissTokens(before, after));
+}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -18,6 +18,7 @@ import type {
 } from "../shared/sessionSchemas.ts";
 import type { UsageCall } from "./usage.ts";
 import { aggregateUsage } from "./usageAnalytics.ts";
+import { aggregateTtlMisses } from "./ttlMissAnalytics.ts";
 import { contextRange } from "../shared/contextMetrics.ts";
 import { openArchiveDatabase, sqlitePath } from "./database.ts";
 import { SessionRepository } from "./sessionRepository.ts";
@@ -386,6 +387,42 @@ function listSessions(
     pagination: { page, pageSize, totalItems: 0, totalPages: 0 },
   };
 }
+
+app.get("/api/ttl-misses", (context) => {
+  const harness = context.req.query("harness") ?? "all";
+  if (!["all", "opencode", "claude-code", "pi", "codex"].includes(harness)) {
+    return context.json({ error: "Invalid harness" }, 400);
+  }
+  const rangeParam = context.req.query("range") ?? "90";
+  const range = Math.min(
+    365,
+    Math.max(1, Number.parseInt(rangeParam, 10) || 90),
+  );
+  const start = new Date(
+    new Date().setHours(0, 0, 0, 0) - (range - 1) * 86_400_000,
+  ).getTime();
+  const usageCalls: UsageCall[] = [];
+
+  if (archiveRepository) {
+    usageCalls.push(...archiveRepository.listUsageCalls(
+      start,
+      harness === "all" ? undefined : harness as SessionSummary["harness"],
+    ));
+  } else {
+    const sources = [
+      ["opencode", repository],
+      ["claude-code", claudeRepository],
+      ["pi", piRepository],
+      ["codex", codexRepository],
+    ] as const;
+    for (const [name, source] of sources) {
+      if (!source || (harness !== "all" && harness !== name)) continue;
+      usageCalls.push(...source.listUsageCalls(start));
+    }
+  }
+
+  return context.json(aggregateTtlMisses(usageCalls, start, range));
+});
 
 app.get("/api/usage", (context) => {
   const requestStartedAt = performance.now();

--- a/src/server/pricing.ts
+++ b/src/server/pricing.ts
@@ -3,6 +3,10 @@ import type {
   TokenUsage,
 } from "../shared/sessionSchemas.ts";
 import { contextSize } from "../shared/contextMetrics.ts";
+import {
+  type CacheMissTokens,
+  estimateCacheMissCost,
+} from "./cacheMissPricing.ts";
 
 type RateCard = {
   input: number;
@@ -120,6 +124,18 @@ export function computeModelCallCost(
     cacheWriteCost +
     (tokens.output + tokens.reasoning) * rates.output
   ) / 1_000_000;
+}
+
+export function estimateModelCacheMissCost(
+  before: CacheMissTokens,
+  after: CacheMissTokens,
+  model: string,
+  timestamp: number,
+) {
+  // A hit changes the billing category, not the request's context size. Resolve
+  // short- versus long-context rates from the call where the miss occurred.
+  const rates = rateCard(model, timestamp, contextSize(after));
+  return rates && estimateCacheMissCost(rates, before, after);
 }
 
 export function priceSessionDetail(session: SessionDetail): SessionDetail {

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -484,6 +484,7 @@ export class SessionRepository {
       parent_public_id: string | null;
       root_started_at: number | null;
       root_updated_at: number;
+      follows_compaction: number;
     };
     const rows = this.db.prepare(`
       WITH RECURSIVE session_tree(id, root_id) AS (
@@ -502,7 +503,12 @@ export class SessionRepository {
         COALESCE(root.public_id, root.external_id) AS root_public_id,
         COALESCE(parent.public_id, parent.external_id) AS parent_public_id,
         root_session.started_at AS root_started_at,
-        root_session.updated_at AS root_updated_at
+        root_session.updated_at AS root_updated_at,
+        EXISTS (
+          SELECT 1 FROM context_events ce
+          WHERE ce.affected_model_call_id = mc.id
+            AND ce.event_type = 'compaction'
+        ) AS follows_compaction
       FROM model_calls mc
       JOIN turns t ON t.id = mc.turn_id
       JOIN sessions s ON s.source_session_id = t.session_id
@@ -541,6 +547,7 @@ export class SessionRepository {
       startedAt: row.started_at,
       tokens: tokens(row),
       reportedCost: optional(row.reported_cost),
+      followsCompaction: row.follows_compaction === 1,
     }));
   }
 

--- a/src/server/ttlMissAnalytics.test.ts
+++ b/src/server/ttlMissAnalytics.test.ts
@@ -1,0 +1,91 @@
+import { deepStrictEqual } from "node:assert/strict";
+import { aggregateTtlMisses } from "./ttlMissAnalytics.ts";
+import type { UsageCall } from "./usage.ts";
+
+const MINUTE = 60 * 1_000;
+const start = Date.UTC(2026, 0, 1);
+
+function call(
+  session: string,
+  startedAt: number,
+  options: {
+    root?: string;
+    chain?: string;
+    sessionStartedAt?: number;
+    followsCompaction?: boolean;
+  } = {},
+): UsageCall {
+  const root = options.root ?? session;
+  return {
+    harness: "claude-code",
+    session: { id: session, rootID: root },
+    cacheChainID: options.chain ?? session,
+    sessionStartedAt: options.sessionStartedAt ?? start,
+    provider: "anthropic",
+    model: "claude-sonnet-4-5",
+    startedAt,
+    followsCompaction: options.followsCompaction,
+    tokens: {
+      uncachedInput: 100,
+      cacheRead: 0,
+      cacheWrite: 100,
+      cacheWrite5m: 100,
+      cacheWrite1h: 0,
+      freshPrompt: 0,
+      output: 0,
+      reasoning: 0,
+      processed: 100,
+    },
+  };
+}
+
+Deno.test("counts every root TTL miss in its elapsed-time bucket", () => {
+  const calls = [
+    call("affected", start),
+    call("affected", start + 60 * MINUTE),
+    call("affected", start + 3 * 60 * MINUTE),
+    call("affected", start + 11 * 60 * MINUTE),
+    call("clean", start),
+  ];
+
+  deepStrictEqual(aggregateTtlMisses(calls, start, 90), {
+    rangeDays: 90,
+    sessions: 2,
+    affectedSessions: 1,
+    misses: {
+      total: 3,
+      underTwoHours: 1,
+      twoToEightHours: 1,
+      eightHoursOrMore: 1,
+    },
+    subagents: { affectedSessions: 0, misses: 0 },
+  });
+});
+
+Deno.test("separates subagent misses and excludes compactions and old sessions", () => {
+  const calls = [
+    call("root", start),
+    call("root", start + 10 * MINUTE, { followsCompaction: true }),
+    call("child", start, { root: "root" }),
+    call("child", start + 10 * MINUTE, { root: "root" }),
+    call("old", start - 2 * MINUTE, {
+      sessionStartedAt: start - 2 * MINUTE,
+    }),
+    call("old", start + 10 * MINUTE, {
+      sessionStartedAt: start - 2 * MINUTE,
+    }),
+  ];
+
+  deepStrictEqual(aggregateTtlMisses(calls, start, 90), {
+    rangeDays: 90,
+    sessions: 1,
+    affectedSessions: 0,
+    misses: {
+      total: 0,
+      underTwoHours: 0,
+      twoToEightHours: 0,
+      eightHoursOrMore: 0,
+    },
+    subagents: { affectedSessions: 1, misses: 1 },
+  });
+});

--- a/src/server/ttlMissAnalytics.test.ts
+++ b/src/server/ttlMissAnalytics.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert/strict";
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
 import { aggregateTtlMisses } from "./ttlMissAnalytics.ts";
 import type { UsageCall } from "./usage.ts";
 
@@ -13,6 +13,7 @@ function call(
     chain?: string;
     sessionStartedAt?: number;
     followsCompaction?: boolean;
+    model?: string;
   } = {},
 ): UsageCall {
   const root = options.root ?? session;
@@ -22,11 +23,11 @@ function call(
     cacheChainID: options.chain ?? session,
     sessionStartedAt: options.sessionStartedAt ?? start,
     provider: "anthropic",
-    model: "claude-sonnet-4-5",
+    model: options.model ?? "claude-sonnet-4-5",
     startedAt,
     followsCompaction: options.followsCompaction,
     tokens: {
-      uncachedInput: 100,
+      uncachedInput: 0,
       cacheRead: 0,
       cacheWrite: 100,
       cacheWrite5m: 100,
@@ -48,15 +49,51 @@ Deno.test("counts every root TTL miss in its elapsed-time bucket", () => {
     call("clean", start),
   ];
 
-  deepStrictEqual(aggregateTtlMisses(calls, start, 90), {
+  const result = aggregateTtlMisses(calls, start, 90);
+  strictEqual(Math.abs(result.totalSessionCost - 0.001875) < 1e-12, true);
+  strictEqual(Math.abs(result.affectedSessionCost - 0.0015) < 1e-12, true);
+  strictEqual(Math.abs(result.misses.attributedCost - 0.001125) < 1e-12, true);
+  strictEqual(
+    Math.abs(result.misses.underTwoHoursCost - 0.000375) < 1e-12,
+    true,
+  );
+  strictEqual(
+    Math.abs(result.misses.twoToEightHoursCost - 0.000375) < 1e-12,
+    true,
+  );
+  strictEqual(
+    Math.abs(result.misses.eightHoursOrMoreCost - 0.000375) < 1e-12,
+    true,
+  );
+  deepStrictEqual({
+    ...result,
+    totalSessionCost: 0,
+    affectedSessionCost: 0,
+    misses: {
+      ...result.misses,
+      attributedCost: 0,
+      underTwoHoursCost: 0,
+      twoToEightHoursCost: 0,
+      eightHoursOrMoreCost: 0,
+    },
+  }, {
     rangeDays: 90,
     sessions: 2,
+    totalSessionCost: 0,
+    hasUnpricedSessionCost: false,
     affectedSessions: 1,
+    affectedSessionCost: 0,
+    hasUnpricedAffectedSessionCost: false,
     misses: {
       total: 3,
+      attributedCost: 0,
+      unpriced: 0,
       underTwoHours: 1,
+      underTwoHoursCost: 0,
       twoToEightHours: 1,
+      twoToEightHoursCost: 0,
       eightHoursOrMore: 1,
+      eightHoursOrMoreCost: 0,
     },
     subagents: { affectedSessions: 0, misses: 0 },
   });
@@ -79,13 +116,42 @@ Deno.test("separates subagent misses and excludes compactions and old sessions",
   deepStrictEqual(aggregateTtlMisses(calls, start, 90), {
     rangeDays: 90,
     sessions: 1,
+    totalSessionCost: 0.00075,
+    hasUnpricedSessionCost: false,
     affectedSessions: 0,
+    affectedSessionCost: 0,
+    hasUnpricedAffectedSessionCost: false,
     misses: {
       total: 0,
+      attributedCost: 0,
+      unpriced: 0,
       underTwoHours: 0,
+      underTwoHoursCost: 0,
       twoToEightHours: 0,
+      twoToEightHoursCost: 0,
       eightHoursOrMore: 0,
+      eightHoursOrMoreCost: 0,
     },
     subagents: { affectedSessions: 1, misses: 1 },
   });
+});
+
+Deno.test("reports incomplete affected-session and miss pricing", () => {
+  const result = aggregateTtlMisses(
+    [
+      call("unknown", start, { model: "unknown-model" }),
+      call("unknown", start + 10 * MINUTE, { model: "unknown-model" }),
+    ],
+    start,
+    90,
+  );
+
+  strictEqual(result.affectedSessions, 1);
+  strictEqual(result.totalSessionCost, 0);
+  strictEqual(result.hasUnpricedSessionCost, true);
+  strictEqual(result.affectedSessionCost, 0);
+  strictEqual(result.hasUnpricedAffectedSessionCost, true);
+  strictEqual(result.misses.total, 1);
+  strictEqual(result.misses.attributedCost, 0);
+  strictEqual(result.misses.unpriced, 1);
 });

--- a/src/server/ttlMissAnalytics.ts
+++ b/src/server/ttlMissAnalytics.ts
@@ -1,12 +1,15 @@
 import type { TtlMissMetrics } from "../shared/sessionSchemas.ts";
 import { assessCache, ttlExpired } from "./cacheAnalysis.ts";
+import { computeModelCallCost, estimateModelCacheMissCost } from "./pricing.ts";
 import type { UsageCall } from "./usage.ts";
 
 const TWO_HOURS_MS = 2 * 60 * 60 * 1_000;
 const EIGHT_HOURS_MS = 8 * 60 * 60 * 1_000;
 
-function ttlMissGaps(calls: UsageCall[]) {
-  const gaps: number[] = [];
+type TtlMiss = { gap: number; attributedCost?: number };
+
+function ttlMisses(calls: UsageCall[]) {
+  const misses: TtlMiss[] = [];
   for (
     const chain of Map.groupBy(calls, (call) => call.cacheChainID).values()
   ) {
@@ -19,12 +22,20 @@ function ttlMissGaps(calls: UsageCall[]) {
         miss && !call.followsCompaction && previous &&
         ttlExpired(previous, call)
       ) {
-        gaps.push(call.startedAt - previous.startedAt);
+        misses.push({
+          gap: call.startedAt - previous.startedAt,
+          attributedCost: estimateModelCacheMissCost(
+            previous.tokens,
+            call.tokens,
+            call.model,
+            call.startedAt,
+          )?.actualMissedCost,
+        });
       }
       previous = call;
     }
   }
-  return gaps;
+  return misses;
 }
 
 export function aggregateTtlMisses(
@@ -39,33 +50,69 @@ export function aggregateTtlMisses(
   const result: TtlMissMetrics = {
     rangeDays,
     sessions: sessions.size,
+    totalSessionCost: 0,
+    hasUnpricedSessionCost: false,
     affectedSessions: 0,
+    affectedSessionCost: 0,
+    hasUnpricedAffectedSessionCost: false,
     misses: {
       total: 0,
+      attributedCost: 0,
+      unpriced: 0,
       underTwoHours: 0,
+      underTwoHoursCost: 0,
       twoToEightHours: 0,
+      twoToEightHoursCost: 0,
       eightHoursOrMore: 0,
+      eightHoursOrMoreCost: 0,
     },
     subagents: { affectedSessions: 0, misses: 0 },
   };
 
   for (const calls of sessions.values()) {
-    const rootGaps = ttlMissGaps(
-      calls.filter((call) => call.session.id === call.session.rootID),
+    const rootCalls = calls.filter((call) =>
+      call.session.id === call.session.rootID
     );
-    if (rootGaps.length > 0) result.affectedSessions++;
-    result.misses.total += rootGaps.length;
-    for (const gap of rootGaps) {
-      if (gap < TWO_HOURS_MS) result.misses.underTwoHours++;
-      else if (gap < EIGHT_HOURS_MS) result.misses.twoToEightHours++;
-      else result.misses.eightHoursOrMore++;
+    const rootMisses = ttlMisses(rootCalls);
+    let rootSessionCost = 0;
+    let hasUnpricedRootSessionCost = false;
+    for (const call of rootCalls) {
+      const cost = call.computedCost ?? computeModelCallCost(
+        call.tokens,
+        call.model,
+        call.startedAt,
+      );
+      if (cost === undefined) hasUnpricedRootSessionCost = true;
+      else rootSessionCost += cost;
+    }
+    result.totalSessionCost += rootSessionCost;
+    result.hasUnpricedSessionCost ||= hasUnpricedRootSessionCost;
+    if (rootMisses.length > 0) {
+      result.affectedSessions++;
+      result.affectedSessionCost += rootSessionCost;
+      result.hasUnpricedAffectedSessionCost ||= hasUnpricedRootSessionCost;
+    }
+    result.misses.total += rootMisses.length;
+    for (const miss of rootMisses) {
+      if (miss.attributedCost === undefined) result.misses.unpriced++;
+      else result.misses.attributedCost += miss.attributedCost;
+      if (miss.gap < TWO_HOURS_MS) {
+        result.misses.underTwoHours++;
+        result.misses.underTwoHoursCost += miss.attributedCost ?? 0;
+      } else if (miss.gap < EIGHT_HOURS_MS) {
+        result.misses.twoToEightHours++;
+        result.misses.twoToEightHoursCost += miss.attributedCost ?? 0;
+      } else {
+        result.misses.eightHoursOrMore++;
+        result.misses.eightHoursOrMoreCost += miss.attributedCost ?? 0;
+      }
     }
 
-    const subagentGaps = ttlMissGaps(
+    const subagentMisses = ttlMisses(
       calls.filter((call) => call.session.id !== call.session.rootID),
     );
-    if (subagentGaps.length > 0) result.subagents.affectedSessions++;
-    result.subagents.misses += subagentGaps.length;
+    if (subagentMisses.length > 0) result.subagents.affectedSessions++;
+    result.subagents.misses += subagentMisses.length;
   }
 
   return result;

--- a/src/server/ttlMissAnalytics.ts
+++ b/src/server/ttlMissAnalytics.ts
@@ -1,0 +1,72 @@
+import type { TtlMissMetrics } from "../shared/sessionSchemas.ts";
+import { assessCache, ttlExpired } from "./cacheAnalysis.ts";
+import type { UsageCall } from "./usage.ts";
+
+const TWO_HOURS_MS = 2 * 60 * 60 * 1_000;
+const EIGHT_HOURS_MS = 8 * 60 * 60 * 1_000;
+
+function ttlMissGaps(calls: UsageCall[]) {
+  const gaps: number[] = [];
+  for (
+    const chain of Map.groupBy(calls, (call) => call.cacheChainID).values()
+  ) {
+    let previous: UsageCall | undefined;
+    for (const call of chain.sort((a, b) => a.startedAt - b.startedAt)) {
+      const assessment = assessCache(previous, call);
+      const miss = assessment.status === "partial-hit" ||
+        assessment.status === "full-miss";
+      if (
+        miss && !call.followsCompaction && previous &&
+        ttlExpired(previous, call)
+      ) {
+        gaps.push(call.startedAt - previous.startedAt);
+      }
+      previous = call;
+    }
+  }
+  return gaps;
+}
+
+export function aggregateTtlMisses(
+  usageCalls: UsageCall[],
+  start: number,
+  rangeDays: number,
+): TtlMissMetrics {
+  const sessions = Map.groupBy(
+    usageCalls.filter((call) => call.sessionStartedAt >= start),
+    (call) => `${call.harness}:${call.session.rootID}`,
+  );
+  const result: TtlMissMetrics = {
+    rangeDays,
+    sessions: sessions.size,
+    affectedSessions: 0,
+    misses: {
+      total: 0,
+      underTwoHours: 0,
+      twoToEightHours: 0,
+      eightHoursOrMore: 0,
+    },
+    subagents: { affectedSessions: 0, misses: 0 },
+  };
+
+  for (const calls of sessions.values()) {
+    const rootGaps = ttlMissGaps(
+      calls.filter((call) => call.session.id === call.session.rootID),
+    );
+    if (rootGaps.length > 0) result.affectedSessions++;
+    result.misses.total += rootGaps.length;
+    for (const gap of rootGaps) {
+      if (gap < TWO_HOURS_MS) result.misses.underTwoHours++;
+      else if (gap < EIGHT_HOURS_MS) result.misses.twoToEightHours++;
+      else result.misses.eightHoursOrMore++;
+    }
+
+    const subagentGaps = ttlMissGaps(
+      calls.filter((call) => call.session.id !== call.session.rootID),
+    );
+    if (subagentGaps.length > 0) result.subagents.affectedSessions++;
+    result.subagents.misses += subagentGaps.length;
+  }
+
+  return result;
+}

--- a/src/server/usage.ts
+++ b/src/server/usage.ts
@@ -19,6 +19,7 @@ export type UsageCall = {
   tokens: TokenUsage;
   reportedCost?: number;
   computedCost?: number;
+  followsCompaction?: boolean;
 };
 
 export function usageCallsFromSession(
@@ -42,6 +43,9 @@ export function usageCallsFromSession(
         tokens: call.tokens,
         reportedCost: call.reportedCost,
         computedCost: call.computedCost,
+        followsCompaction: (call.contextEventsBefore ?? []).some((event) =>
+          event.type === "compaction"
+        ),
       }))
     ),
     ...session.subagents.flatMap((subagent) =>

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -234,12 +234,21 @@ export const usageResponseSchema = z.object({
 export const ttlMissMetricsSchema = z.object({
   rangeDays: z.number().int().positive(),
   sessions: z.number().int().nonnegative(),
+  totalSessionCost: z.number().nonnegative(),
+  hasUnpricedSessionCost: z.boolean(),
   affectedSessions: z.number().int().nonnegative(),
+  affectedSessionCost: z.number().nonnegative(),
+  hasUnpricedAffectedSessionCost: z.boolean(),
   misses: z.object({
     total: z.number().int().nonnegative(),
+    attributedCost: z.number().nonnegative(),
+    unpriced: z.number().int().nonnegative(),
     underTwoHours: z.number().int().nonnegative(),
+    underTwoHoursCost: z.number().nonnegative(),
     twoToEightHours: z.number().int().nonnegative(),
+    twoToEightHoursCost: z.number().nonnegative(),
     eightHoursOrMore: z.number().int().nonnegative(),
+    eightHoursOrMoreCost: z.number().nonnegative(),
   }),
   subagents: z.object({
     affectedSessions: z.number().int().nonnegative(),

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -231,6 +231,22 @@ export const usageResponseSchema = z.object({
   })),
 });
 
+export const ttlMissMetricsSchema = z.object({
+  rangeDays: z.number().int().positive(),
+  sessions: z.number().int().nonnegative(),
+  affectedSessions: z.number().int().nonnegative(),
+  misses: z.object({
+    total: z.number().int().nonnegative(),
+    underTwoHours: z.number().int().nonnegative(),
+    twoToEightHours: z.number().int().nonnegative(),
+    eightHoursOrMore: z.number().int().nonnegative(),
+  }),
+  subagents: z.object({
+    affectedSessions: z.number().int().nonnegative(),
+    misses: z.number().int().nonnegative(),
+  }),
+});
+
 export type ModelCall = z.infer<typeof modelCallSchema>;
 export type ContextEvent = z.infer<typeof contextEventSchema>;
 export type CacheAssessment = z.infer<typeof cacheAssessmentSchema>;
@@ -241,3 +257,4 @@ export type SessionListResponse = z.infer<typeof sessionListResponseSchema>;
 export type SessionSummary = z.infer<typeof sessionSummarySchema>;
 export type TokenUsage = z.infer<typeof tokenUsageSchema>;
 export type UsageResponse = z.infer<typeof usageResponseSchema>;
+export type TtlMissMetrics = z.infer<typeof ttlMissMetricsSchema>;


### PR DESCRIPTION
- Add 90-day TTL miss metrics with root and subagent breakdowns.
- Estimate TTL-attributed token costs using model-specific pricing.
- Handle GPT short/long-context pricing at the 272K boundary.
- Show total, root, affected-session, and TTL-attributed spend.
- Add <2h, 2–8h, and 8h+ miss categories.
- Add 90-day chart ranges and calendar-accurate spacing.
- Preserve known costs when mixed with unpriced calls.
- Add focused aggregation and pricing tests.