### PR TITLE
Add 90-day usage overview and concurrent session analytics

### DIFF
--- a/src/client/Overview.tsx
+++ b/src/client/Overview.tsx
@@ -1,6 +1,5 @@
-import { type ReactNode, useEffect, useState } from "react";
+import type { ReactNode } from "react";
 import type { OverviewResponse } from "../shared/sessionSchemas.ts";
-import { getOverview } from "./api.ts";
 
 const integer = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
 const decimal = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
@@ -42,21 +41,31 @@ function MetricRow({
   description,
   values,
   format = decimal.format,
+  partial = false,
+  sectionStart = false,
 }: {
   label: string;
   description?: string;
   values?: Distribution;
   format?: (value: number) => string;
+  partial?: boolean;
+  sectionStart?: boolean;
 }) {
+  const value = (number: number) => (
+    <>
+      {format(number)}
+      {partial && <sup title="Known priced spend only">*</sup>}
+    </>
+  );
   return (
-    <tr>
+    <tr className={sectionStart ? "section-start" : undefined}>
       <th scope="row">
         {label}
         {description && <small>{description}</small>}
       </th>
-      <td>{values ? format(values.average) : "-"}</td>
-      <td>{values ? format(values.median) : "-"}</td>
-      <td>{values ? format(values.p90) : "-"}</td>
+      <td>{values ? value(values.median) : "-"}</td>
+      <td>{values ? value(values.average) : "-"}</td>
+      <td>{values ? value(values.p90) : "-"}</td>
     </tr>
   );
 }
@@ -76,8 +85,8 @@ function MetricTable({
           <thead>
             <tr>
               <th>Metric</th>
-              <th>Average</th>
               <th>Median</th>
+              <th>Average</th>
               <th>P90</th>
             </tr>
           </thead>
@@ -88,30 +97,13 @@ function MetricTable({
   );
 }
 
-export function Overview({ harness }: { harness: string }) {
-  const [data, setData] = useState<OverviewResponse>();
-  const [error, setError] = useState<string>();
-
-  useEffect(() => {
-    let active = true;
-    setData(undefined);
-    setError(undefined);
-    getOverview(90, harness).then((result) => active && setData(result)).catch(
-      (reason) => {
-        if (active) {
-          setError(
-            reason instanceof Error
-              ? reason.message
-              : "Unable to load overview",
-          );
-        }
-      },
-    );
-    return () => {
-      active = false;
-    };
-  }, [harness]);
-
+export function Overview({
+  data,
+  error,
+}: {
+  data?: OverviewResponse;
+  error?: string;
+}) {
   return (
     <section className="overview-panel">
       <div className="overview-heading">
@@ -161,6 +153,7 @@ export function Overview({ harness }: { harness: string }) {
                 label="Spend"
                 values={data.activity.spend}
                 format={currency.format}
+                partial={data.activity.hasUnpricedCost}
               />
             </MetricTable>
             <MetricTable title="Session profile">
@@ -185,6 +178,7 @@ export function Overview({ harness }: { harness: string }) {
                 label="Spend"
                 values={data.sessionProfile.spend}
                 format={currency.format}
+                partial={data.sessionProfile.hasUnpricedCost}
               />
               <MetricRow
                 label="Efficiency"
@@ -255,7 +249,7 @@ export function Overview({ harness }: { harness: string }) {
             data.subagentCoverage !== "full") && (
             <p className="overview-note">
               {data.activity.hasUnpricedCost &&
-                "Spend per day is unavailable when calls cannot be priced; session spend excludes those sessions. "}
+                "Spend statistics use known prices only. "}
               {data.subagentCoverage !== "full" &&
                 `Subagent coverage is ${data.subagentCoverage} for this harness selection.`}
             </p>
@@ -263,5 +257,149 @@ export function Overview({ harness }: { harness: string }) {
         </>
       )}
     </section>
+  );
+}
+
+export function CompactOverview({
+  data,
+  error,
+}: {
+  data?: OverviewResponse;
+  error?: string;
+}) {
+  if (error) return <div className="ttl-miss-message chart-error">{error}</div>;
+  if (!data) return <div className="ttl-miss-message">Loading overview...</div>;
+  const knownSpend = data.models.reduce((sum, model) => sum + model.spend, 0);
+  const hasUnpricedSpend = data.models.some((model) => model.hasUnpricedCost);
+  return (
+    <div className="compact-overview">
+      <div className="compact-overview-summary">
+        <div>
+          <strong>{integer.format(data.activeDays)}</strong>
+          <span>Active days</span>
+          <small>
+            {integer.format(data.activeWeekdays)} weekdays ·{" "}
+            {integer.format(data.weekendDays)} weekend
+          </small>
+        </div>
+        <div>
+          <strong>{integer.format(data.sessions)}</strong>
+          <span>Sessions</span>
+          <small>Worked on</small>
+        </div>
+        <div>
+          <strong>
+            {currency.format(knownSpend)}
+            {hasUnpricedSpend && <sup>*</sup>}
+          </strong>
+          <span>Spend</span>
+          <small>Known prices</small>
+        </div>
+        <div>
+          <strong>{percent(data.sessionProfile.overallEfficiency)}</strong>
+          <span>Token reuse</span>
+          <small>Weighted efficiency</small>
+        </div>
+        <div>
+          <strong>{percent(data.multiDaySessionRate)}</strong>
+          <span>Multi-day</span>
+          <small>{integer.format(data.multiDaySessions)} sessions</small>
+        </div>
+        <div>
+          <strong>{decimal.format(data.averageActiveSpan)} days</strong>
+          <span>Avg active span</span>
+          <small>Distinct dates</small>
+        </div>
+      </div>
+      <div className="compact-overview-table">
+        <table className="overview-table">
+          <thead>
+            <tr>
+              <th>Metric</th>
+              <th>P50</th>
+              <th>Avg</th>
+              <th>P90</th>
+            </tr>
+          </thead>
+          <tbody>
+            <MetricRow
+              label="Sessions / active day"
+              values={data.activity.sessions}
+            />
+            <MetricRow
+              label="Turns / active day"
+              values={data.activity.turns}
+            />
+            <MetricRow
+              label="Spend / active day"
+              values={data.activity.spend}
+              format={currency.format}
+              partial={data.activity.hasUnpricedCost}
+            />
+            <MetricRow
+              label="Turns / session"
+              values={data.sessionProfile.turns}
+              sectionStart
+            />
+            <MetricRow
+              label="Input / session"
+              values={data.sessionProfile.input}
+              format={compact.format}
+            />
+            <MetricRow
+              label="Peak context"
+              values={data.sessionProfile.peakContext}
+              format={compact.format}
+            />
+            <MetricRow
+              label="Elapsed duration"
+              values={data.sessionProfile.elapsed}
+              format={duration}
+            />
+            <MetricRow
+              label="Spend / session"
+              values={data.sessionProfile.spend}
+              format={currency.format}
+              partial={data.sessionProfile.hasUnpricedCost}
+            />
+            <MetricRow
+              label="Efficiency"
+              values={data.sessionProfile.efficiency}
+              format={percent}
+            />
+          </tbody>
+        </table>
+      </div>
+      {data.models.length > 0 && (
+        <div className="compact-models">
+          <h3>Top models by spend</h3>
+          <div className="compact-model-list">
+            {data.models.map((model) => (
+              <div
+                className="compact-model-row"
+                key={`${model.model}:${model.isOther}`}
+              >
+                <span title={model.model}>{modelName(model.model)}</span>
+                <i>
+                  <b style={{ width: `${model.spendShare * 100}%` }} />
+                </i>
+                <small>{percent(model.spendShare)}</small>
+                <strong>
+                  {currency.format(model.spend)}
+                  {model.hasUnpricedCost && <sup>*</sup>}
+                </strong>
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+      {(data.activity.hasUnpricedCost || data.subagentCoverage !== "full") && (
+        <p className="compact-overview-note">
+          {data.activity.hasUnpricedCost && "* Known priced spend only. "}
+          {data.subagentCoverage !== "full" &&
+            `${data.subagentCoverage} subagent coverage.`}
+        </p>
+      )}
+    </div>
   );
 }

--- a/src/client/Overview.tsx
+++ b/src/client/Overview.tsx
@@ -1,4 +1,3 @@
-import type { ReactNode } from "react";
 import type { OverviewResponse } from "../shared/sessionSchemas.ts";
 
 const integer = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
@@ -42,14 +41,12 @@ function modelName(model: string) {
 
 function MetricRow({
   label,
-  description,
   values,
   format = decimal.format,
   partial = false,
   tooltip,
 }: {
   label: string;
-  description?: string;
   values?: Distribution;
   format?: (value: number) => string;
   partial?: boolean;
@@ -63,215 +60,11 @@ function MetricRow({
   );
   return (
     <tr>
-      <th scope="row" title={tooltip}>
-        {label}
-        {description && <small>{description}</small>}
-      </th>
+      <th scope="row" title={tooltip}>{label}</th>
       <td>{values ? value(values.median) : "-"}</td>
       <td>{values ? value(values.average) : "-"}</td>
       <td>{values ? value(values.p90) : "-"}</td>
     </tr>
-  );
-}
-
-function MetricTable({
-  title,
-  children,
-}: {
-  title: string;
-  children: ReactNode;
-}) {
-  return (
-    <div className="overview-table-block">
-      <h3>{title}</h3>
-      <div className="overview-table-wrap">
-        <table className="overview-table">
-          <thead>
-            <tr>
-              <th>Metric</th>
-              <th>Median</th>
-              <th>Average</th>
-              <th>P90</th>
-            </tr>
-          </thead>
-          <tbody>{children}</tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-export function Overview({
-  data,
-  error,
-}: {
-  data?: OverviewResponse;
-  error?: string;
-}) {
-  return (
-    <section className="overview-panel">
-      <div className="overview-heading">
-        <div>
-          <p className="eyebrow">Working profile</p>
-          <h2>Overview</h2>
-        </div>
-        <span>Last 90 days</span>
-      </div>
-      {error && <div className="overview-message">{error}</div>}
-      {!data && !error && (
-        <div className="overview-message">Loading overview...</div>
-      )}
-      {data && (
-        <>
-          <div className="overview-summary">
-            <div>
-              <strong>{integer.format(data.activeDays)}</strong>
-              <span>Active days</span>
-            </div>
-            <div>
-              <strong>{integer.format(data.activeWeekdays)}</strong>
-              <span>Active weekdays</span>
-            </div>
-            <div>
-              <strong>{integer.format(data.weekendDays)}</strong>
-              <span>Weekend days</span>
-            </div>
-            <div>
-              <strong>{percent(data.weekdayActivityRate)}</strong>
-              <span>Weekday activity</span>
-            </div>
-            <div>
-              <strong>{integer.format(data.sessions)}</strong>
-              <span>Sessions worked on</span>
-            </div>
-          </div>
-
-          <div className="overview-matrices">
-            <MetricTable title="Activity per active day">
-              <MetricRow
-                label="Sessions worked on"
-                values={data.activity.sessions}
-              />
-              <MetricRow
-                label="Peak concurrent sessions"
-                values={data.activity.peakConcurrentSessions}
-                tooltip={`Distribution of each active day's peak root sessions executing or within ${data.rotationInactivityMinutes} minutes after recorded completion`}
-              />
-              <MetricRow label="Turns" values={data.activity.turns} />
-              <MetricRow
-                label="Spend"
-                values={data.activity.spend}
-                format={currency.format}
-                partial={data.activity.hasUnpricedCost}
-              />
-            </MetricTable>
-            <MetricTable title="Session profile">
-              <MetricRow label="Turns" values={data.sessionProfile.turns} />
-              <MetricRow
-                label="Input processed"
-                values={data.sessionProfile.input}
-                format={compact.format}
-              />
-              <MetricRow
-                label="Peak context"
-                values={data.sessionProfile.peakContext}
-                format={compact.format}
-              />
-              <MetricRow
-                label="Session duration"
-                description="First turn to final model call"
-                values={data.sessionProfile.elapsed}
-                format={duration}
-              />
-              <MetricRow
-                label="Spend"
-                values={data.sessionProfile.spend}
-                format={currency.format}
-                partial={data.sessionProfile.hasUnpricedCost}
-              />
-              <MetricRow
-                label="Efficiency"
-                values={data.sessionProfile.efficiency}
-                format={percent}
-              />
-            </MetricTable>
-          </div>
-
-          <div className="overview-secondary">
-            <div>
-              <span>Overall efficiency</span>
-              <strong>{percent(data.sessionProfile.overallEfficiency)}</strong>
-              <small>Token-weighted reuse</small>
-            </div>
-            <div>
-              <span>Multi-day sessions</span>
-              <strong>{percent(data.multiDaySessionRate)}</strong>
-              <small>{integer.format(data.multiDaySessions)} sessions</small>
-            </div>
-            <div>
-              <span>Average active span</span>
-              <strong>{days(data.averageActiveSpan)}</strong>
-              <small>Distinct dates per session</small>
-            </div>
-          </div>
-
-          <div className="overview-models">
-            <h3>Top models by spend</h3>
-            <div className="overview-table-wrap">
-              <table className="overview-table model-table">
-                <thead>
-                  <tr>
-                    <th>Model</th>
-                    <th>Spend</th>
-                    <th>Share</th>
-                    <th>Input</th>
-                    <th>Sessions</th>
-                    <th>Efficiency</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {data.models.map((model) => (
-                    <tr key={`${model.model}:${model.isOther}`}>
-                      <th scope="row" title={model.model}>
-                        {modelName(model.model)}
-                      </th>
-                      <td>
-                        {currency.format(model.spend)}
-                        {model.hasUnpricedCost && (
-                          <sup title="Some calls could not be priced">*</sup>
-                        )}
-                      </td>
-                      <td>{percent(model.spendShare)}</td>
-                      <td title={integer.format(model.input)}>
-                        {compact.format(model.input)}
-                      </td>
-                      <td>{integer.format(model.sessions)}</td>
-                      <td>{percent(model.efficiency)}</td>
-                    </tr>
-                  ))}
-                </tbody>
-              </table>
-            </div>
-          </div>
-
-          {(data.activity.hasUnpricedCost ||
-            data.subagentCoverage !== "full") && (
-            <p className="overview-note">
-              {data.activity.hasUnpricedCost && (
-                <span>Spend and spend share use known prices only.</span>
-              )}
-              {data.subagentCoverage !== "full" &&
-                (
-                  <span>
-                    Subagent coverage is {data.subagentCoverage}{" "}
-                    for this harness selection.
-                  </span>
-                )}
-            </p>
-          )}
-        </>
-      )}
-    </section>
   );
 }
 
@@ -423,13 +216,12 @@ export function CompactOverview({
           {data.activity.hasUnpricedCost && (
             <span>* Spend and spend share use known prices only.</span>
           )}
-          {data.subagentCoverage !== "full" &&
-            (
-              <span>
-                Subagent coverage is {data.subagentCoverage}{" "}
-                for this harness selection.
-              </span>
-            )}
+          {data.subagentCoverage !== "full" && (
+            <span>
+              Subagent coverage is {data.subagentCoverage}{" "}
+              for this harness selection.
+            </span>
+          )}
         </p>
       )}
     </div>

--- a/src/client/Overview.tsx
+++ b/src/client/Overview.tsx
@@ -92,15 +92,14 @@ export function CompactOverview({
         </div>
         <div>
           <strong>{integer.format(data.sessions)}</strong>
-          <span>Sessions worked on</span>
+          <span>Sessions</span>
         </div>
         <div>
           <strong>
             {currency.format(knownSpend)}
             {hasUnpricedSpend && <sup>*</sup>}
           </strong>
-          <span>Spend</span>
-          <small>Known-price total</small>
+          <span>Known-price spend</span>
         </div>
         <div>
           <strong>{percent(data.sessionProfile.overallEfficiency)}</strong>
@@ -114,8 +113,8 @@ export function CompactOverview({
         </div>
         <div>
           <strong>{days(data.averageActiveSpan)}</strong>
-          <span>Active span</span>
-          <small>Avg distinct dates / session</small>
+          <span>Avg active days</span>
+          <small>Distinct dates / session</small>
         </div>
       </div>
       <div className="compact-overview-table">

--- a/src/client/Overview.tsx
+++ b/src/client/Overview.tsx
@@ -28,7 +28,8 @@ function duration(value: number) {
 }
 
 function days(value: number) {
-  return `${decimal.format(value)} ${value === 1 ? "day" : "days"}`;
+  const formatted = decimal.format(value);
+  return `${formatted} ${formatted === decimal.format(1) ? "day" : "days"}`;
 }
 
 function modelName(model: string) {
@@ -82,59 +83,50 @@ export function CompactOverview({
   return (
     <div className="compact-overview">
       <div className="compact-overview-summary">
-        <div>
+        <div
+          title={`${integer.format(data.activeWeekdays)} weekdays, ${
+            integer.format(data.weekendDays)
+          } weekend days`}
+        >
           <strong>{integer.format(data.activeDays)}</strong>
           <span>Active days</span>
-          <small>
-            {integer.format(data.activeWeekdays)} weekdays ·{" "}
-            {integer.format(data.weekendDays)} weekend
-          </small>
         </div>
         <div>
           <strong>{integer.format(data.sessions)}</strong>
           <span>Sessions</span>
         </div>
-        <div>
+        <div title="Spend using known model prices">
           <strong>
             {currency.format(knownSpend)}
             {hasUnpricedSpend && <sup>*</sup>}
           </strong>
           <span>Known-price spend</span>
         </div>
-        <div>
+        <div title="Token-weighted efficiency">
           <strong>{percent(data.sessionProfile.overallEfficiency)}</strong>
           <span>Token reuse</span>
-          <small>Weighted efficiency</small>
         </div>
-        <div>
+        <div title={`${integer.format(data.multiDaySessions)} sessions`}>
           <strong>{percent(data.multiDaySessionRate)}</strong>
           <span>Multi-day</span>
-          <small>{integer.format(data.multiDaySessions)} sessions</small>
         </div>
-        <div>
+        <div title="Average distinct active dates per session">
           <strong>{days(data.averageActiveSpan)}</strong>
-          <span>Avg active days</span>
-          <small>Distinct dates / session</small>
+          <span>Days / session</span>
         </div>
       </div>
       <div className="compact-overview-table">
         <table className="overview-table">
           <thead>
             <tr>
-              <th>Metric</th>
+              <th>Activity / active day</th>
               <th>P50</th>
               <th>Avg</th>
               <th>P90</th>
             </tr>
           </thead>
           <tbody>
-            <tr className="compact-metric-group">
-              <th colSpan={4}>Activity per active day</th>
-            </tr>
-            <MetricRow
-              label="Sessions worked on"
-              values={data.activity.sessions}
-            />
+            <MetricRow label="Sessions" values={data.activity.sessions} />
             <MetricRow
               label="Peak concurrent sessions"
               values={data.activity.peakConcurrentSessions}
@@ -183,10 +175,8 @@ export function CompactOverview({
       </div>
       {data.models.length > 0 && (
         <div className="compact-models">
-          <h3>Top models by spend</h3>
-          <div className="compact-model-header">
-            <span>Model</span>
-            <i />
+          <div className="compact-model-heading">
+            <h3>Top models by spend</h3>
             <small>Share</small>
             <strong>Spend</strong>
           </div>
@@ -212,15 +202,12 @@ export function CompactOverview({
       )}
       {(data.activity.hasUnpricedCost || data.subagentCoverage !== "full") && (
         <p className="compact-overview-note">
-          {data.activity.hasUnpricedCost && (
-            <span>* Spend and spend share use known prices only.</span>
-          )}
-          {data.subagentCoverage !== "full" && (
-            <span>
-              Subagent coverage is {data.subagentCoverage}{" "}
-              for this harness selection.
-            </span>
-          )}
+          {data.activity.hasUnpricedCost &&
+            "* Spend and share use known prices"}
+          {data.activity.hasUnpricedCost && data.subagentCoverage !== "full" &&
+            " · "}
+          {data.subagentCoverage === "partial" && "Partial subagent coverage"}
+          {data.subagentCoverage === "none" && "No subagent coverage"}
         </p>
       )}
     </div>

--- a/src/client/Overview.tsx
+++ b/src/client/Overview.tsx
@@ -100,7 +100,7 @@ export function CompactOverview({
             {currency.format(knownSpend)}
             {hasUnpricedSpend && <sup>*</sup>}
           </strong>
-          <span>Known-price spend</span>
+          <span>Priced spend</span>
         </div>
         <div title="Token-weighted efficiency">
           <strong>{percent(data.sessionProfile.overallEfficiency)}</strong>
@@ -119,7 +119,7 @@ export function CompactOverview({
         <table className="overview-table">
           <thead>
             <tr>
-              <th>Activity / active day</th>
+              <th>Activity per active day</th>
               <th>P50</th>
               <th>Avg</th>
               <th>P90</th>
@@ -142,7 +142,10 @@ export function CompactOverview({
             <tr className="compact-metric-group">
               <th colSpan={4}>Session profile</th>
             </tr>
-            <MetricRow label="Turns" values={data.sessionProfile.turns} />
+            <MetricRow
+              label="Turns / session"
+              values={data.sessionProfile.turns}
+            />
             <MetricRow
               label="Input processed"
               values={data.sessionProfile.input}
@@ -160,7 +163,7 @@ export function CompactOverview({
               tooltip="First turn to final model call"
             />
             <MetricRow
-              label="Spend"
+              label="Spend / session"
               values={data.sessionProfile.spend}
               format={currency.format}
               partial={data.sessionProfile.hasUnpricedCost}

--- a/src/client/Overview.tsx
+++ b/src/client/Overview.tsx
@@ -1,0 +1,267 @@
+import { type ReactNode, useEffect, useState } from "react";
+import type { OverviewResponse } from "../shared/sessionSchemas.ts";
+import { getOverview } from "./api.ts";
+
+const integer = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
+const decimal = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+const compact = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+const currency = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  maximumFractionDigits: 2,
+});
+
+type Distribution = NonNullable<
+  OverviewResponse["sessionProfile"]["turns"]
+>;
+
+function percent(value?: number) {
+  return value === undefined ? "-" : `${decimal.format(value * 100)}%`;
+}
+
+function duration(value: number) {
+  const minutes = value / 60_000;
+  if (minutes < 1) return `${integer.format(value / 1_000)} sec`;
+  if (minutes < 60) return `${decimal.format(minutes)} min`;
+  return `${decimal.format(minutes / 60)} hr`;
+}
+
+function modelName(model: string) {
+  if (model === "Other") return model;
+  return model.replace(/[-_]20\d{6}$/, "").split(/[-_]/).map((part) => {
+    if (part.toLowerCase() === "gpt") return "GPT";
+    return part.length === 0 ? part : part[0].toUpperCase() + part.slice(1);
+  }).join(" ");
+}
+
+function MetricRow({
+  label,
+  description,
+  values,
+  format = decimal.format,
+}: {
+  label: string;
+  description?: string;
+  values?: Distribution;
+  format?: (value: number) => string;
+}) {
+  return (
+    <tr>
+      <th scope="row">
+        {label}
+        {description && <small>{description}</small>}
+      </th>
+      <td>{values ? format(values.average) : "-"}</td>
+      <td>{values ? format(values.median) : "-"}</td>
+      <td>{values ? format(values.p90) : "-"}</td>
+    </tr>
+  );
+}
+
+function MetricTable({
+  title,
+  children,
+}: {
+  title: string;
+  children: ReactNode;
+}) {
+  return (
+    <div className="overview-table-block">
+      <h3>{title}</h3>
+      <div className="overview-table-wrap">
+        <table className="overview-table">
+          <thead>
+            <tr>
+              <th>Metric</th>
+              <th>Average</th>
+              <th>Median</th>
+              <th>P90</th>
+            </tr>
+          </thead>
+          <tbody>{children}</tbody>
+        </table>
+      </div>
+    </div>
+  );
+}
+
+export function Overview({ harness }: { harness: string }) {
+  const [data, setData] = useState<OverviewResponse>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let active = true;
+    setData(undefined);
+    setError(undefined);
+    getOverview(90, harness).then((result) => active && setData(result)).catch(
+      (reason) => {
+        if (active) {
+          setError(
+            reason instanceof Error
+              ? reason.message
+              : "Unable to load overview",
+          );
+        }
+      },
+    );
+    return () => {
+      active = false;
+    };
+  }, [harness]);
+
+  return (
+    <section className="overview-panel">
+      <div className="overview-heading">
+        <div>
+          <p className="eyebrow">Working profile</p>
+          <h2>Overview</h2>
+        </div>
+        <span>Last 90 days</span>
+      </div>
+      {error && <div className="overview-message">{error}</div>}
+      {!data && !error && (
+        <div className="overview-message">Loading overview...</div>
+      )}
+      {data && (
+        <>
+          <div className="overview-summary">
+            <div>
+              <strong>{integer.format(data.activeDays)}</strong>
+              <span>Active days</span>
+            </div>
+            <div>
+              <strong>{integer.format(data.activeWeekdays)}</strong>
+              <span>Active weekdays</span>
+            </div>
+            <div>
+              <strong>{integer.format(data.weekendDays)}</strong>
+              <span>Weekend days</span>
+            </div>
+            <div>
+              <strong>{percent(data.weekdayActivityRate)}</strong>
+              <span>Weekday activity</span>
+            </div>
+            <div>
+              <strong>{integer.format(data.sessions)}</strong>
+              <span>Sessions worked on</span>
+            </div>
+          </div>
+
+          <div className="overview-matrices">
+            <MetricTable title="Activity per active day">
+              <MetricRow
+                label="Sessions worked on"
+                values={data.activity.sessions}
+              />
+              <MetricRow label="Turns" values={data.activity.turns} />
+              <MetricRow
+                label="Spend"
+                values={data.activity.spend}
+                format={currency.format}
+              />
+            </MetricTable>
+            <MetricTable title="Session profile">
+              <MetricRow label="Turns" values={data.sessionProfile.turns} />
+              <MetricRow
+                label="Input processed"
+                values={data.sessionProfile.input}
+                format={compact.format}
+              />
+              <MetricRow
+                label="Peak context"
+                values={data.sessionProfile.peakContext}
+                format={compact.format}
+              />
+              <MetricRow
+                label="Elapsed duration"
+                description="First turn to final model call"
+                values={data.sessionProfile.elapsed}
+                format={duration}
+              />
+              <MetricRow
+                label="Spend"
+                values={data.sessionProfile.spend}
+                format={currency.format}
+              />
+              <MetricRow
+                label="Efficiency"
+                values={data.sessionProfile.efficiency}
+                format={percent}
+              />
+            </MetricTable>
+          </div>
+
+          <div className="overview-secondary">
+            <div>
+              <span>Overall efficiency</span>
+              <strong>{percent(data.sessionProfile.overallEfficiency)}</strong>
+              <small>Token-weighted reuse</small>
+            </div>
+            <div>
+              <span>Multi-day sessions</span>
+              <strong>{percent(data.multiDaySessionRate)}</strong>
+              <small>{integer.format(data.multiDaySessions)} sessions</small>
+            </div>
+            <div>
+              <span>Average active span</span>
+              <strong>{decimal.format(data.averageActiveSpan)} days</strong>
+              <small>Distinct dates per session</small>
+            </div>
+          </div>
+
+          <div className="overview-models">
+            <h3>Top models by spend</h3>
+            <div className="overview-table-wrap">
+              <table className="overview-table model-table">
+                <thead>
+                  <tr>
+                    <th>Model</th>
+                    <th>Spend</th>
+                    <th>Share</th>
+                    <th>Input</th>
+                    <th>Sessions</th>
+                    <th>Efficiency</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.models.map((model) => (
+                    <tr key={`${model.model}:${model.isOther}`}>
+                      <th scope="row" title={model.model}>
+                        {modelName(model.model)}
+                      </th>
+                      <td>
+                        {currency.format(model.spend)}
+                        {model.hasUnpricedCost && (
+                          <sup title="Some calls could not be priced">*</sup>
+                        )}
+                      </td>
+                      <td>{percent(model.spendShare)}</td>
+                      <td title={integer.format(model.input)}>
+                        {compact.format(model.input)}
+                      </td>
+                      <td>{integer.format(model.sessions)}</td>
+                      <td>{percent(model.efficiency)}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </div>
+
+          {(data.activity.hasUnpricedCost ||
+            data.subagentCoverage !== "full") && (
+            <p className="overview-note">
+              {data.activity.hasUnpricedCost &&
+                "Spend per day is unavailable when calls cannot be priced; session spend excludes those sessions. "}
+              {data.subagentCoverage !== "full" &&
+                `Subagent coverage is ${data.subagentCoverage} for this harness selection.`}
+            </p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/src/client/Overview.tsx
+++ b/src/client/Overview.tsx
@@ -152,6 +152,11 @@ export function Overview({
                 label="Sessions worked on"
                 values={data.activity.sessions}
               />
+              <MetricRow
+                label="Peak concurrent sessions"
+                values={data.activity.peakConcurrentSessions}
+                tooltip={`Distribution of each active day's peak root sessions executing or within ${data.rotationInactivityMinutes} minutes after recorded completion`}
+              />
               <MetricRow label="Turns" values={data.activity.turns} />
               <MetricRow
                 label="Spend"
@@ -337,6 +342,11 @@ export function CompactOverview({
             <MetricRow
               label="Sessions worked on"
               values={data.activity.sessions}
+            />
+            <MetricRow
+              label="Peak concurrent sessions"
+              values={data.activity.peakConcurrentSessions}
+              tooltip={`Distribution of each active day's peak root sessions executing or within ${data.rotationInactivityMinutes} minutes after recorded completion`}
             />
             <MetricRow label="Turns" values={data.activity.turns} />
             <MetricRow

--- a/src/client/Overview.tsx
+++ b/src/client/Overview.tsx
@@ -28,6 +28,10 @@ function duration(value: number) {
   return `${decimal.format(minutes / 60)} hr`;
 }
 
+function days(value: number) {
+  return `${decimal.format(value)} ${value === 1 ? "day" : "days"}`;
+}
+
 function modelName(model: string) {
   if (model === "Other") return model;
   return model.replace(/[-_]20\d{6}$/, "").split(/[-_]/).map((part) => {
@@ -42,14 +46,14 @@ function MetricRow({
   values,
   format = decimal.format,
   partial = false,
-  sectionStart = false,
+  tooltip,
 }: {
   label: string;
   description?: string;
   values?: Distribution;
   format?: (value: number) => string;
   partial?: boolean;
-  sectionStart?: boolean;
+  tooltip?: string;
 }) {
   const value = (number: number) => (
     <>
@@ -58,8 +62,8 @@ function MetricRow({
     </>
   );
   return (
-    <tr className={sectionStart ? "section-start" : undefined}>
-      <th scope="row">
+    <tr>
+      <th scope="row" title={tooltip}>
         {label}
         {description && <small>{description}</small>}
       </th>
@@ -169,7 +173,7 @@ export function Overview({
                 format={compact.format}
               />
               <MetricRow
-                label="Elapsed duration"
+                label="Session duration"
                 description="First turn to final model call"
                 values={data.sessionProfile.elapsed}
                 format={duration}
@@ -201,7 +205,7 @@ export function Overview({
             </div>
             <div>
               <span>Average active span</span>
-              <strong>{decimal.format(data.averageActiveSpan)} days</strong>
+              <strong>{days(data.averageActiveSpan)}</strong>
               <small>Distinct dates per session</small>
             </div>
           </div>
@@ -248,10 +252,16 @@ export function Overview({
           {(data.activity.hasUnpricedCost ||
             data.subagentCoverage !== "full") && (
             <p className="overview-note">
-              {data.activity.hasUnpricedCost &&
-                "Spend statistics use known prices only. "}
+              {data.activity.hasUnpricedCost && (
+                <span>Spend and spend share use known prices only.</span>
+              )}
               {data.subagentCoverage !== "full" &&
-                `Subagent coverage is ${data.subagentCoverage} for this harness selection.`}
+                (
+                  <span>
+                    Subagent coverage is {data.subagentCoverage}{" "}
+                    for this harness selection.
+                  </span>
+                )}
             </p>
           )}
         </>
@@ -284,8 +294,7 @@ export function CompactOverview({
         </div>
         <div>
           <strong>{integer.format(data.sessions)}</strong>
-          <span>Sessions</span>
-          <small>Worked on</small>
+          <span>Sessions worked on</span>
         </div>
         <div>
           <strong>
@@ -293,7 +302,7 @@ export function CompactOverview({
             {hasUnpricedSpend && <sup>*</sup>}
           </strong>
           <span>Spend</span>
-          <small>Known prices</small>
+          <small>Known-price total</small>
         </div>
         <div>
           <strong>{percent(data.sessionProfile.overallEfficiency)}</strong>
@@ -306,9 +315,9 @@ export function CompactOverview({
           <small>{integer.format(data.multiDaySessions)} sessions</small>
         </div>
         <div>
-          <strong>{decimal.format(data.averageActiveSpan)} days</strong>
-          <span>Avg active span</span>
-          <small>Distinct dates</small>
+          <strong>{days(data.averageActiveSpan)}</strong>
+          <span>Active span</span>
+          <small>Avg distinct dates / session</small>
         </div>
       </div>
       <div className="compact-overview-table">
@@ -322,27 +331,26 @@ export function CompactOverview({
             </tr>
           </thead>
           <tbody>
+            <tr className="compact-metric-group">
+              <th colSpan={4}>Activity per active day</th>
+            </tr>
             <MetricRow
-              label="Sessions / active day"
+              label="Sessions worked on"
               values={data.activity.sessions}
             />
+            <MetricRow label="Turns" values={data.activity.turns} />
             <MetricRow
-              label="Turns / active day"
-              values={data.activity.turns}
-            />
-            <MetricRow
-              label="Spend / active day"
+              label="Spend"
               values={data.activity.spend}
               format={currency.format}
               partial={data.activity.hasUnpricedCost}
             />
+            <tr className="compact-metric-group">
+              <th colSpan={4}>Session profile</th>
+            </tr>
+            <MetricRow label="Turns" values={data.sessionProfile.turns} />
             <MetricRow
-              label="Turns / session"
-              values={data.sessionProfile.turns}
-              sectionStart
-            />
-            <MetricRow
-              label="Input / session"
+              label="Input processed"
               values={data.sessionProfile.input}
               format={compact.format}
             />
@@ -352,12 +360,13 @@ export function CompactOverview({
               format={compact.format}
             />
             <MetricRow
-              label="Elapsed duration"
+              label="Session duration"
               values={data.sessionProfile.elapsed}
               format={duration}
+              tooltip="First turn to final model call"
             />
             <MetricRow
-              label="Spend / session"
+              label="Spend"
               values={data.sessionProfile.spend}
               format={currency.format}
               partial={data.sessionProfile.hasUnpricedCost}
@@ -373,6 +382,12 @@ export function CompactOverview({
       {data.models.length > 0 && (
         <div className="compact-models">
           <h3>Top models by spend</h3>
+          <div className="compact-model-header">
+            <span>Model</span>
+            <i />
+            <small>Share</small>
+            <strong>Spend</strong>
+          </div>
           <div className="compact-model-list">
             {data.models.map((model) => (
               <div
@@ -395,9 +410,16 @@ export function CompactOverview({
       )}
       {(data.activity.hasUnpricedCost || data.subagentCoverage !== "full") && (
         <p className="compact-overview-note">
-          {data.activity.hasUnpricedCost && "* Known priced spend only. "}
+          {data.activity.hasUnpricedCost && (
+            <span>* Spend and spend share use known prices only.</span>
+          )}
           {data.subagentCoverage !== "full" &&
-            `${data.subagentCoverage} subagent coverage.`}
+            (
+              <span>
+                Subagent coverage is {data.subagentCoverage}{" "}
+                for this harness selection.
+              </span>
+            )}
         </p>
       )}
     </div>

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -18,6 +18,7 @@ import openCodeIcon from "./assets/icons/opencode-logo-light.svg";
 import piIcon from "./assets/icons/pi-logo.svg";
 import { UsageChart } from "./UsageChart.tsx";
 import { TtlMissCard } from "./TtlMissCard.tsx";
+import { Overview } from "./Overview.tsx";
 
 const route = getRouteApi("/");
 const integer = new Intl.NumberFormat("en-US");
@@ -1677,6 +1678,8 @@ export function SessionsPage() {
           See where tokens went, what was reused, and what each model call cost.
         </p>
       </header>
+
+      <Overview harness={harness} />
 
       <div className="homepage-metrics">
         <TtlMissCard harness={harness} />

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -5,13 +5,14 @@ import type {
   CacheIssue,
   CacheSummary,
   ModelCall,
+  OverviewResponse,
   SessionDetail,
   SessionListResponse,
   SessionSummary,
   TokenUsage,
 } from "../shared/sessionSchemas.ts";
 import { contextRange, contextSize } from "../shared/contextMetrics.ts";
-import { getSession, getSessions } from "./api.ts";
+import { getOverview, getSession, getSessions } from "./api.ts";
 import claudeCodeIcon from "./assets/icons/claudecode-color.svg";
 import codexIcon from "./assets/icons/codex-logo-light.svg";
 import openCodeIcon from "./assets/icons/opencode-logo-light.svg";
@@ -1543,6 +1544,8 @@ export function SessionsPage() {
   const { harness } = route.useSearch();
   const navigate = route.useNavigate();
   const [data, setData] = useState<SessionListResponse>();
+  const [overview, setOverview] = useState<OverviewResponse>();
+  const [overviewError, setOverviewError] = useState<string>();
   const [expandedIDs, setExpandedIDs] = useState<Set<string>>(
     () => new Set(),
   );
@@ -1554,6 +1557,25 @@ export function SessionsPage() {
   const loadingMoreRef = useRef(false);
   const harnessRef = useRef(harness);
   harnessRef.current = harness;
+
+  useEffect(() => {
+    let active = true;
+    setOverview(undefined);
+    setOverviewError(undefined);
+    getOverview(90, harness).then((result) => active && setOverview(result))
+      .catch((reason) => {
+        if (active) {
+          setOverviewError(
+            reason instanceof Error
+              ? reason.message
+              : "Unable to load overview",
+          );
+        }
+      });
+    return () => {
+      active = false;
+    };
+  }, [harness]);
 
   useEffect(() => {
     let active = true;
@@ -1679,10 +1701,14 @@ export function SessionsPage() {
         </p>
       </header>
 
-      <Overview harness={harness} />
+      <Overview data={overview} error={overviewError} />
 
       <div className="homepage-metrics">
-        <TtlMissCard harness={harness} />
+        <TtlMissCard
+          harness={harness}
+          overview={overview}
+          overviewError={overviewError}
+        />
         <UsageChart harness={harness} />
       </div>
 

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -19,7 +19,6 @@ import openCodeIcon from "./assets/icons/opencode-logo-light.svg";
 import piIcon from "./assets/icons/pi-logo.svg";
 import { UsageChart } from "./UsageChart.tsx";
 import { TtlMissCard } from "./TtlMissCard.tsx";
-import { Overview } from "./Overview.tsx";
 
 const route = getRouteApi("/");
 const integer = new Intl.NumberFormat("en-US");
@@ -1700,8 +1699,6 @@ export function SessionsPage() {
           See where tokens went, what was reused, and what each model call cost.
         </p>
       </header>
-
-      <Overview data={overview} error={overviewError} />
 
       <div className="homepage-metrics">
         <TtlMissCard

--- a/src/client/TtlMissCard.tsx
+++ b/src/client/TtlMissCard.tsx
@@ -1,6 +1,10 @@
 import { useEffect, useState } from "react";
-import type { TtlMissMetrics } from "../shared/sessionSchemas.ts";
+import type {
+  OverviewResponse,
+  TtlMissMetrics,
+} from "../shared/sessionSchemas.ts";
 import { getTtlMissMetrics } from "./api.ts";
+import { CompactOverview } from "./Overview.tsx";
 
 const integer = new Intl.NumberFormat();
 const compactInteger = new Intl.NumberFormat(undefined, {
@@ -22,8 +26,16 @@ function share(value: number, total: number) {
   return percent.format(total === 0 ? 0 : value / total);
 }
 
-export function TtlMissCard({ harness }: { harness: string }) {
-  const [view, setView] = useState<"ttl" | "cost">("ttl");
+export function TtlMissCard({
+  harness,
+  overview,
+  overviewError,
+}: {
+  harness: string;
+  overview?: OverviewResponse;
+  overviewError?: string;
+}) {
+  const [view, setView] = useState<"overview" | "ttl" | "cost">("overview");
   const [metrics, setMetrics] = useState<TtlMissMetrics>();
   const [error, setError] = useState<string>();
 
@@ -48,13 +60,27 @@ export function TtlMissCard({ harness }: { harness: string }) {
   }, [harness]);
 
   return (
-    <section className="ttl-miss-card" aria-label="Cache efficiency">
+    <section
+      className={`ttl-miss-card${
+        view === "overview" ? " overview-active" : ""
+      }`}
+      aria-label="Overview and cache efficiency"
+    >
       <div className="ttl-analytics-toolbar">
         <div
           className="chart-tabs"
           role="tablist"
-          aria-label="Cache efficiency view"
+          aria-label="Overview and cache efficiency view"
         >
+          <button
+            type="button"
+            role="tab"
+            aria-selected={view === "overview"}
+            className={view === "overview" ? "active" : undefined}
+            onClick={() => setView("overview")}
+          >
+            Overview
+          </button>
           <button
             type="button"
             role="tab"
@@ -76,10 +102,15 @@ export function TtlMissCard({ harness }: { harness: string }) {
         </div>
         <span>Last 90 days</span>
       </div>
-      {!metrics && !error && (
+      {view === "overview" && (
+        <CompactOverview data={overview} error={overviewError} />
+      )}
+      {view !== "overview" && !metrics && !error && (
         <div className="ttl-miss-message">Analyzing session gaps...</div>
       )}
-      {error && <div className="ttl-miss-message chart-error">{error}</div>}
+      {view !== "overview" && error && (
+        <div className="ttl-miss-message chart-error">{error}</div>
+      )}
       {metrics && view === "ttl" && (
         <>
           <div className="ttl-miss-lead">

--- a/src/client/TtlMissCard.tsx
+++ b/src/client/TtlMissCard.tsx
@@ -3,6 +3,10 @@ import type { TtlMissMetrics } from "../shared/sessionSchemas.ts";
 import { getTtlMissMetrics } from "./api.ts";
 
 const integer = new Intl.NumberFormat();
+const compactInteger = new Intl.NumberFormat(undefined, {
+  notation: "compact",
+  maximumFractionDigits: 2,
+});
 const percent = new Intl.NumberFormat(undefined, {
   style: "percent",
   maximumFractionDigits: 1,
@@ -44,7 +48,7 @@ export function TtlMissCard({ harness }: { harness: string }) {
   }, [harness]);
 
   return (
-    <section className="ttl-miss-card" aria-labelledby="ttl-miss-title">
+    <section className="ttl-miss-card" aria-label="Cache efficiency">
       <div className="ttl-analytics-toolbar">
         <div
           className="chart-tabs"
@@ -58,7 +62,7 @@ export function TtlMissCard({ harness }: { harness: string }) {
             className={view === "ttl" ? "active" : undefined}
             onClick={() => setView("ttl")}
           >
-            TTL misses
+            TTL expiry
           </button>
           <button
             type="button"
@@ -72,14 +76,6 @@ export function TtlMissCard({ harness }: { harness: string }) {
         </div>
         <span>Last 90 days</span>
       </div>
-      <div className="ttl-miss-heading">
-        <div>
-          <p className="eyebrow">Cache efficiency</p>
-          <h2 id="ttl-miss-title">
-            {view === "ttl" ? "TTL misses" : "Full and partial misses"}
-          </h2>
-        </div>
-      </div>
       {!metrics && !error && (
         <div className="ttl-miss-message">Analyzing session gaps...</div>
       )}
@@ -89,44 +85,32 @@ export function TtlMissCard({ harness }: { harness: string }) {
           <div className="ttl-miss-lead">
             <strong>{integer.format(metrics.affectedSessions)}</strong>
             <div>
-              <span>of {integer.format(metrics.sessions)} sessions</span>
+              <span>affected root sessions</span>
               <b>
-                {share(metrics.affectedSessions, metrics.sessions)} affected
+                {share(metrics.affectedSessions, metrics.sessions)} of{" "}
+                {integer.format(metrics.sessions)} analyzed
               </b>
             </div>
           </div>
           <div className="ttl-cost-summary">
             <div>
-              <span>All spend in range</span>
-              <strong>{money.format(metrics.totalCost)}</strong>
-              <small>
-                Root + subagents
-                {metrics.hasUnpricedTotalCost ? " · known prices only" : ""}
-              </small>
-            </div>
-            <div>
-              <span>Root spend analyzed</span>
+              <span>Root-session spend</span>
               <strong>{money.format(metrics.totalSessionCost)}</strong>
               <small>
-                {share(metrics.totalSessionCost, metrics.totalCost)}{" "}
-                of all spend
-                {metrics.hasUnpricedSessionCost ? " · known prices only" : ""}
+                {share(metrics.totalSessionCost, metrics.totalCost)} of total
               </small>
             </div>
             <div>
-              <span>Affected root-session spend</span>
+              <span>Affected-session spend</span>
               <strong>{money.format(metrics.affectedSessionCost)}</strong>
               <small>
                 {share(metrics.affectedSessionCost, metrics.totalSessionCost)}
                 {" "}
                 of root spend
-                {metrics.hasUnpricedAffectedSessionCost
-                  ? " · known prices only"
-                  : ""}
               </small>
             </div>
             <div>
-              <span>Estimated TTL-attributed cost</span>
+              <span>Attributed TTL miss cost</span>
               <strong>{money.format(metrics.misses.attributedCost)}</strong>
               <small>
                 {share(
@@ -138,7 +122,7 @@ export function TtlMissCard({ harness }: { harness: string }) {
           </div>
           <div className="ttl-miss-breakdown">
             <div className="ttl-miss-breakdown-title">
-              <span>Root-session gap</span>
+              <span>Root session gap</span>
               <strong>{integer.format(metrics.misses.total)} misses</strong>
             </div>
             {([
@@ -168,11 +152,14 @@ export function TtlMissCard({ harness }: { harness: string }) {
               </div>
             ))}
           </div>
-          {metrics.misses.unpriced > 0 && (
+          {(metrics.hasUnpricedSessionCost || metrics.misses.unpriced > 0) && (
             <p className="ttl-pricing-note">
-              {integer.format(metrics.misses.unpriced)}{" "}
-              miss{metrics.misses.unpriced === 1 ? "" : "es"}{" "}
-              could not be priced.
+              Costs use known prices only
+              {metrics.misses.unpriced > 0
+                ? ` and exclude ${
+                  integer.format(metrics.misses.unpriced)
+                } unpriced miss${metrics.misses.unpriced === 1 ? "" : "es"}`
+                : ""}.
             </p>
           )}
           <div className="ttl-subagent-summary">
@@ -200,45 +187,33 @@ export function TtlMissCard({ harness }: { harness: string }) {
             <div className="ttl-miss-lead">
               <strong>{integer.format(totalMisses)}</strong>
               <div>
-                <span>root-session cache misses</span>
+                <span>cache misses</span>
                 <b>
                   {integer.format(cacheMisses.affectedSessions)} of{" "}
-                  {integer.format(metrics.sessions)} sessions affected
+                  {integer.format(metrics.sessions)} root sessions affected
                 </b>
               </div>
             </div>
             <div className="ttl-cost-summary">
               <div>
-                <span>All spend in range</span>
-                <strong>{money.format(metrics.totalCost)}</strong>
-                <small>
-                  Root + subagents{metrics.hasUnpricedTotalCost
-                    ? " · known prices only"
-                    : ""}
-                </small>
-              </div>
-              <div>
-                <span>Root spend analyzed</span>
+                <span>Root-session spend</span>
                 <strong>{money.format(metrics.totalSessionCost)}</strong>
                 <small>
-                  {share(metrics.totalSessionCost, metrics.totalCost)}{" "}
-                  of all spend
+                  {share(metrics.totalSessionCost, metrics.totalCost)} of total
                 </small>
               </div>
               <div>
-                <span>Affected root-session spend</span>
+                <span>Affected-session spend</span>
                 <strong>{money.format(cacheMisses.affectedSessionCost)}</strong>
                 <small>
                   {share(
                     cacheMisses.affectedSessionCost,
                     metrics.totalSessionCost,
-                  )} of root spend{cacheMisses.hasUnpricedAffectedSessionCost
-                    ? " · known prices only"
-                    : ""}
+                  )} of root spend
                 </small>
               </div>
               <div>
-                <span>Estimated miss-attributed cost</span>
+                <span>Attributed miss cost</span>
                 <strong>{money.format(attributedCost)}</strong>
                 <small>
                   {share(attributedCost, cacheMisses.affectedSessionCost)}{" "}
@@ -263,7 +238,7 @@ export function TtlMissCard({ harness }: { harness: string }) {
                 return (
                   <div className="cache-miss-cost-row" role="row" key={type}>
                     <strong role="cell">
-                      {type === "full" ? "Full misses" : "Partial misses"}
+                      {type === "full" ? "Full" : "Partial"}
                     </strong>
                     <span role="cell">{integer.format(category.misses)}</span>
                     <span role="cell">
@@ -276,25 +251,20 @@ export function TtlMissCard({ harness }: { harness: string }) {
                       {money.format(category.estimatedExtraCost)}
                     </span>
                     <small>
-                      {integer.format(category.missedTokens)}{" "}
-                      reusable tokens missed ·{" "}
-                      {money.format(category.expectedReadCost)}{" "}
-                      expected read cost
+                      {compactInteger.format(category.missedTokens)}{" "}
+                      reusable tokens missed
                     </small>
                   </div>
                 );
               })}
             </div>
-            {unpriced > 0 && (
-              <p className="ttl-pricing-note">
-                {integer.format(unpriced)} miss{unpriced === 1 ? "" : "es"}{" "}
-                could not be priced.
-              </p>
-            )}
             <p className="cache-miss-cost-note">
-              Includes TTL and compaction-related misses. Extra cost compares
-              observed miss billing with the cache-read cost expected for
-              reusable tokens.
+              Includes TTL and compaction-related misses
+              {unpriced > 0
+                ? `. Costs exclude ${integer.format(unpriced)} unpriced miss${
+                  unpriced === 1 ? "" : "es"
+                }`
+                : ""}.
             </p>
           </>
         );

--- a/src/client/TtlMissCard.tsx
+++ b/src/client/TtlMissCard.tsx
@@ -61,9 +61,7 @@ export function TtlMissCard({
 
   return (
     <section
-      className={`ttl-miss-card${
-        view === "overview" ? " overview-active" : ""
-      }`}
+      className="ttl-miss-card"
       aria-label="Overview and cache efficiency"
     >
       <div className="ttl-analytics-toolbar">

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,4 +1,5 @@
 import {
+  overviewResponseSchema,
   sessionDetailSchema,
   sessionListResponseSchema,
   ttlMissMetricsSchema,
@@ -20,6 +21,12 @@ async function getJson(path: string) {
 export async function getUsage(range: number | "all", harness: string) {
   return usageResponseSchema.parse(
     await getJson(`/api/usage?range=${range}&harness=${harness}`),
+  );
+}
+
+export async function getOverview(range: number, harness: string) {
+  return overviewResponseSchema.parse(
+    await getJson(`/api/overview?range=${range}&harness=${harness}`),
   );
 }
 

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -283,7 +283,7 @@ h1 {
 }
 
 .compact-overview-table {
-  padding: 12px 28px 8px;
+  padding: 6px 28px 8px;
 }
 
 .compact-overview-table .overview-table th,
@@ -304,7 +304,7 @@ h1 {
 }
 
 .compact-models {
-  padding: 8px 28px 12px;
+  padding: 4px 28px 12px;
   border-top: 1px solid var(--row-border);
 }
 

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -154,6 +154,211 @@ h1 {
   margin-bottom: 24px;
 }
 
+.overview-panel {
+  margin-bottom: 24px;
+  border: 1px solid var(--panel-border);
+  background: var(--panel);
+  box-shadow: 0 18px 60px rgba(57, 51, 40, .08);
+}
+
+.overview-heading {
+  display: flex;
+  min-height: 72px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 0 28px;
+  border-bottom: 1px solid var(--row-border);
+}
+
+.overview-heading .eyebrow {
+  margin-bottom: 4px;
+  font-size: 9px;
+}
+
+.overview-heading h2 {
+  margin: 0;
+  font-size: 22px;
+  letter-spacing: -.03em;
+}
+
+.overview-heading > span {
+  color: var(--muted);
+  font: 10px var(--mono);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.overview-message {
+  display: grid;
+  min-height: 180px;
+  place-items: center;
+  color: var(--muted);
+  font: 11px var(--mono);
+}
+
+.overview-summary {
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
+  border-bottom: 1px solid var(--row-border);
+}
+
+.overview-summary > div {
+  display: grid;
+  gap: 5px;
+  padding: 18px 28px;
+}
+
+.overview-summary > div + div {
+  border-left: 1px solid var(--row-border);
+}
+
+.overview-summary strong {
+  font: 600 24px/1 var(--mono);
+  letter-spacing: -.04em;
+}
+
+.overview-summary span {
+  color: var(--muted);
+  font: 9px var(--mono);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.overview-matrices {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr);
+  border-bottom: 1px solid var(--row-border);
+}
+
+.overview-table-block {
+  min-width: 0;
+  padding: 22px 28px 25px;
+}
+
+.overview-table-block + .overview-table-block {
+  border-left: 1px solid var(--row-border);
+}
+
+.overview-table-block h3,
+.overview-models h3 {
+  margin: 0 0 12px;
+  color: var(--muted);
+  font: 10px var(--mono);
+  letter-spacing: .06em;
+  text-transform: uppercase;
+}
+
+.overview-table-wrap {
+  min-width: 0;
+  overflow-x: auto;
+}
+
+.overview-table {
+  width: 100%;
+  border-collapse: collapse;
+  font: 11px var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.overview-table th,
+.overview-table td {
+  padding: 8px 10px;
+  border-bottom: 1px solid var(--row-border);
+  text-align: right;
+  white-space: nowrap;
+}
+
+.overview-table thead th {
+  padding-top: 0;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+}
+
+.overview-table th:first-child {
+  width: 100%;
+  padding-left: 0;
+  text-align: left;
+}
+
+.overview-table td:last-child,
+.overview-table th:last-child {
+  padding-right: 0;
+}
+
+.overview-table tbody th {
+  font-weight: 500;
+}
+
+.overview-table tbody th small {
+  display: block;
+  margin-top: 2px;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 400;
+}
+
+.overview-table tbody tr:last-child th,
+.overview-table tbody tr:last-child td {
+  border-bottom: 0;
+}
+
+.overview-secondary {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-bottom: 1px solid var(--row-border);
+  background: var(--surface-1);
+}
+
+.overview-secondary > div {
+  display: grid;
+  grid-template-columns: 1fr auto;
+  gap: 3px 18px;
+  padding: 14px 28px;
+  font-family: var(--mono);
+}
+
+.overview-secondary > div + div {
+  border-left: 1px solid var(--row-border);
+}
+
+.overview-secondary span,
+.overview-secondary small {
+  color: var(--muted);
+  font-size: 9px;
+}
+
+.overview-secondary strong {
+  grid-row: span 2;
+  align-self: center;
+  font-size: 15px;
+}
+
+.overview-models {
+  padding: 22px 28px 25px;
+}
+
+.model-table th:first-child {
+  max-width: 280px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.model-table sup {
+  color: var(--danger);
+}
+
+.overview-note {
+  margin: 0;
+  padding: 11px 28px;
+  border-top: 1px solid var(--row-border);
+  color: var(--muted);
+  font: 9px/1.5 var(--mono);
+}
+
 .homepage-metrics .usage-chart {
   min-width: 0;
   margin-bottom: 0;
@@ -164,16 +369,6 @@ h1 {
   border: 1px solid var(--panel-border);
   background: var(--panel);
   box-shadow: 0 18px 60px rgba(57, 51, 40, .08);
-}
-
-.ttl-miss-heading {
-  display: flex;
-  min-height: 76px;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 20px;
-  padding: 22px 28px 18px;
-  background: var(--surface-1);
 }
 
 .ttl-analytics-toolbar {
@@ -196,16 +391,6 @@ h1 {
   font: 10px var(--mono);
   letter-spacing: .05em;
   text-transform: uppercase;
-}
-
-.ttl-miss-heading .eyebrow {
-  margin-bottom: 5px;
-}
-
-.ttl-miss-heading h2 {
-  margin: 0;
-  font-size: 22px;
-  letter-spacing: -.02em;
 }
 
 .ttl-miss-message {
@@ -246,7 +431,7 @@ h1 {
 
 .ttl-cost-summary {
   display: grid;
-  grid-template-columns: repeat(2, 1fr);
+  grid-template-columns: repeat(3, 1fr);
   margin: 0 28px 18px;
   border: 1px solid var(--row-border);
   background: var(--surface-1);
@@ -261,14 +446,6 @@ h1 {
 
 .ttl-cost-summary > div + div {
   border-left: 1px solid var(--row-border);
-}
-
-.ttl-cost-summary > div:nth-child(n + 3) {
-  border-top: 1px solid var(--row-border);
-}
-
-.ttl-cost-summary > div:nth-child(odd) {
-  border-left: 0;
 }
 
 .ttl-cost-summary span,
@@ -418,6 +595,15 @@ h1 {
     display: none;
   }
 
+  .ttl-cost-summary {
+    grid-template-columns: 1fr;
+  }
+
+  .ttl-cost-summary > div + div {
+    border-top: 1px solid var(--row-border);
+    border-left: 0;
+  }
+
   .cache-miss-cost-header,
   .cache-miss-cost-row {
     grid-template-columns: minmax(90px, 1fr) repeat(2, minmax(66px, .8fr));
@@ -434,6 +620,28 @@ h1 {
 @media (max-width: 1100px) {
   .homepage-metrics {
     grid-template-columns: 1fr;
+  }
+
+  .overview-summary {
+    grid-template-columns: repeat(3, 1fr);
+  }
+
+  .overview-summary > div:nth-child(4) {
+    border-top: 1px solid var(--row-border);
+    border-left: 0;
+  }
+
+  .overview-summary > div:nth-child(5) {
+    border-top: 1px solid var(--row-border);
+  }
+
+  .overview-matrices {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-table-block + .overview-table-block {
+    border-top: 1px solid var(--row-border);
+    border-left: 0;
   }
 }
 
@@ -1994,6 +2202,57 @@ table.data-table {
   .intro {
     margin-top: 20px;
     font-size: 14px;
+  }
+
+  .overview-heading,
+  .overview-table-block,
+  .overview-models {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .overview-summary {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .overview-summary > div {
+    padding: 15px 18px;
+    border-left: 0;
+  }
+
+  .overview-summary > div:nth-child(even) {
+    border-left: 1px solid var(--row-border);
+  }
+
+  .overview-summary > div:nth-child(n + 3) {
+    border-top: 1px solid var(--row-border);
+  }
+
+  .overview-secondary {
+    grid-template-columns: 1fr;
+  }
+
+  .overview-secondary > div {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .overview-secondary > div + div {
+    border-top: 1px solid var(--row-border);
+    border-left: 0;
+  }
+
+  .overview-table {
+    min-width: 430px;
+  }
+
+  .model-table {
+    min-width: 680px;
+  }
+
+  .overview-note {
+    padding-right: 18px;
+    padding-left: 18px;
   }
 
   .panel-heading {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -347,7 +347,7 @@ h1 {
   text-overflow: ellipsis;
 }
 
-.model-table sup {
+.overview-table sup {
   color: var(--danger);
 }
 
@@ -369,6 +369,10 @@ h1 {
   border: 1px solid var(--panel-border);
   background: var(--panel);
   box-shadow: 0 18px 60px rgba(57, 51, 40, .08);
+}
+
+.ttl-miss-card.overview-active {
+  min-height: 650px;
 }
 
 .ttl-analytics-toolbar {
@@ -399,6 +403,138 @@ h1 {
   place-items: center;
   color: var(--muted);
   font: 11px var(--mono);
+}
+
+.compact-overview {
+  font-family: var(--mono);
+}
+
+.compact-overview-summary {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  border-bottom: 1px solid var(--row-border);
+  background: var(--surface-1);
+}
+
+.compact-overview-summary > div {
+  display: grid;
+  gap: 4px;
+  padding: 13px 14px;
+}
+
+.compact-overview-summary > div + div {
+  border-left: 1px solid var(--row-border);
+}
+
+.compact-overview-summary > div:nth-child(n + 4) {
+  border-top: 1px solid var(--row-border);
+}
+
+.compact-overview-summary > div:nth-child(4) {
+  border-left: 0;
+}
+
+.compact-overview-summary strong {
+  font-size: 16px;
+  font-variant-numeric: tabular-nums;
+}
+
+.compact-overview-summary span {
+  color: var(--muted);
+  font-size: 8px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.compact-overview-summary small {
+  overflow: hidden;
+  color: var(--muted);
+  font-size: 8px;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compact-overview-summary sup,
+.compact-model-row sup {
+  color: var(--danger);
+}
+
+.compact-overview-table {
+  padding: 14px 28px 10px;
+}
+
+.compact-overview-table .overview-table th,
+.compact-overview-table .overview-table td {
+  padding-top: 5px;
+  padding-bottom: 5px;
+}
+
+.compact-overview-table .overview-table .section-start th,
+.compact-overview-table .overview-table .section-start td {
+  padding-top: 10px;
+  border-top: 1px solid var(--panel-border);
+}
+
+.compact-models {
+  padding: 8px 28px 12px;
+  border-top: 1px solid var(--row-border);
+}
+
+.compact-models h3 {
+  margin: 0 0 8px;
+  color: var(--muted);
+  font-size: 9px;
+  font-weight: 500;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.compact-model-list {
+  display: grid;
+  gap: 7px;
+}
+
+.compact-model-row {
+  display: grid;
+  grid-template-columns: minmax(95px, 1.4fr) minmax(60px, 1fr) 44px 64px;
+  gap: 9px;
+  align-items: center;
+  font-size: 9px;
+  font-variant-numeric: tabular-nums;
+}
+
+.compact-model-row > span {
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.compact-model-row i {
+  height: 4px;
+  overflow: hidden;
+  background: var(--row-border);
+}
+
+.compact-model-row i b {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+
+.compact-model-row small,
+.compact-model-row strong {
+  text-align: right;
+}
+
+.compact-model-row small {
+  color: var(--muted);
+}
+
+.compact-overview-note {
+  margin: 0;
+  padding: 0 28px 13px;
+  color: var(--muted);
+  font-size: 8px;
 }
 
 .ttl-miss-lead {
@@ -593,6 +729,52 @@ h1 {
 
   .ttl-analytics-toolbar > span {
     display: none;
+  }
+
+  .ttl-analytics-toolbar .chart-tabs {
+    gap: 16px;
+  }
+
+  .compact-overview-summary {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .compact-overview-summary > div:nth-child(3) {
+    border-top: 1px solid var(--row-border);
+    border-left: 0;
+  }
+
+  .compact-overview-summary > div:nth-child(4) {
+    border-top: 1px solid var(--row-border);
+  }
+
+  .compact-overview-summary > div:nth-child(5) {
+    border-top: 1px solid var(--row-border);
+    border-left: 0;
+  }
+
+  .compact-overview-summary > div:nth-child(6) {
+    border-top: 1px solid var(--row-border);
+  }
+
+  .compact-overview-table {
+    padding-right: 18px;
+    padding-left: 18px;
+    overflow-x: auto;
+  }
+
+  .compact-overview-table .overview-table {
+    min-width: 430px;
+  }
+
+  .compact-overview-note {
+    padding-right: 18px;
+    padding-left: 18px;
+  }
+
+  .compact-models {
+    padding-right: 18px;
+    padding-left: 18px;
   }
 
   .ttl-cost-summary {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -154,106 +154,6 @@ h1 {
   margin-bottom: 24px;
 }
 
-.overview-panel {
-  margin-bottom: 24px;
-  border: 1px solid var(--panel-border);
-  background: var(--panel);
-  box-shadow: 0 18px 60px rgba(57, 51, 40, .08);
-}
-
-.overview-heading {
-  display: flex;
-  min-height: 72px;
-  align-items: center;
-  justify-content: space-between;
-  gap: 24px;
-  padding: 0 28px;
-  border-bottom: 1px solid var(--row-border);
-}
-
-.overview-heading .eyebrow {
-  margin-bottom: 4px;
-  font-size: 9px;
-}
-
-.overview-heading h2 {
-  margin: 0;
-  font-size: 22px;
-  letter-spacing: -.03em;
-}
-
-.overview-heading > span {
-  color: var(--muted);
-  font: 10px var(--mono);
-  letter-spacing: .05em;
-  text-transform: uppercase;
-}
-
-.overview-message {
-  display: grid;
-  min-height: 180px;
-  place-items: center;
-  color: var(--muted);
-  font: 11px var(--mono);
-}
-
-.overview-summary {
-  display: grid;
-  grid-template-columns: repeat(5, 1fr);
-  border-bottom: 1px solid var(--row-border);
-}
-
-.overview-summary > div {
-  display: grid;
-  gap: 5px;
-  padding: 18px 28px;
-}
-
-.overview-summary > div + div {
-  border-left: 1px solid var(--row-border);
-}
-
-.overview-summary strong {
-  font: 600 24px/1 var(--mono);
-  letter-spacing: -.04em;
-}
-
-.overview-summary span {
-  color: var(--muted);
-  font: 9px var(--mono);
-  letter-spacing: .04em;
-  text-transform: uppercase;
-}
-
-.overview-matrices {
-  display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1.35fr);
-  border-bottom: 1px solid var(--row-border);
-}
-
-.overview-table-block {
-  min-width: 0;
-  padding: 22px 28px 25px;
-}
-
-.overview-table-block + .overview-table-block {
-  border-left: 1px solid var(--row-border);
-}
-
-.overview-table-block h3,
-.overview-models h3 {
-  margin: 0 0 12px;
-  color: var(--muted);
-  font: 10px var(--mono);
-  letter-spacing: .06em;
-  text-transform: uppercase;
-}
-
-.overview-table-wrap {
-  min-width: 0;
-  overflow-x: auto;
-}
-
 .overview-table {
   width: 100%;
   border-collapse: collapse;
@@ -293,74 +193,13 @@ h1 {
   font-weight: 500;
 }
 
-.overview-table tbody th small {
-  display: block;
-  margin-top: 2px;
-  color: var(--muted);
-  font-size: 9px;
-  font-weight: 400;
-}
-
 .overview-table tbody tr:last-child th,
 .overview-table tbody tr:last-child td {
   border-bottom: 0;
 }
 
-.overview-secondary {
-  display: grid;
-  grid-template-columns: repeat(3, 1fr);
-  border-bottom: 1px solid var(--row-border);
-  background: var(--surface-1);
-}
-
-.overview-secondary > div {
-  display: grid;
-  grid-template-columns: 1fr auto;
-  gap: 3px 18px;
-  padding: 14px 28px;
-  font-family: var(--mono);
-}
-
-.overview-secondary > div + div {
-  border-left: 1px solid var(--row-border);
-}
-
-.overview-secondary span,
-.overview-secondary small {
-  color: var(--muted);
-  font-size: 9px;
-}
-
-.overview-secondary strong {
-  grid-row: span 2;
-  align-self: center;
-  font-size: 15px;
-}
-
-.overview-models {
-  padding: 22px 28px 25px;
-}
-
-.model-table th:first-child {
-  max-width: 280px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .overview-table sup {
   color: var(--danger);
-}
-
-.overview-note {
-  margin: 0;
-  padding: 11px 28px;
-  border-top: 1px solid var(--row-border);
-  color: var(--muted);
-  font: 9px/1.5 var(--mono);
-}
-
-.overview-note span {
-  display: block;
 }
 
 .homepage-metrics .usage-chart {
@@ -838,28 +677,6 @@ h1 {
 @media (max-width: 1100px) {
   .homepage-metrics {
     grid-template-columns: 1fr;
-  }
-
-  .overview-summary {
-    grid-template-columns: repeat(3, 1fr);
-  }
-
-  .overview-summary > div:nth-child(4) {
-    border-top: 1px solid var(--row-border);
-    border-left: 0;
-  }
-
-  .overview-summary > div:nth-child(5) {
-    border-top: 1px solid var(--row-border);
-  }
-
-  .overview-matrices {
-    grid-template-columns: 1fr;
-  }
-
-  .overview-table-block + .overview-table-block {
-    border-top: 1px solid var(--row-border);
-    border-left: 0;
   }
 }
 
@@ -2422,55 +2239,8 @@ table.data-table {
     font-size: 14px;
   }
 
-  .overview-heading,
-  .overview-table-block,
-  .overview-models {
-    padding-right: 18px;
-    padding-left: 18px;
-  }
-
-  .overview-summary {
-    grid-template-columns: repeat(2, 1fr);
-  }
-
-  .overview-summary > div {
-    padding: 15px 18px;
-    border-left: 0;
-  }
-
-  .overview-summary > div:nth-child(even) {
-    border-left: 1px solid var(--row-border);
-  }
-
-  .overview-summary > div:nth-child(n + 3) {
-    border-top: 1px solid var(--row-border);
-  }
-
-  .overview-secondary {
-    grid-template-columns: 1fr;
-  }
-
-  .overview-secondary > div {
-    padding-right: 18px;
-    padding-left: 18px;
-  }
-
-  .overview-secondary > div + div {
-    border-top: 1px solid var(--row-border);
-    border-left: 0;
-  }
-
   .overview-table {
     min-width: 430px;
-  }
-
-  .model-table {
-    min-width: 680px;
-  }
-
-  .overview-note {
-    padding-right: 18px;
-    padding-left: 18px;
   }
 
   .panel-heading {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -215,7 +215,7 @@ h1 {
 }
 
 .ttl-miss-card.overview-active {
-  min-height: 650px;
+  min-height: 600px;
 }
 
 .ttl-analytics-toolbar {
@@ -261,8 +261,8 @@ h1 {
 
 .compact-overview-summary > div {
   display: grid;
-  gap: 4px;
-  padding: 13px 14px;
+  gap: 3px;
+  padding: 10px 14px;
 }
 
 .compact-overview-summary > div + div {
@@ -293,6 +293,7 @@ h1 {
   overflow: hidden;
   color: var(--muted);
   font-size: 8px;
+  line-height: 1.2;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -303,17 +304,17 @@ h1 {
 }
 
 .compact-overview-table {
-  padding: 14px 28px 10px;
+  padding: 12px 28px 8px;
 }
 
 .compact-overview-table .overview-table th,
 .compact-overview-table .overview-table td {
-  padding-top: 5px;
-  padding-bottom: 5px;
+  padding-top: 4px;
+  padding-bottom: 4px;
 }
 
 .compact-overview-table .compact-metric-group th {
-  padding: 10px 0 4px;
+  padding: 8px 0 3px;
   border-top: 1px solid var(--panel-border);
   border-bottom: 0;
   color: var(--muted);
@@ -376,6 +377,7 @@ h1 {
 
 .compact-model-row > span {
   overflow: hidden;
+  color: var(--ink);
   text-overflow: ellipsis;
   white-space: nowrap;
 }
@@ -403,9 +405,10 @@ h1 {
 
 .compact-overview-note {
   margin: 0;
-  padding: 0 28px 13px;
+  padding: 8px 28px 13px;
   color: var(--muted);
   font-size: 8px;
+  line-height: 1.3;
 }
 
 .compact-overview-note span {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -214,10 +214,6 @@ h1 {
   box-shadow: 0 18px 60px rgba(57, 51, 40, .08);
 }
 
-.ttl-miss-card.overview-active {
-  min-height: 600px;
-}
-
 .ttl-analytics-toolbar {
   display: flex;
   min-height: 48px;
@@ -254,7 +250,7 @@ h1 {
 
 .compact-overview-summary {
   display: grid;
-  grid-template-columns: repeat(3, 1fr);
+  grid-template-columns: repeat(6, minmax(0, 1fr));
   border-bottom: 1px solid var(--row-border);
   background: var(--surface-1);
 }
@@ -269,14 +265,6 @@ h1 {
   border-left: 1px solid var(--row-border);
 }
 
-.compact-overview-summary > div:nth-child(n + 4) {
-  border-top: 1px solid var(--row-border);
-}
-
-.compact-overview-summary > div:nth-child(4) {
-  border-left: 0;
-}
-
 .compact-overview-summary strong {
   font-size: 16px;
   font-variant-numeric: tabular-nums;
@@ -287,15 +275,6 @@ h1 {
   font-size: 8px;
   letter-spacing: .04em;
   text-transform: uppercase;
-}
-
-.compact-overview-summary small {
-  overflow: hidden;
-  color: var(--muted);
-  font-size: 8px;
-  line-height: 1.2;
-  text-overflow: ellipsis;
-  white-space: nowrap;
 }
 
 .compact-overview-summary sup,
@@ -324,31 +303,17 @@ h1 {
   text-transform: uppercase;
 }
 
-.compact-overview-table .compact-metric-group:first-child th {
-  padding-top: 3px;
-  border-top: 0;
-}
-
 .compact-models {
   padding: 8px 28px 12px;
   border-top: 1px solid var(--row-border);
 }
 
-.compact-models h3 {
-  margin: 0 0 8px;
-  color: var(--muted);
-  font-size: 9px;
-  font-weight: 500;
-  letter-spacing: .05em;
-  text-transform: uppercase;
-}
-
 .compact-model-list {
   display: grid;
-  gap: 7px;
+  gap: 5px;
 }
 
-.compact-model-header {
+.compact-model-heading {
   display: grid;
   grid-template-columns: minmax(95px, 1.4fr) minmax(60px, 1fr) 44px 64px;
   gap: 9px;
@@ -359,8 +324,15 @@ h1 {
   text-transform: uppercase;
 }
 
-.compact-model-header small,
-.compact-model-header strong {
+.compact-model-heading h3 {
+  grid-column: 1 / 3;
+  margin: 0;
+  font-size: inherit;
+  font-weight: 500;
+}
+
+.compact-model-heading small,
+.compact-model-heading strong {
   font-size: inherit;
   font-weight: 500;
   text-align: right;
@@ -409,10 +381,6 @@ h1 {
   color: var(--muted);
   font-size: 8px;
   line-height: 1.3;
-}
-
-.compact-overview-note span {
-  display: block;
 }
 
 .ttl-miss-lead {
@@ -614,25 +582,15 @@ h1 {
   }
 
   .compact-overview-summary {
-    grid-template-columns: repeat(2, 1fr);
+    grid-template-columns: repeat(3, 1fr);
   }
 
-  .compact-overview-summary > div:nth-child(3) {
+  .compact-overview-summary > div:nth-child(n + 4) {
     border-top: 1px solid var(--row-border);
-    border-left: 0;
   }
 
   .compact-overview-summary > div:nth-child(4) {
-    border-top: 1px solid var(--row-border);
-  }
-
-  .compact-overview-summary > div:nth-child(5) {
-    border-top: 1px solid var(--row-border);
     border-left: 0;
-  }
-
-  .compact-overview-summary > div:nth-child(6) {
-    border-top: 1px solid var(--row-border);
   }
 
   .compact-overview-table {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -359,6 +359,10 @@ h1 {
   font: 9px/1.5 var(--mono);
 }
 
+.overview-note span {
+  display: block;
+}
+
 .homepage-metrics .usage-chart {
   min-width: 0;
   margin-bottom: 0;
@@ -469,10 +473,20 @@ h1 {
   padding-bottom: 5px;
 }
 
-.compact-overview-table .overview-table .section-start th,
-.compact-overview-table .overview-table .section-start td {
-  padding-top: 10px;
+.compact-overview-table .compact-metric-group th {
+  padding: 10px 0 4px;
   border-top: 1px solid var(--panel-border);
+  border-bottom: 0;
+  color: var(--muted);
+  font-size: 8px;
+  font-weight: 500;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.compact-overview-table .compact-metric-group:first-child th {
+  padding-top: 3px;
+  border-top: 0;
 }
 
 .compact-models {
@@ -492,6 +506,24 @@ h1 {
 .compact-model-list {
   display: grid;
   gap: 7px;
+}
+
+.compact-model-header {
+  display: grid;
+  grid-template-columns: minmax(95px, 1.4fr) minmax(60px, 1fr) 44px 64px;
+  gap: 9px;
+  margin-bottom: 6px;
+  color: var(--muted);
+  font-size: 8px;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.compact-model-header small,
+.compact-model-header strong {
+  font-size: inherit;
+  font-weight: 500;
+  text-align: right;
 }
 
 .compact-model-row {
@@ -535,6 +567,10 @@ h1 {
   padding: 0 28px 13px;
   color: var(--muted);
   font-size: 8px;
+}
+
+.compact-overview-note span {
+  display: block;
 }
 
 .ttl-miss-lead {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -19,6 +19,7 @@ import type {
 import type { UsageCall } from "./usage.ts";
 import { aggregateUsage } from "./usageAnalytics.ts";
 import { aggregateTtlMisses } from "./ttlMissAnalytics.ts";
+import { aggregateOverview } from "./overviewAnalytics.ts";
 import { contextRange } from "../shared/contextMetrics.ts";
 import { openArchiveDatabase, sqlitePath } from "./database.ts";
 import { SessionRepository } from "./sessionRepository.ts";
@@ -388,6 +389,31 @@ function listSessions(
   };
 }
 
+function overviewSessions(start: number, harness: string) {
+  const harnesses = harness === "all"
+    ? (["opencode", "claude-code", "pi", "codex"] as const)
+    : [harness as SessionSummary["harness"]];
+  const sessions: SessionDetail[] = [];
+  for (const name of harnesses) {
+    const source = repositoryForHarness(name);
+    if (!source) continue;
+    const pageSize = 100;
+    for (let page = 1;; page++) {
+      const result = source.listSessions(page, pageSize);
+      for (const summary of result.items) {
+        if (summary.updatedAt < start) continue;
+        const detail = source.getSession(summary.id);
+        if (detail) sessions.push(priceSessionDetail(detail));
+      }
+      if (
+        page >= result.pagination.totalPages ||
+        result.items.every((session) => session.updatedAt < start)
+      ) break;
+    }
+  }
+  return sessions;
+}
+
 app.get("/api/ttl-misses", (context) => {
   const harness = context.req.query("harness") ?? "all";
   if (!["all", "opencode", "claude-code", "pi", "codex"].includes(harness)) {
@@ -422,6 +448,36 @@ app.get("/api/ttl-misses", (context) => {
   }
 
   return context.json(aggregateTtlMisses(usageCalls, start, range));
+});
+
+app.get("/api/overview", (context) => {
+  const harness = context.req.query("harness") ?? "all";
+  if (!["all", "opencode", "claude-code", "pi", "codex"].includes(harness)) {
+    return context.json({ error: "Invalid harness" }, 400);
+  }
+  const rangeParam = context.req.query("range") ?? "90";
+  const range = Math.min(
+    365,
+    Math.max(1, Number.parseInt(rangeParam, 10) || 90),
+  );
+  const start = new Date(
+    new Date().setHours(0, 0, 0, 0) - (range - 1) * 86_400_000,
+  ).getTime();
+  const end = Date.now();
+  const coverage = harness === "pi" || harness === "codex"
+    ? "none"
+    : harness === "all"
+    ? "partial"
+    : "full";
+  return context.json(
+    aggregateOverview(
+      overviewSessions(start, harness),
+      start,
+      end,
+      range,
+      coverage,
+    ),
+  );
 });
 
 app.get("/api/usage", (context) => {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -19,7 +19,10 @@ import type {
 import type { UsageCall } from "./usage.ts";
 import { aggregateUsage } from "./usageAnalytics.ts";
 import { aggregateTtlMisses } from "./ttlMissAnalytics.ts";
-import { aggregateOverview } from "./overviewAnalytics.ts";
+import {
+  aggregateOverview,
+  ROTATION_INACTIVITY_MINUTES,
+} from "./overviewAnalytics.ts";
 import { contextRange } from "../shared/contextMetrics.ts";
 import { openArchiveDatabase, sqlitePath } from "./database.ts";
 import { SessionRepository } from "./sessionRepository.ts";
@@ -471,7 +474,10 @@ app.get("/api/overview", (context) => {
     : "full";
   return context.json(
     aggregateOverview(
-      overviewSessions(start, harness),
+      overviewSessions(
+        start - ROTATION_INACTIVITY_MINUTES * 60_000,
+        harness,
+      ),
       start,
       end,
       range,

--- a/src/server/overviewAnalytics.test.ts
+++ b/src/server/overviewAnalytics.test.ts
@@ -141,3 +141,29 @@ Deno.test("keeps overall efficiency token-weighted", () => {
   ok(Math.abs(result.sessionProfile.efficiency!.average - 0.5) < 1e-10);
   ok(Math.abs(result.sessionProfile.efficiency!.median - 0.5) < 1e-10);
 });
+
+Deno.test("keeps known spend when some calls are unpriced", () => {
+  const startedAt = new Date(2026, 6, 10, 9).getTime();
+  const result = aggregateOverview(
+    [
+      session("priced", [{
+        startedAt,
+        input: 100,
+        cacheRead: 0,
+        cost: 5,
+      }]),
+      session("unpriced", [{
+        startedAt: startedAt + 60_000,
+        input: 100,
+        cacheRead: 0,
+      }]),
+    ],
+    new Date(2026, 6, 10).getTime(),
+    startedAt + 3_600_000,
+    1,
+  );
+
+  strictEqual(result.activity.hasUnpricedCost, true);
+  strictEqual(result.activity.spend!.median, 5);
+  strictEqual(result.sessionProfile.spend!.median, 2.5);
+});

--- a/src/server/overviewAnalytics.test.ts
+++ b/src/server/overviewAnalytics.test.ts
@@ -1,0 +1,143 @@
+import { deepStrictEqual, ok, strictEqual } from "node:assert";
+import type { SessionDetail, TokenUsage } from "../shared/sessionSchemas.ts";
+import { overviewResponseSchema } from "../shared/sessionSchemas.ts";
+import { aggregateOverview } from "./overviewAnalytics.ts";
+
+function tokens(input: number, cacheRead: number): TokenUsage {
+  return {
+    uncachedInput: input - cacheRead,
+    cacheRead,
+    freshPrompt: input - cacheRead,
+    output: 0,
+    reasoning: 0,
+    processed: input,
+  };
+}
+
+function session(
+  id: string,
+  turns: Array<{
+    startedAt: number;
+    input: number;
+    cacheRead: number;
+    cost?: number;
+    model?: string;
+  }>,
+  subagents: SessionDetail[] = [],
+): SessionDetail {
+  const usage = turns.map((turn) => tokens(turn.input, turn.cacheRead));
+  return {
+    id,
+    harness: "opencode",
+    title: id,
+    updatedAt: turns.at(-1)?.startedAt ?? 0,
+    startedAt: turns.at(0)?.startedAt,
+    endedAt: turns.at(-1)?.startedAt,
+    providers: ["test"],
+    models: [...new Set(turns.map((turn) => turn.model ?? "model"))],
+    userTurns: turns.length,
+    modelCalls: turns.length,
+    tokens: tokens(
+      usage.reduce(
+        (sum, value) =>
+          sum + value.uncachedInput + value.cacheRead + (value.cacheWrite ?? 0),
+        0,
+      ),
+      usage.reduce((sum, value) => sum + value.cacheRead, 0),
+    ),
+    turns: turns.map((turn, index) => ({
+      number: index + 1,
+      startedAt: turn.startedAt,
+      calls: [{
+        id: `${id}-${index + 1}`,
+        callWithinTurn: 1,
+        provider: "test",
+        model: turn.model ?? "model",
+        startedAt: turn.startedAt,
+        completedAt: turn.startedAt + 60_000,
+        computedCost: turn.cost,
+        tokens: tokens(turn.input, turn.cacheRead),
+        activity: { hasText: true, hasReasoning: false, tools: [] },
+      }],
+    })),
+    subagents,
+  };
+}
+
+Deno.test("aggregates active dates and inclusive subagent work", () => {
+  const friday = new Date(2026, 6, 10, 9).getTime();
+  const saturday = new Date(2026, 6, 11, 9).getTime();
+  const child = session("child", [{
+    startedAt: saturday,
+    input: 900,
+    cacheRead: 0,
+    cost: 9,
+  }]);
+  const roots = [
+    session("multi-day", [{
+      startedAt: friday,
+      input: 100,
+      cacheRead: 50,
+      cost: 1,
+    }], [child]),
+    session("friday-only", [{
+      startedAt: friday + 60_000,
+      input: 100,
+      cacheRead: 100,
+      cost: 2,
+    }]),
+  ];
+
+  const result = aggregateOverview(
+    roots,
+    new Date(2026, 6, 10).getTime(),
+    new Date(2026, 6, 11, 23, 59).getTime(),
+    2,
+  );
+
+  overviewResponseSchema.parse(result);
+  strictEqual(result.activeDays, 2);
+  strictEqual(result.activeWeekdays, 1);
+  strictEqual(result.weekendDays, 1);
+  strictEqual(result.weekdayActivityRate, 1);
+  strictEqual(result.sessions, 2);
+  strictEqual(result.multiDaySessions, 1);
+  strictEqual(result.averageActiveSpan, 1.5);
+  deepStrictEqual(result.activity.sessions, {
+    average: 1.5,
+    median: 1.5,
+    p90: 1.9,
+  });
+  deepStrictEqual(result.sessionProfile.turns, {
+    average: 1.5,
+    median: 1.5,
+    p90: 1.9,
+  });
+});
+
+Deno.test("keeps overall efficiency token-weighted", () => {
+  const startedAt = new Date(2026, 6, 10, 9).getTime();
+  const result = aggregateOverview(
+    [
+      session("large", [{
+        startedAt,
+        input: 900,
+        cacheRead: 0,
+        cost: 9,
+      }]),
+      session("small", [{
+        startedAt: startedAt + 60_000,
+        input: 100,
+        cacheRead: 100,
+        cost: 1,
+      }]),
+    ],
+    new Date(2026, 6, 10).getTime(),
+    startedAt + 3_600_000,
+    1,
+  );
+
+  ok(Math.abs(result.sessionProfile.overallEfficiency! - 0.1) < 1e-10);
+  ok(Math.abs(result.sessionProfile.efficiency!.average - 0.5) < 1e-10);
+  ok(Math.abs(result.sessionProfile.efficiency!.median - 0.5) < 1e-10);
+});

--- a/src/server/overviewAnalytics.test.ts
+++ b/src/server/overviewAnalytics.test.ts
@@ -167,3 +167,99 @@ Deno.test("keeps known spend when some calls are unpriced", () => {
   strictEqual(result.activity.spend!.median, 5);
   strictEqual(result.sessionProfile.spend!.median, 2.5);
 });
+
+Deno.test("counts overlapping root sessions in rotation without double-counting subagents", () => {
+  const day = new Date(2026, 6, 10).getTime();
+  const rootStart = day + 9 * 3_600_000;
+  const child = session("child", [{
+    startedAt: rootStart + 10 * 60_000,
+    input: 100,
+    cacheRead: 0,
+    cost: 1,
+  }]);
+  const result = aggregateOverview(
+    [
+      session("root", [{
+        startedAt: rootStart,
+        input: 100,
+        cacheRead: 0,
+        cost: 1,
+      }], [child]),
+      session("other-root", [{
+        startedAt: rootStart + 20 * 60_000,
+        input: 100,
+        cacheRead: 0,
+        cost: 1,
+      }]),
+    ],
+    day,
+    day + 86_400_000 - 1,
+    1,
+  );
+
+  strictEqual(result.rotationInactivityMinutes, 30);
+  deepStrictEqual(result.activity.peakConcurrentSessions, {
+    average: 2,
+    median: 2,
+    p90: 2,
+  });
+});
+
+Deno.test("expires rotation tails but retains observed tool execution", () => {
+  const day = new Date(2026, 6, 10).getTime();
+  const startedAt = day + 9 * 3_600_000;
+  const executing = session("executing", [{
+    startedAt,
+    input: 100,
+    cacheRead: 0,
+    cost: 1,
+  }]);
+  executing.turns[0].calls[0].activity.tools.push({
+    name: "long-running",
+    status: "completed",
+    startedAt,
+    completedAt: startedAt + 60 * 60_000,
+  });
+  const result = aggregateOverview(
+    [
+      executing,
+      session("overlapping", [{
+        startedAt: startedAt + 45 * 60_000,
+        input: 100,
+        cacheRead: 0,
+        cost: 1,
+      }]),
+      session("after-expiry", [{
+        startedAt: startedAt + 92 * 60_000,
+        input: 100,
+        cacheRead: 0,
+        cost: 1,
+      }]),
+    ],
+    day,
+    day + 86_400_000 - 1,
+    1,
+  );
+
+  strictEqual(result.activity.peakConcurrentSessions!.median, 2);
+});
+
+Deno.test("does not create an active day from a cross-midnight tail", () => {
+  const day = new Date(2026, 6, 10).getTime();
+  const result = aggregateOverview(
+    [
+      session("late", [{
+        startedAt: day + 23 * 3_600_000 + 50 * 60_000,
+        input: 100,
+        cacheRead: 0,
+        cost: 1,
+      }]),
+    ],
+    day,
+    day + 36 * 3_600_000,
+    2,
+  );
+
+  strictEqual(result.activeDays, 1);
+  strictEqual(result.activity.peakConcurrentSessions!.median, 1);
+});

--- a/src/server/overviewAnalytics.ts
+++ b/src/server/overviewAnalytics.ts
@@ -264,11 +264,11 @@ export function aggregateOverview(
   const rankedModels = [...models.values()].sort((a, b) =>
     b.spend - a.spend || b.input - a.input || a.model.localeCompare(b.model)
   );
-  const topModels = rankedModels.slice(0, 5).map((model) =>
+  const topModels = rankedModels.slice(0, 4).map((model) =>
     modelResult(model, totalSpend)
   );
-  if (rankedModels.length > 5) {
-    const other = rankedModels.slice(5).reduce<ModelBucket>(
+  if (rankedModels.length > 4) {
+    const other = rankedModels.slice(4).reduce<ModelBucket>(
       (result, model) => {
         model.sessions.forEach((session) => result.sessions.add(session));
         result.input += model.input;

--- a/src/server/overviewAnalytics.ts
+++ b/src/server/overviewAnalytics.ts
@@ -17,6 +17,10 @@ type ModelBucket = {
   hasUnpricedCost: boolean;
 };
 
+type Interval = { start: number; end: number };
+
+export const ROTATION_INACTIVITY_MINUTES = 30;
+
 function dateKey(value: number) {
   const date = new Date(value);
   return [
@@ -49,6 +53,66 @@ function sessionTree(session: SessionDetail): SessionDetail[] {
     session,
     ...session.subagents.flatMap((subagent) => sessionTree(subagent)),
   ];
+}
+
+function turnExecutionEnd(turn: SessionDetail["turns"][number]) {
+  let end = turn.startedAt;
+  for (const call of turn.calls) {
+    end = Math.max(end, call.completedAt ?? call.startedAt);
+    for (const tool of call.activity.tools) {
+      end = Math.max(
+        end,
+        tool.completedAt ?? tool.startedAt ?? call.completedAt ??
+          call.startedAt,
+      );
+    }
+  }
+  return end;
+}
+
+function mergeIntervals(intervals: Interval[]) {
+  const merged: Interval[] = [];
+  for (const interval of intervals.toSorted((a, b) => a.start - b.start)) {
+    const previous = merged.at(-1);
+    if (previous && interval.start <= previous.end) {
+      previous.end = Math.max(previous.end, interval.end);
+    } else {
+      merged.push({ ...interval });
+    }
+  }
+  return merged;
+}
+
+function localDayBounds(date: string): Interval {
+  const [year, month, day] = date.split("-").map(Number);
+  return {
+    start: new Date(year, month - 1, day).getTime(),
+    end: new Date(year, month - 1, day + 1).getTime(),
+  };
+}
+
+function dailyRotationPeaks(
+  activeDates: Set<string>,
+  intervalsBySession: Map<string, Interval[]>,
+) {
+  const merged = [...intervalsBySession.values()].flatMap(mergeIntervals);
+  return [...activeDates].map((date) => {
+    const day = localDayBounds(date);
+    const events: Array<{ at: number; delta: number }> = [];
+    for (const interval of merged) {
+      if (interval.end <= day.start || interval.start >= day.end) continue;
+      events.push({ at: Math.max(interval.start, day.start), delta: 1 });
+      events.push({ at: Math.min(interval.end, day.end), delta: -1 });
+    }
+    events.sort((a, b) => a.at - b.at || a.delta - b.delta);
+    let active = 0;
+    let peak = 0;
+    for (const event of events) {
+      active += event.delta;
+      peak = Math.max(peak, active);
+    }
+    return peak;
+  });
 }
 
 function modelResult(
@@ -102,6 +166,8 @@ export function aggregateOverview(
   const profileEfficiency: number[] = [];
   const activeSpans: number[] = [];
   const models = new Map<string, ModelBucket>();
+  const rotationIntervals = new Map<string, Interval[]>();
+  const rotationTail = ROTATION_INACTIVITY_MINUTES * 60_000;
   let sessions = 0;
   let multiDaySessions = 0;
   let overallInput = 0;
@@ -110,16 +176,19 @@ export function aggregateOverview(
 
   for (const root of roots) {
     const rootKey = `${root.harness}:${root.id}`;
-    const turns = sessionTree(root).flatMap((session) =>
-      session.turns.filter((turn) =>
-        turn.startedAt >= start && turn.startedAt <= end
-      )
+    const allTurns = sessionTree(root).flatMap((session) => session.turns);
+    const intervals = allTurns.map((turn) => ({
+      start: turn.startedAt,
+      end: turnExecutionEnd(turn) + rotationTail,
+    })).filter((interval) => interval.end > start && interval.start <= end);
+    if (intervals.length > 0) rotationIntervals.set(rootKey, intervals);
+    const turns = allTurns.filter((turn) =>
+      turn.startedAt >= start && turn.startedAt <= end
     );
     if (turns.length === 0) continue;
     sessions++;
 
     const sessionDates = new Set<string>();
-    const calls = turns.flatMap((turn) => turn.calls);
     let sessionInput = 0;
     let sessionCacheRead = 0;
     let sessionSpend = 0;
@@ -227,9 +296,11 @@ export function aggregateOverview(
   const dailySpendValues = [...activeDates].map((date) =>
     dailySpend.get(date) ?? 0
   );
+  const rotationPeaks = dailyRotationPeaks(activeDates, rotationIntervals);
 
   return {
     rangeDays,
+    rotationInactivityMinutes: ROTATION_INACTIVITY_MINUTES,
     sessions,
     activeDays: activeDates.size,
     activeWeekdays: activeWeekdays.size,
@@ -241,6 +312,7 @@ export function aggregateOverview(
     subagentCoverage,
     activity: {
       sessions: distribution(dailySessionValues),
+      peakConcurrentSessions: distribution(rotationPeaks),
       turns: distribution(dailyTurnValues),
       spend: distribution(dailySpendValues),
       hasUnpricedCost,

--- a/src/server/overviewAnalytics.ts
+++ b/src/server/overviewAnalytics.ts
@@ -123,7 +123,6 @@ export function aggregateOverview(
     let sessionInput = 0;
     let sessionCacheRead = 0;
     let sessionSpend = 0;
-    let sessionHasUnpricedCost = false;
     let peakContext = 0;
     let firstTurn = Number.POSITIVE_INFINITY;
     let lastCall = Number.NEGATIVE_INFINITY;
@@ -149,7 +148,6 @@ export function aggregateOverview(
         peakContext = Math.max(peakContext, input);
         lastCall = Math.max(lastCall, call.completedAt ?? call.startedAt);
         if (cost === undefined) {
-          sessionHasUnpricedCost = true;
           hasUnpricedCost = true;
         } else {
           sessionSpend += cost;
@@ -180,7 +178,7 @@ export function aggregateOverview(
     if (Number.isFinite(firstTurn) && Number.isFinite(lastCall)) {
       profileElapsed.push(Math.max(0, lastCall - firstTurn));
     }
-    if (!sessionHasUnpricedCost) profileSpend.push(sessionSpend);
+    profileSpend.push(sessionSpend);
     if (sessionInput > 0) {
       profileEfficiency.push(sessionCacheRead / sessionInput);
     }
@@ -226,9 +224,9 @@ export function aggregateOverview(
   const dailyTurnValues = [...activeDates].map((date) =>
     dailyTurns.get(date) ?? 0
   );
-  const dailySpendValues = hasUnpricedCost
-    ? []
-    : [...activeDates].map((date) => dailySpend.get(date) ?? 0);
+  const dailySpendValues = [...activeDates].map((date) =>
+    dailySpend.get(date) ?? 0
+  );
 
   return {
     rangeDays,

--- a/src/server/overviewAnalytics.ts
+++ b/src/server/overviewAnalytics.ts
@@ -195,11 +195,11 @@ export function aggregateOverview(
   const rankedModels = [...models.values()].sort((a, b) =>
     b.spend - a.spend || b.input - a.input || a.model.localeCompare(b.model)
   );
-  const topModels = rankedModels.slice(0, 3).map((model) =>
+  const topModels = rankedModels.slice(0, 5).map((model) =>
     modelResult(model, totalSpend)
   );
-  if (rankedModels.length > 3) {
-    const other = rankedModels.slice(3).reduce<ModelBucket>(
+  if (rankedModels.length > 5) {
+    const other = rankedModels.slice(5).reduce<ModelBucket>(
       (result, model) => {
         model.sessions.forEach((session) => result.sessions.add(session));
         result.input += model.input;

--- a/src/server/overviewAnalytics.ts
+++ b/src/server/overviewAnalytics.ts
@@ -1,0 +1,270 @@
+import type {
+  OverviewResponse,
+  SessionDetail,
+} from "../shared/sessionSchemas.ts";
+import { contextSize } from "../shared/contextMetrics.ts";
+
+type Distribution = NonNullable<
+  OverviewResponse["sessionProfile"]["turns"]
+>;
+
+type ModelBucket = {
+  model: string;
+  sessions: Set<string>;
+  input: number;
+  cacheRead: number;
+  spend: number;
+  hasUnpricedCost: boolean;
+};
+
+function dateKey(value: number) {
+  const date = new Date(value);
+  return [
+    date.getFullYear(),
+    String(date.getMonth() + 1).padStart(2, "0"),
+    String(date.getDate()).padStart(2, "0"),
+  ].join("-");
+}
+
+function percentile(values: number[], quantile: number) {
+  const index = (values.length - 1) * quantile;
+  const lower = Math.floor(index);
+  const remainder = index - lower;
+  return values[lower] + (values[lower + 1] - values[lower]) * remainder ||
+    values[lower];
+}
+
+function distribution(values: number[]): Distribution | undefined {
+  if (values.length === 0) return undefined;
+  const sorted = values.toSorted((a, b) => a - b);
+  return {
+    average: sorted.reduce((sum, value) => sum + value, 0) / sorted.length,
+    median: percentile(sorted, 0.5),
+    p90: percentile(sorted, 0.9),
+  };
+}
+
+function sessionTree(session: SessionDetail): SessionDetail[] {
+  return [
+    session,
+    ...session.subagents.flatMap((subagent) => sessionTree(subagent)),
+  ];
+}
+
+function modelResult(
+  bucket: ModelBucket,
+  totalSpend: number,
+  isOther = false,
+): OverviewResponse["models"][number] {
+  return {
+    model: bucket.model,
+    sessions: bucket.sessions.size,
+    input: bucket.input,
+    spend: bucket.spend,
+    spendShare: totalSpend === 0 ? 0 : bucket.spend / totalSpend,
+    efficiency: bucket.input === 0
+      ? undefined
+      : bucket.cacheRead / bucket.input,
+    hasUnpricedCost: bucket.hasUnpricedCost,
+    isOther,
+  };
+}
+
+export function aggregateOverview(
+  roots: SessionDetail[],
+  start: number,
+  end: number,
+  rangeDays: number,
+  subagentCoverage: OverviewResponse["subagentCoverage"] = "full",
+): OverviewResponse {
+  const startDate = Temporal.PlainDate.from(dateKey(start));
+  const endDate = Temporal.PlainDate.from(dateKey(end));
+  let elapsedWeekdays = 0;
+  for (
+    let date = startDate;
+    Temporal.PlainDate.compare(date, endDate) <= 0;
+    date = date.add({ days: 1 })
+  ) {
+    if (date.dayOfWeek <= 5) elapsedWeekdays++;
+  }
+
+  const activeDates = new Set<string>();
+  const activeWeekdays = new Set<string>();
+  const weekendDates = new Set<string>();
+  const dailySessions = new Map<string, Set<string>>();
+  const dailyTurns = new Map<string, number>();
+  const dailySpend = new Map<string, number>();
+  const profileTurns: number[] = [];
+  const profileInput: number[] = [];
+  const profilePeakContext: number[] = [];
+  const profileElapsed: number[] = [];
+  const profileSpend: number[] = [];
+  const profileEfficiency: number[] = [];
+  const activeSpans: number[] = [];
+  const models = new Map<string, ModelBucket>();
+  let sessions = 0;
+  let multiDaySessions = 0;
+  let overallInput = 0;
+  let overallCacheRead = 0;
+  let hasUnpricedCost = false;
+
+  for (const root of roots) {
+    const rootKey = `${root.harness}:${root.id}`;
+    const turns = sessionTree(root).flatMap((session) =>
+      session.turns.filter((turn) =>
+        turn.startedAt >= start && turn.startedAt <= end
+      )
+    );
+    if (turns.length === 0) continue;
+    sessions++;
+
+    const sessionDates = new Set<string>();
+    const calls = turns.flatMap((turn) => turn.calls);
+    let sessionInput = 0;
+    let sessionCacheRead = 0;
+    let sessionSpend = 0;
+    let sessionHasUnpricedCost = false;
+    let peakContext = 0;
+    let firstTurn = Number.POSITIVE_INFINITY;
+    let lastCall = Number.NEGATIVE_INFINITY;
+
+    for (const turn of turns) {
+      const date = dateKey(turn.startedAt);
+      const plainDate = Temporal.PlainDate.from(date);
+      sessionDates.add(date);
+      activeDates.add(date);
+      if (plainDate.dayOfWeek <= 5) activeWeekdays.add(date);
+      else weekendDates.add(date);
+      const workedOn = dailySessions.get(date) ?? new Set<string>();
+      workedOn.add(rootKey);
+      dailySessions.set(date, workedOn);
+      dailyTurns.set(date, (dailyTurns.get(date) ?? 0) + 1);
+      firstTurn = Math.min(firstTurn, turn.startedAt);
+
+      for (const call of turn.calls) {
+        const input = contextSize(call.tokens);
+        const cost = call.computedCost;
+        sessionInput += input;
+        sessionCacheRead += call.tokens.cacheRead;
+        peakContext = Math.max(peakContext, input);
+        lastCall = Math.max(lastCall, call.completedAt ?? call.startedAt);
+        if (cost === undefined) {
+          sessionHasUnpricedCost = true;
+          hasUnpricedCost = true;
+        } else {
+          sessionSpend += cost;
+          const callDate = dateKey(call.startedAt);
+          dailySpend.set(callDate, (dailySpend.get(callDate) ?? 0) + cost);
+        }
+
+        const bucket = models.get(call.model) ?? {
+          model: call.model,
+          sessions: new Set<string>(),
+          input: 0,
+          cacheRead: 0,
+          spend: 0,
+          hasUnpricedCost: false,
+        };
+        bucket.sessions.add(rootKey);
+        bucket.input += input;
+        bucket.cacheRead += call.tokens.cacheRead;
+        bucket.spend += cost ?? 0;
+        bucket.hasUnpricedCost ||= cost === undefined;
+        models.set(call.model, bucket);
+      }
+    }
+
+    profileTurns.push(turns.length);
+    profileInput.push(sessionInput);
+    profilePeakContext.push(peakContext);
+    if (Number.isFinite(firstTurn) && Number.isFinite(lastCall)) {
+      profileElapsed.push(Math.max(0, lastCall - firstTurn));
+    }
+    if (!sessionHasUnpricedCost) profileSpend.push(sessionSpend);
+    if (sessionInput > 0) {
+      profileEfficiency.push(sessionCacheRead / sessionInput);
+    }
+    overallInput += sessionInput;
+    overallCacheRead += sessionCacheRead;
+    activeSpans.push(sessionDates.size);
+    if (sessionDates.size > 1) multiDaySessions++;
+  }
+
+  const totalSpend = [...models.values()].reduce(
+    (sum, model) => sum + model.spend,
+    0,
+  );
+  const rankedModels = [...models.values()].sort((a, b) =>
+    b.spend - a.spend || b.input - a.input || a.model.localeCompare(b.model)
+  );
+  const topModels = rankedModels.slice(0, 3).map((model) =>
+    modelResult(model, totalSpend)
+  );
+  if (rankedModels.length > 3) {
+    const other = rankedModels.slice(3).reduce<ModelBucket>(
+      (result, model) => {
+        model.sessions.forEach((session) => result.sessions.add(session));
+        result.input += model.input;
+        result.cacheRead += model.cacheRead;
+        result.spend += model.spend;
+        result.hasUnpricedCost ||= model.hasUnpricedCost;
+        return result;
+      },
+      {
+        model: "Other",
+        sessions: new Set(),
+        input: 0,
+        cacheRead: 0,
+        spend: 0,
+        hasUnpricedCost: false,
+      },
+    );
+    topModels.push(modelResult(other, totalSpend, true));
+  }
+
+  const dailySessionValues = [...dailySessions.values()].map((day) => day.size);
+  const dailyTurnValues = [...activeDates].map((date) =>
+    dailyTurns.get(date) ?? 0
+  );
+  const dailySpendValues = hasUnpricedCost
+    ? []
+    : [...activeDates].map((date) => dailySpend.get(date) ?? 0);
+
+  return {
+    rangeDays,
+    sessions,
+    activeDays: activeDates.size,
+    activeWeekdays: activeWeekdays.size,
+    elapsedWeekdays,
+    weekendDays: weekendDates.size,
+    weekdayActivityRate: elapsedWeekdays === 0
+      ? 0
+      : activeWeekdays.size / elapsedWeekdays,
+    subagentCoverage,
+    activity: {
+      sessions: distribution(dailySessionValues),
+      turns: distribution(dailyTurnValues),
+      spend: distribution(dailySpendValues),
+      hasUnpricedCost,
+    },
+    sessionProfile: {
+      turns: distribution(profileTurns),
+      input: distribution(profileInput),
+      peakContext: distribution(profilePeakContext),
+      elapsed: distribution(profileElapsed),
+      spend: distribution(profileSpend),
+      efficiency: distribution(profileEfficiency),
+      overallEfficiency: overallInput === 0
+        ? undefined
+        : overallCacheRead / overallInput,
+      hasUnpricedCost,
+    },
+    multiDaySessions,
+    multiDaySessionRate: sessions === 0 ? 0 : multiDaySessions / sessions,
+    averageActiveSpan: activeSpans.length === 0
+      ? 0
+      : activeSpans.reduce((sum, value) => sum + value, 0) /
+        activeSpans.length,
+    models: topModels,
+  };
+}

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -231,6 +231,52 @@ export const usageResponseSchema = z.object({
   })),
 });
 
+const distributionSchema = z.object({
+  average: z.number().nonnegative(),
+  median: z.number().nonnegative(),
+  p90: z.number().nonnegative(),
+});
+
+export const overviewResponseSchema = z.object({
+  rangeDays: z.number().int().positive(),
+  sessions: z.number().int().nonnegative(),
+  activeDays: z.number().int().nonnegative(),
+  activeWeekdays: z.number().int().nonnegative(),
+  elapsedWeekdays: z.number().int().nonnegative(),
+  weekendDays: z.number().int().nonnegative(),
+  weekdayActivityRate: z.number().min(0).max(1),
+  subagentCoverage: z.enum(["full", "partial", "none"]),
+  activity: z.object({
+    sessions: distributionSchema.optional(),
+    turns: distributionSchema.optional(),
+    spend: distributionSchema.optional(),
+    hasUnpricedCost: z.boolean(),
+  }),
+  sessionProfile: z.object({
+    turns: distributionSchema.optional(),
+    input: distributionSchema.optional(),
+    peakContext: distributionSchema.optional(),
+    elapsed: distributionSchema.optional(),
+    spend: distributionSchema.optional(),
+    efficiency: distributionSchema.optional(),
+    overallEfficiency: z.number().min(0).max(1).optional(),
+    hasUnpricedCost: z.boolean(),
+  }),
+  multiDaySessions: z.number().int().nonnegative(),
+  multiDaySessionRate: z.number().min(0).max(1),
+  averageActiveSpan: z.number().nonnegative(),
+  models: z.array(z.object({
+    model: z.string(),
+    sessions: z.number().int().nonnegative(),
+    input: z.number().int().nonnegative(),
+    spend: z.number().nonnegative(),
+    spendShare: z.number().min(0).max(1),
+    efficiency: z.number().min(0).max(1).optional(),
+    hasUnpricedCost: z.boolean(),
+    isOther: z.boolean(),
+  })),
+});
+
 export const ttlMissMetricsSchema = z.object({
   rangeDays: z.number().int().positive(),
   sessions: z.number().int().nonnegative(),
@@ -291,4 +337,5 @@ export type SessionListResponse = z.infer<typeof sessionListResponseSchema>;
 export type SessionSummary = z.infer<typeof sessionSummarySchema>;
 export type TokenUsage = z.infer<typeof tokenUsageSchema>;
 export type UsageResponse = z.infer<typeof usageResponseSchema>;
+export type OverviewResponse = z.infer<typeof overviewResponseSchema>;
 export type TtlMissMetrics = z.infer<typeof ttlMissMetricsSchema>;

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -239,6 +239,7 @@ const distributionSchema = z.object({
 
 export const overviewResponseSchema = z.object({
   rangeDays: z.number().int().positive(),
+  rotationInactivityMinutes: z.number().int().positive(),
   sessions: z.number().int().nonnegative(),
   activeDays: z.number().int().nonnegative(),
   activeWeekdays: z.number().int().nonnegative(),
@@ -248,6 +249,7 @@ export const overviewResponseSchema = z.object({
   subagentCoverage: z.enum(["full", "partial", "none"]),
   activity: z.object({
     sessions: distributionSchema.optional(),
+    peakConcurrentSessions: distributionSchema.optional(),
     turns: distributionSchema.optional(),
     spend: distributionSchema.optional(),
     hasUnpricedCost: z.boolean(),


### PR DESCRIPTION
- Add a compact 90-day overview with activity and session percentile metrics
- Show token reuse, priced spend, active-day statistics, and four top models plus Other
- Integrate Overview, TTL expiry, and miss cost into a shared tabbed panel
- Calculate peak concurrent root sessions using execution intervals and a 30-minute inactivity threshold
- Attribute subagent and tool activity to root sessions
- Handle interval expiry, cross-midnight activity, and partial data caveats
- Add focused tests for overview and concurrent-session aggregation