### PR TITLE
Parse legacy Codex transcripts

### DIFF
--- a/src/server/codexImporter.ts
+++ b/src/server/codexImporter.ts
@@ -13,7 +13,7 @@ export async function syncCodexSessions(
     harness: "codex",
     label: "Codex",
     directory,
-    parserVersion: "codex-5",
+    parserVersion: "codex-6",
     repository,
     discover: discoverCodexSessions,
     normalize: normalizeCodexSession,

--- a/src/server/codexRepository.test.ts
+++ b/src/server/codexRepository.test.ts
@@ -1,4 +1,4 @@
-import { deepStrictEqual } from "node:assert/strict";
+import { deepStrictEqual, strictEqual } from "node:assert/strict";
 import { CodexRepository } from "./codexRepository.ts";
 import type { SessionDetail } from "../shared/sessionSchemas.ts";
 
@@ -162,6 +162,52 @@ Deno.test("normalizes exported Codex session arrays", () => {
   deepStrictEqual(actual?.title, "Imported session");
   deepStrictEqual(actual?.modelCalls, 1);
   deepStrictEqual(actual?.tokens.processed, 7963);
+});
+
+Deno.test("falls back to legacy Codex user-message records", () => {
+  const actual = repository({
+    "2026/02/05/rollout-legacy.jsonl": `
+{"timestamp":"2026-02-05T14:00:00.000Z","type":"event_msg","payload":{"type":"user_message","message":"Inspect legacy usage"}}
+{"timestamp":"2026-02-05T14:00:01.000Z","type":"turn_context","payload":{"model":"gpt-5.3-codex"}}
+{"timestamp":"2026-02-05T14:00:02.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":50,"output_tokens":10,"reasoning_output_tokens":4}}}}
+{"timestamp":"2026-02-05T14:00:03.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":100,"cached_input_tokens":50,"output_tokens":10,"reasoning_output_tokens":4}}}}
+{"timestamp":"2026-02-05T14:00:04.000Z","type":"event_msg","payload":{"type":"context_compacted"}}
+{"timestamp":"2026-02-05T14:00:05.000Z","type":"event_msg","payload":{"type":"user_message","message":"Continue"}}
+{"timestamp":"2026-02-05T14:00:06.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":120,"cached_input_tokens":100,"output_tokens":8,"reasoning_output_tokens":0}}}}
+`,
+  }).getSession("2026/02/05/rollout-legacy")!;
+
+  strictEqual(actual.title, "Inspect legacy usage");
+  strictEqual(actual.userTurns, 2);
+  strictEqual(actual.modelCalls, 2);
+  deepStrictEqual(actual.tokens, {
+    uncachedInput: 70,
+    cacheRead: 150,
+    cacheWrite: undefined,
+    cacheWrite5m: undefined,
+    cacheWrite1h: undefined,
+    freshPrompt: 70,
+    output: 18,
+    reasoning: 4,
+    processed: 242,
+  });
+  deepStrictEqual(actual.turns[1].calls[0].contextEventsBefore, [{
+    type: "compaction",
+    sourceOrder: 5,
+    occurredAt: Date.parse("2026-02-05T14:00:04.000Z"),
+  }]);
+});
+
+Deno.test("does not fall back for startup-only Codex transcripts", () => {
+  const actual = repository({
+    "2026/02/05/rollout-startup.jsonl": `
+{"timestamp":"2026-02-05T14:00:00.000Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"# AGENTS.md instructions"}]}}
+{"timestamp":"2026-02-05T14:00:01.000Z","type":"event_msg","payload":{"type":"user_message","message":"<environment_context>"}}
+`,
+  }).getSession("2026/02/05/rollout-startup")!;
+
+  strictEqual(actual.modelCalls, 0);
+  strictEqual(actual.userTurns, 0);
 });
 
 Deno.test("lists Codex sessions recursively by latest transcript timestamp", () => {

--- a/src/server/codexRepository.ts
+++ b/src/server/codexRepository.ts
@@ -48,6 +48,17 @@ const recordSchema = z.object({
 }).passthrough();
 
 type Record = z.infer<typeof recordSchema>;
+
+const legacyUserMessageSchema = z.object({
+  type: z.literal("event_msg"),
+  timestamp: z.string(),
+  payload: z.object({
+    type: z.literal("user_message"),
+    message: z.string(),
+  }).passthrough(),
+}).passthrough();
+
+type LegacyUserMessage = z.infer<typeof legacyUserMessageSchema>;
 export type CodexSessionCandidate = {
   id: string;
   path: string;
@@ -149,6 +160,35 @@ function userText(record: Record) {
   return record.payload.content?.find((block) => block.type === "input_text")
     ?.text ??
     record.payload.content?.find((block) => block.type === "text")?.text;
+}
+
+function legacyUserMessage(record: Record): LegacyUserMessage | undefined {
+  const result = legacyUserMessageSchema.safeParse(record);
+  return result.success ? result.data : undefined;
+}
+
+function legacyUserText(record: Record) {
+  return legacyUserMessage(record)?.payload.message;
+}
+
+function tokenUsageSignature(record: Record) {
+  if (
+    record.type !== "event_msg" || record.payload?.type !== "token_count" ||
+    !record.payload.info?.last_token_usage
+  ) return undefined;
+  const usage = record.payload.info.last_token_usage;
+  if (
+    usage.input_tokens === 0 && usage.cached_input_tokens === 0 &&
+    usage.output_tokens === 0 && usage.reasoning_output_tokens === 0 &&
+    (usage.total_tokens ?? 0) === 0
+  ) return undefined;
+  return [
+    usage.input_tokens,
+    usage.cached_input_tokens,
+    usage.output_tokens,
+    usage.reasoning_output_tokens,
+    usage.total_tokens ?? 0,
+  ].join(":");
 }
 
 function toolName(record: Record) {
@@ -390,6 +430,43 @@ function decodeRecords(records: Record[]) {
   };
 }
 
+function hasLegacyUsageEvidence(records: Record[]) {
+  return records.some(legacyUserMessage) && records.some(tokenUsageSignature);
+}
+
+function decodeLegacyRecords(records: Record[]) {
+  const adapted: Record[] = [];
+  let previousUsageSignature: string | undefined;
+  for (const record of records) {
+    const legacyUser = legacyUserMessage(record);
+    if (legacyUser) {
+      adapted.push({
+        type: "event_msg",
+        timestamp: legacyUser.timestamp,
+        payload: { type: "task_started" },
+      });
+      adapted.push({
+        type: "response_item",
+        timestamp: legacyUser.timestamp,
+        payload: {
+          type: "message",
+          role: "user",
+          content: [{ type: "input_text", text: legacyUser.payload.message }],
+        },
+      });
+      previousUsageSignature = undefined;
+      continue;
+    }
+    const usageSignature = tokenUsageSignature(record);
+    if (usageSignature !== undefined) {
+      if (usageSignature === previousUsageSignature) continue;
+      previousUsageSignature = usageSignature;
+    }
+    adapted.push(record);
+  }
+  return decodeRecords(adapted);
+}
+
 export class CodexRepository {
   constructor(private directory: string) {}
 
@@ -510,9 +587,16 @@ export function discoverCodexSessions(directory: string) {
 }
 
 function codexSession(records: Record[], id: string, updatedAt: number) {
-  const decoded = decodeRecords(records);
-  const firstPrompt = records.find((record) => userText(record)?.trim());
-  const promptTitle = userText(firstPrompt ?? { type: "" })?.replace(
+  const current = decodeRecords(records);
+  const usesLegacyDecoder = current.turns.length === 0 &&
+    hasLegacyUsageEvidence(records);
+  const decoded = usesLegacyDecoder ? decodeLegacyRecords(records) : current;
+  const prompt = usesLegacyDecoder
+    ? records.map(legacyUserText).find((value) => value?.trim())
+    : userText(records.find((record) => userText(record)?.trim()) ?? {
+      type: "",
+    });
+  const promptTitle = prompt?.replace(
     /\s+/g,
     " ",
   )


### PR DESCRIPTION
## Summary
- fall back to legacy `event_msg/user_message` turn boundaries when the current parser finds no calls
- deduplicate repeated legacy token usage snapshots and retain compaction context
- bump the Codex parser version to reimport archived transcripts

## Testing
- `deno test --allow-env --allow-read --allow-write src/server/codexRepository.test.ts src/server/codexImporter.test.ts`