### PR TITLE
Expand performance cache analysis

### DIFF
--- a/docs/performance.md
+++ b/docs/performance.md
@@ -1,0 +1,88 @@
+# Performance Notes
+
+## Resolved Demo Timestamp Bug
+
+The demo database generator previously shifted every timestamp so the earliest
+value became a fixed demo date. That was incorrect because
+`source_sessions.source_modified_at` can contain a non-epoch value. In one
+source archive, its value was `8,174,153`, so the calculated offset moved real
+session activity into 2080.
+
+This made the dashboard sluggish and rendered future session dates. The
+generator now preserves original timestamps. Do not reintroduce timestamp
+shifting without normalizing and validating every timestamp source first.
+
+The regenerated sanitized database was responsive with this representative
+data set:
+
+| Measure | Count |
+| --- | ---: |
+| Root/source sessions | 989 |
+| Turns | 6,657 |
+| Model calls | 35,608 |
+| Tool events | 34,302 |
+| Compacted database size | 8.5 MB |
+
+This indicates that the observed demo slowdown was caused by the timestamp
+bug, not by SQLite storage size or the current row count.
+
+## Deferred Query Risks
+
+These are known scaling risks from static review. Do not optimize them without
+measuring an actual slow endpoint first.
+
+### Usage And TTL Analytics Scan Before Filtering
+
+`SessionRepository.listUsageCalls` builds a recursive tree for all sessions
+before applying its optional date and harness predicates. The query shape is in
+`src/server/sessionRepository.ts`. It can therefore traverse and hydrate calls
+outside the requested range even though `model_calls.started_at` has an index.
+
+Potential direction: apply optional filters through dynamic SQL and constrain
+calls before tree expansion. The persisted `source_sessions.tree_root_id` can
+avoid rebuilding the hierarchy recursively.
+
+### Full-Tree Hydration For Summary Views
+
+The sessions endpoint enriches each list row by loading its complete session
+tree. The overview endpoint similarly loads qualifying root sessions in full.
+Detail hydration issues separate queries for context events, turns, model calls,
+tools, content, and child sessions in `SessionRepository.#detail`.
+
+This is appropriate for `GET /api/sessions/:id`, but it is expensive for list
+and overview views. It is an N+1-style risk as session count and tree depth
+increase.
+
+Potential direction: use summary-specific SQL aggregates or persisted summary
+fields for list and overview endpoints, and reserve full hydration for the
+detail endpoint. Batch child-row reads when full hydration is required.
+
+### Session Pagination And Detail Lookup
+
+Session listing sorts by `updated_at`, computed public ID, and harness. The
+existing `sessions_updated_idx` cannot satisfy all of those terms, so SQLite may
+need to sort a broad result set. Each page also runs `COUNT(*)` and uses an
+increasing `OFFSET`.
+
+Session detail lookup filters through `COALESCE(public_id, external_id)`, which
+does not have a matching index.
+
+Potential direction: order ties by `source_session_id` to match the timestamp
+index, switch to keyset pagination when needed, and index the public-ID lookup
+or make `public_id` mandatory.
+
+### Concurrent Initial Analytics Requests
+
+The client initially requests overview, sessions, usage, and TTL metrics. The
+server uses synchronous `DatabaseSync`, so expensive SQLite and JavaScript
+aggregation work blocks the process and can delay unrelated requests.
+
+Potential direction: defer non-critical analytics panels, combine shared data
+retrieval, or cache expensive responses by range and harness.
+
+## Measurement Before Optimization
+
+Use the existing `Server-Timing` response headers and server logs for
+`/api/usage` and `/api/sessions` to identify the slow endpoint. Before changing
+SQL, run `EXPLAIN QUERY PLAN` against a representative archive and compare
+endpoint latency before and after the smallest proposed change.

--- a/src/client/PerformancePage.tsx
+++ b/src/client/PerformancePage.tsx
@@ -1,0 +1,252 @@
+import { useEffect, useState } from "react";
+import { getRouteApi } from "@tanstack/react-router";
+import {
+  Line,
+  LineChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from "recharts";
+import type { PerformanceResponse } from "../shared/sessionSchemas.ts";
+import { getPerformance } from "./api.ts";
+import { SiteHeader } from "./SiteHeader.tsx";
+
+const route = getRouteApi("/performance");
+const integer = new Intl.NumberFormat("en-US");
+const date = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
+
+type ProviderResult = PerformanceResponse["openai"];
+type Week = ProviderResult["weeks"][number] & {
+  sessionRate: number | null;
+  turnRate: number | null;
+};
+
+function rate(part: number, total: number) {
+  return total === 0 ? null : part / total * 100;
+}
+
+function displayRate(value: number | null) {
+  return value === null ? "No data" : `${value.toFixed(1)}%`;
+}
+
+function formatModel(model: string) {
+  if (model === "all") return "All models";
+  return model.split(/[-_]/).map((part) =>
+    part.toLowerCase() === "gpt"
+      ? "GPT"
+      : part ? part[0].toUpperCase() + part.slice(1) : part
+  ).join(" ");
+}
+
+function MissTooltip({ active, payload }: {
+  active?: boolean;
+  payload?: Array<{ payload?: Week }>;
+}) {
+  const week = payload?.[0]?.payload;
+  if (!active || !week) return null;
+  return (
+    <div className="usage-tooltip performance-tooltip">
+      <p>
+        {date.format(new Date(`${week.date}T00:00:00`))}–
+        {date.format(new Date(`${week.endDate}T00:00:00`))}
+      </p>
+      <div>
+        <span>Sessions with a miss</span>
+        <strong>
+          {week.sessionsWithMiss} of {week.sessions} · {displayRate(week.sessionRate)}
+        </strong>
+      </div>
+      <div>
+        <span>Turns with a miss</span>
+        <strong>
+          {week.turnsWithMiss} of {week.turns} · {displayRate(week.turnRate)}
+        </strong>
+      </div>
+    </div>
+  );
+}
+
+function ProviderPanel({
+  title,
+  result,
+  models,
+  onModelChange,
+}: {
+  title: string;
+  result?: ProviderResult;
+  models: string[];
+  onModelChange: (model: string) => void;
+}) {
+  const rows: Week[] = (result?.weeks ?? []).map((week) => ({
+    ...week,
+    sessionRate: rate(week.sessionsWithMiss, week.sessions),
+    turnRate: rate(week.turnsWithMiss, week.turns),
+  }));
+  return (
+    <article className="performance-provider">
+      <div className="performance-provider-heading">
+        <div>
+          <p className="eyebrow">Provider</p>
+          <h2>{title}</h2>
+        </div>
+        <label>
+          <span>Model</span>
+          <select
+            value={result?.selectedModel ?? "all"}
+            onChange={(event) => onModelChange(event.target.value)}
+          >
+            <option value="all">All models</option>
+            {models.map((model) => (
+              <option key={model} value={model}>{formatModel(model)}</option>
+            ))}
+          </select>
+        </label>
+      </div>
+      <div className="performance-totals">
+        <div>
+          <strong>{integer.format(result?.sessions ?? 0)}</strong>
+          <span>Sessions</span>
+        </div>
+        <div>
+          <strong>{integer.format(result?.turns ?? 0)}</strong>
+          <span>Turns</span>
+        </div>
+        <div>
+          <strong>
+            {result ? displayRate(rate(result.sessionsWithMiss, result.sessions)) : "–"}
+          </strong>
+          <span>Sessions with miss</span>
+        </div>
+        <div>
+          <strong>
+            {result ? displayRate(rate(result.turnsWithMiss, result.turns)) : "–"}
+          </strong>
+          <span>Turns with miss</span>
+        </div>
+      </div>
+      <div className="performance-chart">
+        {!result
+          ? <div className="chart-message">Loading comparison…</div>
+          : (
+            <ResponsiveContainer width="100%" height="100%">
+              <LineChart data={rows} margin={{ top: 12, right: 10, bottom: 4, left: -12 }}>
+                <CartesianGrid vertical={false} stroke="#e6e2d9" />
+                <XAxis
+                  dataKey="date"
+                  tickFormatter={(value) => date.format(new Date(`${value}T00:00:00`))}
+                  tickLine={false}
+                  axisLine={false}
+                  minTickGap={24}
+                />
+                <YAxis
+                  domain={[0, 100]}
+                  tickFormatter={(value) => `${value}%`}
+                  tickLine={false}
+                  axisLine={false}
+                  width={48}
+                />
+                <Tooltip content={<MissTooltip />} />
+                <Line
+                  type="monotone"
+                  dataKey="sessionRate"
+                  name="Sessions"
+                  stroke="#b4522d"
+                  strokeWidth={2}
+                  dot={{ r: 3, fill: "#b4522d", strokeWidth: 0 }}
+                  activeDot={{ r: 5, fill: "#b4522d", stroke: "#fffdf8", strokeWidth: 2 }}
+                  connectNulls={false}
+                />
+                <Line
+                  type="monotone"
+                  dataKey="turnRate"
+                  name="Turns"
+                  stroke="#466244"
+                  strokeWidth={2}
+                  dot={{ r: 3, fill: "#466244", strokeWidth: 0 }}
+                  activeDot={{ r: 5, fill: "#466244", stroke: "#fffdf8", strokeWidth: 2 }}
+                  connectNulls={false}
+                />
+              </LineChart>
+            </ResponsiveContainer>
+          )}
+      </div>
+      <div className="performance-legend">
+        <span><i className="session-series" /> Sessions with any miss</span>
+        <span><i className="turn-series" /> Turns with any miss</span>
+      </div>
+    </article>
+  );
+}
+
+export function PerformancePage() {
+  const search = route.useSearch();
+  const navigate = route.useNavigate();
+  const [data, setData] = useState<PerformanceResponse>();
+  const [error, setError] = useState<string>();
+
+  useEffect(() => {
+    let active = true;
+    setData(undefined);
+    setError(undefined);
+    getPerformance(search.harness, search.openai, search.anthropic).then((result) => {
+      if (active) setData(result);
+    }).catch((reason) => {
+      if (active) setError(reason instanceof Error ? reason.message : "Unable to load performance");
+    });
+    return () => { active = false; };
+  }, [search.harness, search.openai, search.anthropic]);
+
+  function update(next: Partial<typeof search>) {
+    navigate({ search: { ...search, ...next } });
+  }
+
+  return (
+    <main>
+      <SiteHeader active="performance" />
+      <section className="performance-intro">
+        <div>
+          <p className="eyebrow">Model comparison</p>
+          <h2>Cache performance</h2>
+          <p>Weekly session cohorts from the last 90 days.</p>
+        </div>
+        <label>
+          <span>Harness</span>
+          <select
+            value={search.harness}
+            onChange={(event) => update({ harness: event.target.value as typeof search.harness })}
+          >
+            <option value="all">All harnesses</option>
+            <option value="claude-code">Claude Code</option>
+            <option value="opencode">OpenCode</option>
+            <option value="pi">PI</option>
+            <option value="codex">Codex</option>
+          </select>
+        </label>
+      </section>
+      {error && <div className="error performance-error">{error}</div>}
+      <section className="performance-grid">
+        <ProviderPanel
+          title="OpenAI"
+          result={data?.openai}
+          models={data?.models.openai ?? []}
+          onModelChange={(openai) => update({ openai })}
+        />
+        <ProviderPanel
+          title="Anthropic"
+          result={data?.anthropic}
+          models={data?.models.anthropic ?? []}
+          onModelChange={(anthropic) => update({ anthropic })}
+        />
+      </section>
+      <section className="performance-next" aria-label="Planned cache efficiency comparison">
+        <div>
+          <p className="eyebrow">Next metric</p>
+          <h2>Cache efficiency distribution</h2>
+          <p>Weekly session-level box and whisker comparison.</p>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/src/client/PerformancePage.tsx
+++ b/src/client/PerformancePage.tsx
@@ -76,8 +76,8 @@ function EfficiencyBoxPlot({ weeks }: { weeks: ProviderResult["weeks"] }) {
   const [selected, setSelected] = useState<ProviderResult["weeks"][number]>();
   const width = 720;
   const height = 260;
-  const left = 52;
-  const right = 18;
+  const left = 42;
+  const right = 10;
   const top = 14;
   const bottom = 40;
   const plotWidth = width - left - right;
@@ -170,7 +170,7 @@ function EfficiencyBoxPlot({ weeks }: { weeks: ProviderResult["weeks"] }) {
               </dl>
             </div>
           )
-          : <span className="efficiency-tooltip-hint">Hover or focus a weekly box for details</span>}
+          : <span className="efficiency-tooltip-hint">Hover to see details</span>}
       </div>
     </div>
   );
@@ -190,6 +190,53 @@ function EfficiencyPanel({ title, result }: { title: string; result?: ProviderRe
       {!result
         ? <div className="performance-chart"><div className="chart-message">Loading distribution…</div></div>
         : <EfficiencyBoxPlot weeks={result.weeks} />}
+    </article>
+  );
+}
+
+const imageCohortLabels = {
+  "no-image": "No image",
+  "first-turn-image": "Image in first turn",
+  "later-turn-image": "Image introduced later",
+} as const;
+
+function ImageCohortPanel({
+  title,
+  result,
+}: {
+  title: string;
+  result?: ProviderResult;
+}) {
+  return (
+    <article className="performance-provider image-cohort-panel">
+      <div className="performance-provider-heading">
+        <h2>{title}</h2>
+        <span className="efficiency-model">
+          {formatModel(result?.selectedModel ?? "all")}
+        </span>
+      </div>
+      {!result
+        ? <div className="image-cohort-message">Loading image cohorts…</div>
+        : (
+          <div className="image-cohort-list">
+            {result.imageCohorts.map((cohort) => {
+              const missRate = rate(cohort.sessionsWithMiss, cohort.sessions);
+              const title = `${cohort.sessionsWithMiss} of ${cohort.sessions} sessions`;
+              return (
+                <div className="image-cohort-row" key={cohort.cohort} title={title}>
+                  <div>
+                    <span>{imageCohortLabels[cohort.cohort]}</span>
+                    <strong>{displayRate(missRate)}</strong>
+                  </div>
+                  <i>
+                    <b style={{ width: `${missRate ?? 0}%` }} />
+                  </i>
+                  <small>{cohort.sessionsWithMiss} of {cohort.sessions}</small>
+                </div>
+              );
+            })}
+          </div>
+        )}
     </article>
   );
 }
@@ -214,7 +261,6 @@ function ProviderPanel({
     <article className="performance-provider">
       <div className="performance-provider-heading">
         <div>
-          <p className="eyebrow">Provider</p>
           <h2>{title}</h2>
         </div>
         <label>
@@ -299,8 +345,8 @@ function ProviderPanel({
           )}
       </div>
       <div className="performance-legend">
-        <span><i className="session-series" /> Sessions with any miss</span>
-        <span><i className="turn-series" /> Turns with any miss</span>
+        <span><i className="session-series" /> Sessions</span>
+        <span><i className="turn-series" /> Turns</span>
       </div>
     </article>
   );
@@ -333,9 +379,7 @@ export function PerformancePage() {
       <SiteHeader active="performance" />
       <section className="performance-intro">
         <div>
-          <p className="eyebrow">Model comparison</p>
           <h2>Cache performance</h2>
-          <p>Weekly session cohorts from the last 90 days.</p>
         </div>
         <label>
           <span>Harness</span>
@@ -372,6 +416,13 @@ export function PerformancePage() {
       <section className="performance-grid">
         <EfficiencyPanel title="OpenAI" result={data?.openai} />
         <EfficiencyPanel title="Anthropic" result={data?.anthropic} />
+      </section>
+      <section className="performance-section-heading">
+        <h2>Miss rate by image use</h2>
+      </section>
+      <section className="performance-grid">
+        <ImageCohortPanel title="OpenAI" result={data?.openai} />
+        <ImageCohortPanel title="Anthropic" result={data?.anthropic} />
       </section>
     </main>
   );

--- a/src/client/PerformancePage.tsx
+++ b/src/client/PerformancePage.tsx
@@ -68,6 +68,132 @@ function MissTooltip({ active, payload }: {
   );
 }
 
+function percent(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function EfficiencyBoxPlot({ weeks }: { weeks: ProviderResult["weeks"] }) {
+  const [selected, setSelected] = useState<ProviderResult["weeks"][number]>();
+  const width = 720;
+  const height = 260;
+  const left = 52;
+  const right = 18;
+  const top = 14;
+  const bottom = 40;
+  const plotWidth = width - left - right;
+  const plotHeight = height - top - bottom;
+  const step = plotWidth / Math.max(weeks.length, 1);
+  const y = (value: number) => top + (1 - value) * plotHeight;
+  const selectedEfficiency = selected?.efficiency;
+
+  return (
+    <div className="efficiency-chart">
+      <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Weekly cache efficiency distributions">
+        {[0, 0.25, 0.5, 0.75, 1].map((value) => (
+          <g key={value}>
+            <line
+              x1={left}
+              x2={width - right}
+              y1={y(value)}
+              y2={y(value)}
+              className="efficiency-grid-line"
+            />
+            <text x={left - 9} y={y(value) + 3} textAnchor="end" className="efficiency-axis-label">
+              {Math.round(value * 100)}%
+            </text>
+          </g>
+        ))}
+        {weeks.map((week, index) => {
+          const value = week.efficiency;
+          const x = left + step * index + step / 2;
+          const boxWidth = Math.min(24, step * .48);
+          return (
+            <g key={week.date}>
+              {value && (
+                <g
+                  className={`efficiency-box ${value.sampleSize < 5 ? "small-sample" : ""}`}
+                  tabIndex={0}
+                  role="img"
+                  aria-label={`${week.date}, median ${percent(value.median)}, ${value.sampleSize} sessions`}
+                  onMouseEnter={() => setSelected(week)}
+                  onMouseLeave={() => setSelected(undefined)}
+                  onFocus={() => setSelected(week)}
+                  onBlur={() => setSelected(undefined)}
+                >
+                  <line x1={x} x2={x} y1={y(value.upperWhisker)} y2={y(value.lowerWhisker)} />
+                  <line x1={x - boxWidth / 3} x2={x + boxWidth / 3} y1={y(value.upperWhisker)} y2={y(value.upperWhisker)} />
+                  <line x1={x - boxWidth / 3} x2={x + boxWidth / 3} y1={y(value.lowerWhisker)} y2={y(value.lowerWhisker)} />
+                  <rect
+                    x={x - boxWidth / 2}
+                    y={y(value.q3)}
+                    width={boxWidth}
+                    height={Math.max(1, y(value.q1) - y(value.q3))}
+                  />
+                  <line
+                    className="efficiency-median"
+                    x1={x - boxWidth / 2}
+                    x2={x + boxWidth / 2}
+                    y1={y(value.median)}
+                    y2={y(value.median)}
+                  />
+                </g>
+              )}
+              {(index % 2 === 0 || weeks.length <= 8) && (
+                <text x={x} y={height - 17} textAnchor="middle" className="efficiency-axis-label">
+                  {date.format(new Date(`${week.date}T00:00:00`))}
+                </text>
+              )}
+            </g>
+          );
+        })}
+      </svg>
+      <div className="efficiency-tooltip-slot" aria-live="polite">
+        {selected && selectedEfficiency
+          ? (
+            <div className="efficiency-tooltip">
+              <div className="efficiency-tooltip-heading">
+                <p>
+                  {date.format(new Date(`${selected.date}T00:00:00`))}–
+                  {date.format(new Date(`${selected.endDate}T00:00:00`))}
+                </p>
+                <strong>{selectedEfficiency.sampleSize} sessions</strong>
+                {selectedEfficiency.sampleSize < 5 && <small>Small sample</small>}
+              </div>
+              <dl>
+                <div><dt>Lower</dt><dd>{percent(selectedEfficiency.lowerWhisker)}</dd></div>
+                <div><dt>P25</dt><dd>{percent(selectedEfficiency.q1)}</dd></div>
+                <div><dt>Median</dt><dd>{percent(selectedEfficiency.median)}</dd></div>
+                <div><dt>P75</dt><dd>{percent(selectedEfficiency.q3)}</dd></div>
+                <div><dt>Upper</dt><dd>{percent(selectedEfficiency.upperWhisker)}</dd></div>
+                <div><dt>Average</dt><dd>{percent(selectedEfficiency.average)}</dd></div>
+                <div><dt>Outliers</dt><dd>{selectedEfficiency.outliers}</dd></div>
+              </dl>
+            </div>
+          )
+          : <span className="efficiency-tooltip-hint">Hover or focus a weekly box for details</span>}
+      </div>
+    </div>
+  );
+}
+
+function EfficiencyPanel({ title, result }: { title: string; result?: ProviderResult }) {
+  return (
+    <article className="performance-provider efficiency-panel">
+      <div className="performance-provider-heading">
+        <div>
+          <h2>{title}</h2>
+        </div>
+        <span className="efficiency-model">
+          {formatModel(result?.selectedModel ?? "all")}
+        </span>
+      </div>
+      {!result
+        ? <div className="performance-chart"><div className="chart-message">Loading distribution…</div></div>
+        : <EfficiencyBoxPlot weeks={result.weeks} />}
+    </article>
+  );
+}
+
 function ProviderPanel({
   title,
   result,
@@ -240,12 +366,12 @@ export function PerformancePage() {
           onModelChange={(anthropic) => update({ anthropic })}
         />
       </section>
-      <section className="performance-next" aria-label="Planned cache efficiency comparison">
-        <div>
-          <p className="eyebrow">Next metric</p>
-          <h2>Cache efficiency distribution</h2>
-          <p>Weekly session-level box and whisker comparison.</p>
-        </div>
+      <section className="performance-section-heading">
+        <h2>Cache efficiency</h2>
+      </section>
+      <section className="performance-grid">
+        <EfficiencyPanel title="OpenAI" result={data?.openai} />
+        <EfficiencyPanel title="Anthropic" result={data?.anthropic} />
       </section>
     </main>
   );

--- a/src/client/PerformancePage.tsx
+++ b/src/client/PerformancePage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { getRouteApi } from "@tanstack/react-router";
 import {
+  Bar,
+  BarChart,
   Line,
   LineChart,
   CartesianGrid,
@@ -15,9 +17,14 @@ import { SiteHeader } from "./SiteHeader.tsx";
 
 const route = getRouteApi("/performance");
 const integer = new Intl.NumberFormat("en-US");
+const compact = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
 const date = new Intl.DateTimeFormat(undefined, { month: "short", day: "numeric" });
 
 type ProviderResult = PerformanceResponse["openai"];
+type DistributionKey = "efficiency" | "finalContextShare";
 type Week = ProviderResult["weeks"][number] & {
   sessionRate: number | null;
   turnRate: number | null;
@@ -72,7 +79,15 @@ function percent(value: number) {
   return `${(value * 100).toFixed(1)}%`;
 }
 
-function EfficiencyBoxPlot({ weeks }: { weeks: ProviderResult["weeks"] }) {
+function EfficiencyBoxPlot({
+  weeks,
+  distribution,
+  label,
+}: {
+  weeks: ProviderResult["weeks"];
+  distribution: DistributionKey;
+  label: string;
+}) {
   const [selected, setSelected] = useState<ProviderResult["weeks"][number]>();
   const width = 720;
   const height = 260;
@@ -84,11 +99,11 @@ function EfficiencyBoxPlot({ weeks }: { weeks: ProviderResult["weeks"] }) {
   const plotHeight = height - top - bottom;
   const step = plotWidth / Math.max(weeks.length, 1);
   const y = (value: number) => top + (1 - value) * plotHeight;
-  const selectedEfficiency = selected?.efficiency;
+  const selectedEfficiency = selected?.[distribution];
 
   return (
     <div className="efficiency-chart">
-      <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label="Weekly cache efficiency distributions">
+      <svg viewBox={`0 0 ${width} ${height}`} role="img" aria-label={`Weekly ${label.toLowerCase()} distributions`}>
         {[0, 0.25, 0.5, 0.75, 1].map((value) => (
           <g key={value}>
             <line
@@ -98,13 +113,13 @@ function EfficiencyBoxPlot({ weeks }: { weeks: ProviderResult["weeks"] }) {
               y2={y(value)}
               className="efficiency-grid-line"
             />
-            <text x={left - 9} y={y(value) + 3} textAnchor="end" className="efficiency-axis-label">
+            <text x={left - 9} y={y(value) + 4} textAnchor="end" className="efficiency-axis-label efficiency-y-axis-label">
               {Math.round(value * 100)}%
             </text>
           </g>
         ))}
         {weeks.map((week, index) => {
-          const value = week.efficiency;
+          const value = week[distribution];
           const x = left + step * index + step / 2;
           const boxWidth = Math.min(24, step * .48);
           return (
@@ -114,7 +129,7 @@ function EfficiencyBoxPlot({ weeks }: { weeks: ProviderResult["weeks"] }) {
                   className={`efficiency-box ${value.sampleSize < 5 ? "small-sample" : ""}`}
                   tabIndex={0}
                   role="img"
-                  aria-label={`${week.date}, median ${percent(value.median)}, ${value.sampleSize} sessions`}
+                  aria-label={`${week.date}, ${label.toLowerCase()} median ${percent(value.median)}, ${value.sampleSize} sessions`}
                   onMouseEnter={() => setSelected(week)}
                   onMouseLeave={() => setSelected(undefined)}
                   onFocus={() => setSelected(week)}
@@ -176,7 +191,17 @@ function EfficiencyBoxPlot({ weeks }: { weeks: ProviderResult["weeks"] }) {
   );
 }
 
-function EfficiencyPanel({ title, result }: { title: string; result?: ProviderResult }) {
+function DistributionPanel({
+  title,
+  result,
+  distribution,
+  label,
+}: {
+  title: string;
+  result?: ProviderResult;
+  distribution: DistributionKey;
+  label: string;
+}) {
   return (
     <article className="performance-provider efficiency-panel">
       <div className="performance-provider-heading">
@@ -189,7 +214,131 @@ function EfficiencyPanel({ title, result }: { title: string; result?: ProviderRe
       </div>
       {!result
         ? <div className="performance-chart"><div className="chart-message">Loading distribution…</div></div>
-        : <EfficiencyBoxPlot weeks={result.weeks} />}
+        : <EfficiencyBoxPlot weeks={result.weeks} distribution={distribution} label={label} />}
+    </article>
+  );
+}
+
+const cacheLossBuckets = [
+  { bucket: "0-16k", key: "loss0To16k", label: "0–16k", color: "#dbad94" },
+  { bucket: "16-64k", key: "loss16To64k", label: "16–64k", color: "#c97850" },
+  { bucket: "64-128k", key: "loss64To128k", label: "64–128k", color: "#a94b2a" },
+  { bucket: "128k+", key: "loss128kPlus", label: "128k+", color: "#762d1b" },
+] as const;
+
+type CacheLossBucket = (typeof cacheLossBuckets)[number]["bucket"];
+type CacheLossWeek = ProviderResult["weeks"][number] & {
+  loss0To16k: number | null;
+  loss16To64k: number | null;
+  loss64To128k: number | null;
+  loss128kPlus: number | null;
+};
+
+function lossTokens(
+  retention: ProviderResult["weeks"][number]["cacheRetention"],
+  bucket: CacheLossBucket,
+) {
+  if (!retention) return null;
+  return retention.lossBuckets.find((entry) => entry.bucket === bucket)
+    ?.unretainedTokens ?? 0;
+}
+
+function CacheLossTooltip({ active, payload }: {
+  active?: boolean;
+  payload?: Array<{ payload?: CacheLossWeek }>;
+}) {
+  const week = payload?.[0]?.payload;
+  const retention = week?.cacheRetention;
+  if (!active || !week || !retention) return null;
+  return (
+    <div className="usage-tooltip performance-tooltip">
+      <p>
+        {date.format(new Date(`${week.date}T00:00:00`))}–
+        {date.format(new Date(`${week.endDate}T00:00:00`))}
+      </p>
+      <div className="cache-loss-tooltip-columns" aria-hidden="true">
+        <span />
+        <span>Requests</span>
+        <span>Tokens</span>
+      </div>
+      {[...retention.lossBuckets].reverse().map((bucket) => bucket.unretainedTokens > 0 && (
+        <div className="cache-loss-tooltip-row" key={bucket.bucket}>
+          <span>{cacheLossBuckets.find((entry) => entry.bucket === bucket.bucket)?.label} misses</span>
+          <strong>{integer.format(bucket.requests)}</strong>
+          <strong title={integer.format(bucket.unretainedTokens)}>
+            {compact.format(bucket.unretainedTokens)}
+          </strong>
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function CacheLossPanel({ title, result }: { title: string; result?: ProviderResult }) {
+  const rows: CacheLossWeek[] = (result?.weeks ?? []).map((week) => ({
+    ...week,
+    loss0To16k: lossTokens(week.cacheRetention, "0-16k"),
+    loss16To64k: lossTokens(week.cacheRetention, "16-64k"),
+    loss64To128k: lossTokens(week.cacheRetention, "64-128k"),
+    loss128kPlus: lossTokens(week.cacheRetention, "128k+"),
+  }));
+  const hasData = rows.some((week) =>
+    week.cacheRetention?.lossBuckets.some((bucket) => bucket.unretainedTokens > 0)
+  );
+
+  return (
+    <article className="performance-provider cache-retention-panel">
+      <div className="performance-provider-heading">
+        <h2>{title}</h2>
+        <span className="efficiency-model">
+          {formatModel(result?.selectedModel ?? "all")}
+        </span>
+      </div>
+      {!result
+        ? <div className="performance-chart"><div className="chart-message">Loading cache misses…</div></div>
+        : !hasData
+        ? <div className="image-cohort-message">No partial or full cache misses.</div>
+        : (
+          <>
+            <div className="performance-chart cache-retention-chart">
+              <ResponsiveContainer width="100%" height="100%">
+                <BarChart data={rows} margin={{ top: 12, right: 10, bottom: 4, left: -12 }}>
+                  <CartesianGrid vertical={false} stroke="#e6e2d9" />
+                  <XAxis
+                    dataKey="date"
+                    tickFormatter={(value) => date.format(new Date(`${value}T00:00:00`))}
+                    tickLine={false}
+                    axisLine={false}
+                    minTickGap={24}
+                  />
+                  <YAxis
+                    tickFormatter={(value) => compact.format(value)}
+                    tickLine={false}
+                    axisLine={false}
+                    width={48}
+                  />
+                  <Tooltip content={<CacheLossTooltip />} />
+                  {cacheLossBuckets.map((bucket) => (
+                    <Bar
+                      key={bucket.key}
+                      dataKey={bucket.key}
+                      name={`${bucket.label} misses`}
+                      stackId="loss"
+                      fill={bucket.color}
+                    />
+                  ))}
+                </BarChart>
+              </ResponsiveContainer>
+            </div>
+            <div className="performance-legend cache-retention-legend">
+              {[...cacheLossBuckets].reverse().map((bucket) => (
+                <span key={bucket.key}>
+                  <i style={{ background: bucket.color }} /> {bucket.label} misses
+                </span>
+              ))}
+            </div>
+          </>
+        )}
     </article>
   );
 }
@@ -412,10 +561,39 @@ export function PerformancePage() {
       </section>
       <section className="performance-section-heading">
         <h2>Cache efficiency</h2>
+        <p>Cached input as a percent of total session input. Higher means more context was served from cache.</p>
       </section>
       <section className="performance-grid">
-        <EfficiencyPanel title="OpenAI" result={data?.openai} />
-        <EfficiencyPanel title="Anthropic" result={data?.anthropic} />
+        <DistributionPanel
+          title="OpenAI"
+          result={data?.openai}
+          distribution="efficiency"
+          label="Cache efficiency"
+        />
+        <DistributionPanel
+          title="Anthropic"
+          result={data?.anthropic}
+          distribution="efficiency"
+          label="Cache efficiency"
+        />
+      </section>
+      <section className="performance-section-heading">
+        <h2>Context efficiency</h2>
+        <p>Final input context as a percent of total session input. Higher means less earlier context processing.</p>
+      </section>
+      <section className="performance-grid">
+        <DistributionPanel
+          title="OpenAI"
+          result={data?.openai}
+          distribution="finalContextShare"
+          label="Context efficiency"
+        />
+        <DistributionPanel
+          title="Anthropic"
+          result={data?.anthropic}
+          distribution="finalContextShare"
+          label="Context efficiency"
+        />
       </section>
       <section className="performance-section-heading">
         <h2>Miss rate by image use</h2>
@@ -423,6 +601,14 @@ export function PerformancePage() {
       <section className="performance-grid">
         <ImageCohortPanel title="OpenAI" result={data?.openai} />
         <ImageCohortPanel title="Anthropic" result={data?.anthropic} />
+      </section>
+      <section className="performance-section-heading">
+        <h2>Unexpected cache-miss volume</h2>
+        <p>Partial/full misses not attributed to compaction or cache expiry, grouped by inferred context loss.</p>
+      </section>
+      <section className="performance-grid">
+        <CacheLossPanel title="OpenAI" result={data?.openai} />
+        <CacheLossPanel title="Anthropic" result={data?.anthropic} />
       </section>
     </main>
   );

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -21,6 +21,7 @@ import openCodeIcon from "./assets/icons/opencode-logo-light.svg";
 import piIcon from "./assets/icons/pi-logo.svg";
 import { UsageChart } from "./UsageChart.tsx";
 import { TtlMissCard } from "./TtlMissCard.tsx";
+import { SiteHeader } from "./SiteHeader.tsx";
 
 const route = getRouteApi("/");
 const integer = new Intl.NumberFormat("en-US");
@@ -1808,12 +1809,7 @@ export function SessionsPage() {
 
   return (
     <main>
-      <header className="page-header">
-        <div>
-          <p className="eyebrow">Local agent economics</p>
-          <h1>Frugal Tokens</h1>
-        </div>
-      </header>
+      <SiteHeader active="overview" />
 
       <div className="homepage-metrics">
         <TtlMissCard

--- a/src/client/SiteHeader.tsx
+++ b/src/client/SiteHeader.tsx
@@ -1,0 +1,21 @@
+export function SiteHeader({ active }: { active: "overview" | "performance" }) {
+  return (
+    <header className="page-header site-header">
+      <div>
+        <p className="eyebrow">Local agent economics</p>
+        <h1>Frugal Tokens</h1>
+      </div>
+      <nav className="page-tabs" aria-label="Primary navigation">
+        <a className={active === "overview" ? "active" : undefined} href="/">
+          Overview
+        </a>
+        <a
+          className={active === "performance" ? "active" : undefined}
+          href="/performance"
+        >
+          Performance
+        </a>
+      </nav>
+    </header>
+  );
+}

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -1,5 +1,6 @@
 import {
   overviewResponseSchema,
+  performanceResponseSchema,
   sessionDetailSchema,
   sessionListResponseSchema,
   ttlMissMetricsSchema,
@@ -31,6 +32,21 @@ export async function getUsage(range: number | "all", harness: string) {
 export async function getOverview(range: number | "all", harness: string) {
   return overviewResponseSchema.parse(
     await getJson(`/api/overview?range=${range}&harness=${harness}`),
+  );
+}
+
+export async function getPerformance(
+  harness: string,
+  openaiModel: string,
+  anthropicModel: string,
+) {
+  const query = new URLSearchParams({
+    harness,
+    openai: openaiModel,
+    anthropic: anthropicModel,
+  });
+  return performanceResponseSchema.parse(
+    await getJson(`/api/performance?${query}`),
   );
 }
 

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -9,6 +9,7 @@ import {
 } from "@tanstack/react-router";
 import { z } from "zod";
 import { SessionsPage } from "./SessionsPage.tsx";
+import { PerformancePage } from "./PerformancePage.tsx";
 import "./styles.css";
 
 function AppError({ error, reset }: { error: unknown; reset: () => void }) {
@@ -64,7 +65,19 @@ const indexRoute = createRoute({
   }),
   component: SessionsPage,
 });
-const router = createRouter({ routeTree: rootRoute.addChildren([indexRoute]) });
+const performanceRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/performance",
+  validateSearch: z.object({
+    harness: z.enum(["all", "opencode", "claude-code", "pi", "codex"]).catch("all"),
+    openai: z.string().catch("all"),
+    anthropic: z.string().catch("all"),
+  }),
+  component: PerformancePage,
+});
+const router = createRouter({
+  routeTree: rootRoute.addChildren([indexRoute, performanceRoute]),
+});
 
 declare module "@tanstack/react-router" {
   interface Register {

--- a/src/client/performance.css
+++ b/src/client/performance.css
@@ -189,18 +189,145 @@
   background: var(--green);
 }
 
-.performance-next {
-  margin-top: 24px;
-  padding: 24px;
-  border: 1px dashed var(--panel-border);
-  background: rgba(255, 253, 248, .5);
+.performance-section-heading {
+  margin: 32px 0 16px;
+}
+
+.performance-section-heading h2 {
+  margin: 0;
+  font-size: 24px;
+  letter-spacing: -.025em;
+}
+
+.efficiency-model {
+  max-width: 220px;
+  overflow: hidden;
+  color: var(--muted);
+  font: 10px var(--mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.efficiency-chart {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 124px;
+  min-height: 270px;
+  padding: 8px 12px 0;
+  font-family: var(--mono);
+}
+
+.efficiency-chart svg {
+  display: block;
+  width: 100%;
+  min-width: 0;
+  min-height: 260px;
+}
+
+.efficiency-grid-line {
+  stroke: var(--row-border);
+  stroke-width: 1;
+}
+
+.efficiency-axis-label {
+  fill: var(--muted);
+  font: 9px var(--mono);
+}
+
+.efficiency-box {
+  outline: none;
+}
+
+.efficiency-box line {
+  stroke: var(--green);
+  stroke-width: 1.5;
+}
+
+.efficiency-box rect {
+  fill: rgba(70, 98, 68, .2);
+  stroke: var(--green);
+  stroke-width: 1.5;
+}
+
+.efficiency-box .efficiency-median {
+  stroke: var(--accent);
+  stroke-width: 2.5;
+}
+
+.efficiency-box:hover rect,
+.efficiency-box:focus rect {
+  fill: rgba(70, 98, 68, .34);
+}
+
+.efficiency-box.small-sample {
+  opacity: .55;
+}
+
+.efficiency-tooltip-slot {
+  min-width: 0;
+  min-height: 236px;
+  margin: 10px 0;
+  padding: 3px 0 3px 10px;
+  border-left: 1px solid var(--row-border);
+  font: 9px var(--mono);
+}
+
+.efficiency-tooltip-hint {
+  display: block;
+  max-width: 125px;
+  padding-top: 8px;
+  color: var(--muted);
+  line-height: 1.5;
+}
+
+.efficiency-tooltip {
+  display: grid;
+  gap: 9px;
+  padding-top: 3px;
+}
+
+.efficiency-tooltip-heading p {
+  margin: 0 0 4px;
+  color: var(--muted);
+}
+
+.efficiency-tooltip-heading strong {
+  font-size: 11px;
+}
+
+.efficiency-tooltip-heading small {
+  display: block;
+  margin-top: 3px;
+  color: var(--accent);
+}
+
+.efficiency-tooltip dl {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 4px;
+  margin: 0;
+}
+
+.efficiency-tooltip dl div {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: 8px;
+}
+
+.efficiency-tooltip dt {
+  color: var(--muted);
+}
+
+.efficiency-tooltip dd {
+  margin: 0;
+  font-weight: 600;
 }
 
 .performance-error {
   margin-bottom: 16px;
 }
 
-@media (max-width: 1000px) {
+@media (max-width: 1250px) {
   .performance-grid {
     grid-template-columns: 1fr;
   }
@@ -235,5 +362,44 @@
 
   .performance-totals > div:nth-child(4) {
     border-top: 1px solid var(--row-border);
+  }
+
+  .efficiency-chart {
+    grid-template-columns: 1fr;
+  }
+
+  .efficiency-tooltip-slot {
+    min-height: 78px;
+    margin: 0 12px 8px 40px;
+    padding: 10px 0 0;
+    border-top: 1px solid var(--row-border);
+    border-left: 0;
+  }
+
+  .efficiency-tooltip {
+    grid-template-columns: minmax(110px, .6fr) minmax(0, 1.4fr);
+    gap: 12px;
+    padding-top: 0;
+  }
+
+  .efficiency-tooltip dl {
+    grid-template-columns: repeat(4, minmax(42px, 1fr));
+    gap: 5px 8px;
+  }
+
+  .efficiency-tooltip dl div {
+    display: grid;
+    justify-content: initial;
+    gap: 2px;
+  }
+}
+
+@media (max-width: 480px) {
+  .efficiency-tooltip {
+    grid-template-columns: 1fr;
+  }
+
+  .efficiency-tooltip dl {
+    grid-template-columns: repeat(4, minmax(38px, 1fr));
   }
 }

--- a/src/client/performance.css
+++ b/src/client/performance.css
@@ -159,6 +159,32 @@
   color: var(--muted);
 }
 
+.cache-loss-tooltip-columns,
+.cache-loss-tooltip-row {
+  display: grid !important;
+  grid-template-columns: minmax(0, 1fr) 54px 58px;
+  gap: 8px !important;
+}
+
+.cache-loss-tooltip-columns {
+  padding-top: 9px !important;
+  color: var(--muted);
+  font-size: 8px;
+  letter-spacing: .03em;
+  text-transform: uppercase;
+}
+
+.cache-loss-tooltip-columns span:not(:first-child),
+.cache-loss-tooltip-row > span,
+.cache-loss-tooltip-row strong {
+  font-variant-numeric: tabular-nums;
+  text-align: right;
+}
+
+.cache-loss-tooltip-row strong {
+  white-space: nowrap;
+}
+
 .performance-legend {
   display: flex;
   justify-content: center;
@@ -198,6 +224,13 @@
   letter-spacing: -.025em;
 }
 
+.performance-section-heading p {
+  max-width: 720px;
+  margin: 6px 0 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
 .efficiency-model {
   max-width: 220px;
   overflow: hidden;
@@ -230,6 +263,12 @@
 .efficiency-axis-label {
   fill: var(--muted);
   font: 9px var(--mono);
+}
+
+.efficiency-y-axis-label {
+  fill: var(--ink);
+  font-size: 11px;
+  font-weight: 600;
 }
 
 .efficiency-box {

--- a/src/client/performance.css
+++ b/src/client/performance.css
@@ -1,0 +1,239 @@
+
+.site-header {
+  position: relative;
+  min-height: 54px;
+}
+
+.page-tabs {
+  position: absolute;
+  left: 50%;
+  bottom: 3px;
+  display: flex;
+  gap: 30px;
+  transform: translateX(-50%);
+}
+
+.page-tabs a {
+  position: relative;
+  padding: 10px 1px;
+  color: var(--muted);
+  font: 11px var(--mono);
+  letter-spacing: .06em;
+  text-decoration: none;
+  text-transform: uppercase;
+}
+
+.page-tabs a:hover,
+.page-tabs a.active {
+  color: var(--ink);
+}
+
+.page-tabs a.active::after {
+  content: "";
+  position: absolute;
+  right: 0;
+  bottom: 0;
+  left: 0;
+  height: 2px;
+  background: var(--accent);
+}
+
+.performance-intro {
+  display: flex;
+  align-items: end;
+  justify-content: space-between;
+  gap: 24px;
+  margin: 34px 0 18px;
+}
+
+.performance-intro h2,
+.performance-next h2 {
+  margin: 4px 0;
+  font-size: 26px;
+  letter-spacing: -.025em;
+}
+
+.performance-intro p:last-child,
+.performance-next p:last-child {
+  margin: 0;
+  color: var(--muted);
+  font-size: 13px;
+}
+
+.performance-intro label,
+.performance-provider-heading label {
+  display: grid;
+  gap: 5px;
+  color: var(--muted);
+  font: 9px var(--mono);
+  letter-spacing: .05em;
+  text-transform: uppercase;
+}
+
+.performance-intro select,
+.performance-provider-heading select {
+  min-width: 160px;
+  padding: 8px 30px 8px 10px;
+  border: 1px solid #bbb8af;
+  border-radius: 0;
+  background: var(--surface-0);
+  color: var(--ink);
+  font: 11px var(--mono);
+}
+
+.performance-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.performance-provider {
+  min-width: 0;
+  border: 1px solid var(--panel-border);
+  background: var(--panel);
+  box-shadow: 0 18px 60px rgba(57, 51, 40, .08);
+}
+
+.performance-provider-heading {
+  display: flex;
+  min-height: 76px;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 14px 20px 14px 24px;
+  border-bottom: 1px solid var(--panel-border);
+  background: var(--surface-1);
+}
+
+.performance-provider-heading h2 {
+  margin: 2px 0 0;
+  font-size: 22px;
+}
+
+.performance-totals {
+  display: grid;
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+  border-bottom: 1px solid var(--row-border);
+}
+
+.performance-totals > div {
+  display: grid;
+  gap: 3px;
+  padding: 12px 14px;
+}
+
+.performance-totals > div + div {
+  border-left: 1px solid var(--row-border);
+}
+
+.performance-totals strong {
+  font: 600 16px var(--mono);
+  font-variant-numeric: tabular-nums;
+}
+
+.performance-totals span {
+  color: var(--muted);
+  font: 8px var(--mono);
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+
+.performance-chart {
+  height: 310px;
+  padding: 12px 14px 0 5px;
+  font: 9px var(--mono);
+}
+
+.performance-tooltip p {
+  margin: 0 0 9px;
+  font-weight: 600;
+}
+
+.performance-tooltip div {
+  display: flex;
+  justify-content: space-between;
+  gap: 20px;
+  padding-top: 5px;
+}
+
+.performance-tooltip span {
+  color: var(--muted);
+}
+
+.performance-legend {
+  display: flex;
+  justify-content: center;
+  gap: 22px;
+  padding: 4px 20px 17px;
+  color: var(--muted);
+  font: 9px var(--mono);
+}
+
+.performance-legend span {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.performance-legend i {
+  width: 9px;
+  height: 9px;
+  border-radius: 50%;
+}
+
+.performance-legend .session-series {
+  background: var(--accent);
+}
+
+.performance-legend .turn-series {
+  background: var(--green);
+}
+
+.performance-next {
+  margin-top: 24px;
+  padding: 24px;
+  border: 1px dashed var(--panel-border);
+  background: rgba(255, 253, 248, .5);
+}
+
+.performance-error {
+  margin-bottom: 16px;
+}
+
+@media (max-width: 1000px) {
+  .performance-grid {
+    grid-template-columns: 1fr;
+  }
+}
+
+@media (max-width: 760px) {
+  .site-header {
+    padding-bottom: 48px;
+  }
+
+  .page-tabs {
+    right: auto;
+    bottom: 0;
+    left: 0;
+    transform: none;
+  }
+
+  .performance-intro,
+  .performance-provider-heading {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .performance-totals {
+    grid-template-columns: repeat(2, 1fr);
+  }
+
+  .performance-totals > div:nth-child(3) {
+    border-top: 1px solid var(--row-border);
+    border-left: 0;
+  }
+
+  .performance-totals > div:nth-child(4) {
+    border-top: 1px solid var(--row-border);
+  }
+}

--- a/src/client/performance.css
+++ b/src/client/performance.css
@@ -46,9 +46,8 @@
   margin: 34px 0 18px;
 }
 
-.performance-intro h2,
-.performance-next h2 {
-  margin: 4px 0;
+.performance-intro h2 {
+  margin: 0;
   font-size: 26px;
   letter-spacing: -.025em;
 }
@@ -96,7 +95,7 @@
 
 .performance-provider-heading {
   display: flex;
-  min-height: 76px;
+  min-height: 68px;
   align-items: center;
   justify-content: space-between;
   gap: 20px;
@@ -210,7 +209,7 @@
 
 .efficiency-chart {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) 124px;
+  grid-template-columns: minmax(0, 1fr) 96px;
   min-height: 270px;
   padding: 8px 12px 0;
   font-family: var(--mono);
@@ -266,7 +265,7 @@
   min-width: 0;
   min-height: 236px;
   margin: 10px 0;
-  padding: 3px 0 3px 10px;
+  padding: 3px 0 3px 8px;
   border-left: 1px solid var(--row-border);
   font: 9px var(--mono);
 }
@@ -311,7 +310,7 @@
   display: flex;
   align-items: baseline;
   justify-content: space-between;
-  gap: 8px;
+  gap: 4px;
 }
 
 .efficiency-tooltip dt {
@@ -321,6 +320,60 @@
 .efficiency-tooltip dd {
   margin: 0;
   font-weight: 600;
+}
+
+.image-cohort-list {
+  display: grid;
+  gap: 18px;
+  padding: 24px;
+}
+
+.image-cohort-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 68px;
+  gap: 7px 14px;
+  font: 10px var(--mono);
+}
+
+.image-cohort-row > div {
+  display: flex;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.image-cohort-row > div strong {
+  font-size: 11px;
+}
+
+.image-cohort-row i {
+  grid-column: 1;
+  height: 8px;
+  overflow: hidden;
+  background: var(--row-border);
+}
+
+.image-cohort-row i b {
+  display: block;
+  height: 100%;
+  background: var(--accent);
+}
+
+.image-cohort-row small {
+  grid-column: 2;
+  grid-row: 1 / 3;
+  align-self: end;
+  padding-bottom: 1px;
+  color: var(--muted);
+  font-size: 9px;
+  text-align: right;
+}
+
+.image-cohort-message {
+  display: grid;
+  min-height: 190px;
+  place-items: center;
+  color: var(--muted);
+  font: 10px var(--mono);
 }
 
 .performance-error {

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -1,3 +1,5 @@
+@import "./performance.css";
+
 :root {
   font-family: "Avenir Next", "Segoe UI", sans-serif;
   color: #252722;

--- a/src/server/cacheAnalysis.ts
+++ b/src/server/cacheAnalysis.ts
@@ -7,6 +7,7 @@ import type {
   TurnCacheSummary,
 } from "../shared/sessionSchemas.ts";
 import { hasInputContext } from "../shared/contextMetrics.ts";
+import type { UsageCall } from "./usage.ts";
 
 export const CACHE_HIT_RATIO = 0.9;
 export const CACHE_FULL_MISS_RATIO = 0.1;
@@ -83,6 +84,40 @@ export function ttlExpired(
     ) return true;
   }
   return elapsed >= CACHE_TTL_1H_MS;
+}
+
+export type AssessedUsageCall = UsageCall & {
+  cacheAssessment: CacheAssessment;
+  previousComparableCall?: UsageCall;
+};
+
+export function categorizeUsageCallCache(
+  calls: UsageCall[],
+): AssessedUsageCall[] {
+  const categorized: AssessedUsageCall[] = [];
+  for (
+    const chain of Map.groupBy(
+      calls,
+      (call) => `${call.harness}:${call.cacheChainID}`,
+    ).values()
+  ) {
+    let previous: UsageCall | undefined;
+    for (const call of chain.toSorted((a, b) => a.startedAt - b.startedAt)) {
+      const rawAssessment = assessCache(previous, call);
+      const cacheAssessment = isMiss(rawAssessment) && call.followsCompaction
+        ? { ...rawAssessment, cause: "compaction" as const }
+        : isMiss(rawAssessment) && previous && ttlExpired(previous, call)
+        ? { ...rawAssessment, cause: "ttl" as const }
+        : rawAssessment;
+      categorized.push({
+        ...call,
+        cacheAssessment,
+        ...(previous ? { previousComparableCall: previous } : {}),
+      });
+      if (hasInputContext(call.tokens)) previous = call;
+    }
+  }
+  return categorized;
 }
 
 export function summarizeTurnCache(calls: ModelCall[]): TurnCacheSummary {

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -21,6 +21,11 @@ import type { UsageCall } from "./usage.ts";
 import { aggregateUsage } from "./usageAnalytics.ts";
 import { aggregateTtlMisses } from "./ttlMissAnalytics.ts";
 import {
+  aggregatePerformance,
+  PERFORMANCE_MODELS,
+  PERFORMANCE_RANGE_DAYS,
+} from "./performanceAnalytics.ts";
+import {
   aggregateOverview,
   ROTATION_INACTIVITY_MINUTES,
 } from "./overviewAnalytics.ts";
@@ -437,6 +442,54 @@ function overviewSessions(start: number, harness: string) {
   }
   return sessions;
 }
+
+app.get("/api/performance", (context) => {
+  const harness = context.req.query("harness") ?? "all";
+  if (!["all", "opencode", "claude-code", "pi", "codex"].includes(harness)) {
+    return context.json({ error: "Invalid harness" }, 400);
+  }
+  const openaiModel = context.req.query("openai") ?? "all";
+  const anthropicModel = context.req.query("anthropic") ?? "all";
+  if (
+    openaiModel !== "all" &&
+    !PERFORMANCE_MODELS.openai.includes(
+      openaiModel as (typeof PERFORMANCE_MODELS.openai)[number],
+    )
+  ) return context.json({ error: "Invalid OpenAI model" }, 400);
+  if (
+    anthropicModel !== "all" &&
+    !PERFORMANCE_MODELS.anthropic.includes(
+      anthropicModel as (typeof PERFORMANCE_MODELS.anthropic)[number],
+    )
+  ) return context.json({ error: "Invalid Anthropic model" }, 400);
+
+  const end = Date.now();
+  const start = new Date(
+    new Date(end).setHours(0, 0, 0, 0) -
+      (PERFORMANCE_RANGE_DAYS - 1) * 86_400_000,
+  ).getTime();
+  const calls: UsageCall[] = [];
+  if (archiveRepository) {
+    calls.push(...archiveRepository.listUsageCalls(
+      start,
+      harness === "all" ? undefined : harness as SessionSummary["harness"],
+    ));
+  } else {
+    const sources = [
+      ["opencode", repository],
+      ["claude-code", claudeRepository],
+      ["pi", piRepository],
+      ["codex", codexRepository],
+    ] as const;
+    for (const [name, source] of sources) {
+      if (!source || (harness !== "all" && harness !== name)) continue;
+      calls.push(...source.listUsageCalls(start));
+    }
+  }
+  return context.json(
+    aggregatePerformance(calls, start, end, openaiModel, anthropicModel),
+  );
+});
 
 app.get("/api/ttl-misses", (context) => {
   const harness = context.req.query("harness") ?? "all";

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -8,6 +8,7 @@ import { CodexRepository } from "./codexRepository.ts";
 import { computeModelCallCost, priceSessionDetail } from "./pricing.ts";
 import {
   analyzeSessionCache,
+  CACHE_TTL_1H_MS,
   sessionCacheIssues,
   summarizeSessionCache,
 } from "./cacheAnalysis.ts";
@@ -468,10 +469,13 @@ app.get("/api/performance", (context) => {
     new Date(end).setHours(0, 0, 0, 0) -
       (PERFORMANCE_RANGE_DAYS - 1) * 86_400_000,
   ).getTime();
+  // Include the preceding cache TTL so requests at the range boundary can be
+  // compared with their immediately preceding context.
+  const cacheStart = start - CACHE_TTL_1H_MS;
   const calls: UsageCall[] = [];
   if (archiveRepository) {
     calls.push(...archiveRepository.listUsageCalls(
-      start,
+      cacheStart,
       harness === "all" ? undefined : harness as SessionSummary["harness"],
     ));
   } else {
@@ -483,7 +487,7 @@ app.get("/api/performance", (context) => {
     ] as const;
     for (const [name, source] of sources) {
       if (!source || (harness !== "all" && harness !== name)) continue;
-      calls.push(...source.listUsageCalls(start));
+      calls.push(...source.listUsageCalls(cacheStart));
     }
   }
   return context.json(

--- a/src/server/opencodeRepository.test.ts
+++ b/src/server/opencodeRepository.test.ts
@@ -102,6 +102,7 @@ Deno.test("removes empty turns without dropping reported cost", () => {
           parentID: undefined,
         },
         cacheChainID: "session",
+        turnID: "session:priced-user",
         sessionStartedAt: 1,
         provider,
         model,

--- a/src/server/opencodeRepository.test.ts
+++ b/src/server/opencodeRepository.test.ts
@@ -84,6 +84,14 @@ Deno.test("removes empty turns without dropping reported cost", () => {
       },
     }),
   );
+  database.prepare(
+    "INSERT INTO part VALUES (?, 'session', ?, ?, ?)",
+  ).run(
+    "image-part",
+    "priced-user",
+    3,
+    JSON.stringify({ type: "file", mime: "image/png" }),
+  );
   database.close();
 
   const repository = new OpenCodeRepository(path);
@@ -93,6 +101,7 @@ Deno.test("removes empty turns without dropping reported cost", () => {
     strictEqual(session.turns[0].number, 1);
     strictEqual(session.turns[0].calls.length, 1);
     strictEqual(session.turns[0].calls[0].reportedCost, 0.25);
+    strictEqual(session.turns[0].calls[0].activity.images, 1);
     const detailCalls = session.turns.flatMap((turn) => turn.calls).map(
       ({ provider, model, startedAt, reportedCost, tokens }) => ({
         harness: "opencode",
@@ -103,6 +112,8 @@ Deno.test("removes empty turns without dropping reported cost", () => {
         },
         cacheChainID: "session",
         turnID: "session:priced-user",
+        turnOrdinal: 2,
+        images: 1,
         sessionStartedAt: 1,
         provider,
         model,

--- a/src/server/opencodeRepository.ts
+++ b/src/server/opencodeRepository.ts
@@ -435,6 +435,7 @@ function decodeUsageMessage(
       },
       cacheChainID: (row as UsageMessageRow).session_id,
       turnID: "unassigned",
+      turnOrdinal: 0,
       sessionStartedAt: session.rootStartedAt,
       provider: message.providerID ?? "unknown",
       model: message.modelID ?? "unknown",
@@ -627,8 +628,21 @@ export class OpenCodeRepository {
         rootStartedAt: root.time_created,
       });
     }
+    const imageRows = this.#db.prepare(`
+      SELECT message_id, COUNT(*) AS count
+      FROM part
+      WHERE json_valid(data)
+        AND json_extract(data, '$.type') = 'file'
+        AND json_extract(data, '$.mime') LIKE 'image/%'
+      GROUP BY message_id
+    `).all() as Array<{ message_id: string; count: number }>;
+    const imagesByMessage = new Map(
+      imageRows.map((row) => [row.message_id, row.count]),
+    );
     const sessionsWithUserTurn = new Set<string>();
     const activeTurnIDs = new Map<string, string>();
+    const activeTurnOrdinals = new Map<string, number>();
+    const pendingTurnImages = new Map<string, number>();
     if (startedAt !== undefined) {
       const priorSessions = this.#db.prepare(`
         SELECT id, session_id
@@ -641,6 +655,11 @@ export class OpenCodeRepository {
       priorSessions.forEach(({ id, session_id }) => {
         sessionsWithUserTurn.add(session_id);
         activeTurnIDs.set(session_id, id);
+        activeTurnOrdinals.set(
+          session_id,
+          (activeTurnOrdinals.get(session_id) ?? 0) + 1,
+        );
+        pendingTurnImages.set(session_id, imagesByMessage.get(id) ?? 0);
       });
     }
     const rows = startedAt === undefined
@@ -664,13 +683,25 @@ export class OpenCodeRepository {
       if (decoded.role === "user") {
         sessionsWithUserTurn.add(row.session_id);
         activeTurnIDs.set(row.session_id, row.id);
+        activeTurnOrdinals.set(
+          row.session_id,
+          (activeTurnOrdinals.get(row.session_id) ?? 0) + 1,
+        );
+        pendingTurnImages.set(
+          row.session_id,
+          imagesByMessage.get(row.id) ?? 0,
+        );
         continue;
       }
       if (decoded.call && sessionsWithUserTurn.has(row.session_id)) {
+        const images = pendingTurnImages.get(row.session_id) ?? 0;
         calls.push({
           ...decoded.call,
           turnID: `${row.session_id}:${activeTurnIDs.get(row.session_id) ?? "prior"}`,
+          turnOrdinal: activeTurnOrdinals.get(row.session_id) ?? 0,
+          ...(images > 0 ? { images } : {}),
         });
+        pendingTurnImages.set(row.session_id, 0);
       }
     }
     return calls;

--- a/src/server/opencodeRepository.ts
+++ b/src/server/opencodeRepository.ts
@@ -434,6 +434,7 @@ function decodeUsageMessage(
         parentID: session.parentID,
       },
       cacheChainID: (row as UsageMessageRow).session_id,
+      turnID: "unassigned",
       sessionStartedAt: session.rootStartedAt,
       provider: message.providerID ?? "unknown",
       model: message.modelID ?? "unknown",
@@ -627,17 +628,20 @@ export class OpenCodeRepository {
       });
     }
     const sessionsWithUserTurn = new Set<string>();
+    const activeTurnIDs = new Map<string, string>();
     if (startedAt !== undefined) {
       const priorSessions = this.#db.prepare(`
-        SELECT DISTINCT session_id
+        SELECT id, session_id
         FROM message
         WHERE time_created < ?
           AND json_valid(data)
           AND json_extract(data, '$.role') = 'user'
-      `).all(startedAt) as Array<{ session_id: string }>;
-      priorSessions.forEach(({ session_id }) =>
-        sessionsWithUserTurn.add(session_id)
-      );
+        ORDER BY time_created, id
+      `).all(startedAt) as Array<{ id: string; session_id: string }>;
+      priorSessions.forEach(({ id, session_id }) => {
+        sessionsWithUserTurn.add(session_id);
+        activeTurnIDs.set(session_id, id);
+      });
     }
     const rows = startedAt === undefined
       ? this.#db.prepare(`
@@ -659,10 +663,14 @@ export class OpenCodeRepository {
       if (!decoded) continue;
       if (decoded.role === "user") {
         sessionsWithUserTurn.add(row.session_id);
+        activeTurnIDs.set(row.session_id, row.id);
         continue;
       }
       if (decoded.call && sessionsWithUserTurn.has(row.session_id)) {
-        calls.push(decoded.call);
+        calls.push({
+          ...decoded.call,
+          turnID: `${row.session_id}:${activeTurnIDs.get(row.session_id) ?? "prior"}`,
+        });
       }
     }
     return calls;

--- a/src/server/performanceAnalytics.test.ts
+++ b/src/server/performanceAnalytics.test.ts
@@ -74,6 +74,33 @@ Deno.test("aggregates weekly session and turn cache miss rates by model", () => 
   strictEqual(result.anthropic.sessions, 0);
 });
 
+Deno.test("buckets partial and full cache misses but excludes cache hits", () => {
+  const start = new Date(2026, 2, 2).getTime();
+  const end = new Date(2026, 2, 8, 23, 59).getTime();
+  const result = aggregatePerformance([
+    call("retention", 1, start + 10, 0, 100),
+    call("retention", 2, start + 20, 80),
+    call("hit", 1, start + 25, 0, 100),
+    call("hit", 2, start + 26, 95),
+    call("compacted", 1, start + 30, 0, 100),
+    { ...call("compacted", 2, start + 40, 0), followsCompaction: true },
+  ], start, end);
+  const retention = result.openai.weeks[0].cacheRetention!;
+
+  strictEqual(retention.comparableRequests, 2);
+  strictEqual(retention.requestsWithLoss, 1);
+  strictEqual(retention.partialHits, 1);
+  strictEqual(retention.fullMisses, 0);
+  strictEqual(retention.retainedTokens, 175);
+  strictEqual(retention.unretainedTokens, 25);
+  strictEqual(retention.retainedShare, 0.875);
+  strictEqual(retention.lossRequestRate, 0.5);
+  strictEqual(retention.p90UnretainedTokens, 18.5);
+  strictEqual(retention.lossBuckets[0].requests, 1);
+  strictEqual(retention.lossBuckets[0].unretainedTokens, 20);
+  strictEqual(retention.lossBuckets[1].requests, 0);
+});
+
 Deno.test("groups image sessions into exclusive cohorts with miss rates", () => {
   const start = new Date(2026, 2, 2).getTime();
   const end = new Date(2026, 2, 8, 23, 59).getTime();
@@ -142,6 +169,22 @@ Deno.test("calculates weekly session cache-efficiency box plot values", () => {
   strictEqual(distribution.average, 0.5);
   strictEqual(distribution.sampleSize, 5);
   strictEqual(distribution.outliers, 0);
+});
+
+Deno.test("calculates final-context share from the latest request and all session input", () => {
+  const start = new Date(2026, 2, 2).getTime();
+  const end = new Date(2026, 2, 8, 23, 59).getTime();
+  const earlier = call("session", 1, start + 10, 0);
+  const latest = call("session", 2, start + 20, 100);
+  earlier.sessionStartedAt = start;
+  latest.sessionStartedAt = start;
+
+  const result = aggregatePerformance([latest, earlier], start, end);
+  const distribution = result.openai.weeks[0].finalContextShare!;
+
+  strictEqual(distribution.median, 2 / 3);
+  strictEqual(distribution.average, 2 / 3);
+  strictEqual(distribution.sampleSize, 1);
 });
 
 Deno.test("uses Tukey whiskers and reports efficiency outliers", () => {

--- a/src/server/performanceAnalytics.test.ts
+++ b/src/server/performanceAnalytics.test.ts
@@ -14,6 +14,7 @@ function call(
     session: { id: session, rootID: session },
     cacheChainID: session,
     turnID: `${session}:${turn}`,
+    turnOrdinal: turn,
     sessionStartedAt: startedAt - turn,
     provider: "openai",
     model: "gpt-5.4",
@@ -71,6 +72,54 @@ Deno.test("aggregates weekly session and turn cache miss rates by model", () => 
   strictEqual(result.openai.weeks.length, 1);
   strictEqual(result.openai.weeks[0].sessions, 5);
   strictEqual(result.anthropic.sessions, 0);
+});
+
+Deno.test("groups image sessions into exclusive cohorts with miss rates", () => {
+  const start = new Date(2026, 2, 2).getTime();
+  const end = new Date(2026, 2, 8, 23, 59).getTime();
+  const cohortSession = (
+    session: string,
+    imagesOn: "none" | "first" | "later",
+    miss: boolean,
+  ) => {
+    const first = call(session, 1, start + 10, 0, 100);
+    const second = call(session, 2, start + 20, miss ? 0 : 100);
+    return [
+      imagesOn === "first" ? { ...first, images: 1 } : first,
+      imagesOn === "later" || imagesOn === "first"
+        ? { ...second, images: 1 }
+        : second,
+    ];
+  };
+  const result = aggregatePerformance([
+    ...cohortSession("no-image-miss", "none", true),
+    ...cohortSession("no-image-clean", "none", false),
+    ...cohortSession("first-image-miss", "first", true),
+    ...cohortSession("first-image-clean", "first", false),
+    ...cohortSession("later-image-miss", "later", true),
+    ...cohortSession("later-image-clean", "later", false),
+  ], start, end);
+
+  for (const cohort of result.openai.imageCohorts) {
+    strictEqual(cohort.sessions, 2);
+    strictEqual(cohort.sessionsWithMiss, 1);
+  }
+});
+
+Deno.test("excludes zero-input calls from performance eligibility", () => {
+  const start = new Date(2026, 2, 2).getTime();
+  const empty = call("empty", 1, start + 10, 0);
+  empty.tokens.uncachedInput = 0;
+  empty.tokens.freshPrompt = 0;
+  empty.tokens.processed = 0;
+  const result = aggregatePerformance(
+    [empty],
+    start,
+    new Date(2026, 2, 8, 23, 59).getTime(),
+  );
+
+  strictEqual(result.openai.sessions, 0);
+  strictEqual(result.openai.turns, 0);
 });
 
 Deno.test("calculates weekly session cache-efficiency box plot values", () => {

--- a/src/server/performanceAnalytics.test.ts
+++ b/src/server/performanceAnalytics.test.ts
@@ -30,6 +30,25 @@ function call(
   };
 }
 
+function efficiencyCall(
+  session: string,
+  startedAt: number,
+  efficiency: number,
+): UsageCall {
+  const result = call(session, 1, startedAt, 0);
+  return {
+    ...result,
+    sessionStartedAt: startedAt,
+    tokens: {
+      ...result.tokens,
+      uncachedInput: 100 - efficiency * 100,
+      cacheRead: efficiency * 100,
+      freshPrompt: 100 - efficiency * 100,
+      processed: 100,
+    },
+  };
+}
+
 Deno.test("aggregates weekly session and turn cache miss rates by model", () => {
   const start = new Date(2026, 2, 2).getTime();
   const end = new Date(2026, 2, 8, 23, 59).getTime();
@@ -52,4 +71,43 @@ Deno.test("aggregates weekly session and turn cache miss rates by model", () => 
   strictEqual(result.openai.weeks.length, 1);
   strictEqual(result.openai.weeks[0].sessions, 5);
   strictEqual(result.anthropic.sessions, 0);
+});
+
+Deno.test("calculates weekly session cache-efficiency box plot values", () => {
+  const start = new Date(2026, 2, 2).getTime();
+  const end = new Date(2026, 2, 8, 23, 59).getTime();
+  const result = aggregatePerformance(
+    [0, 0.25, 0.5, 0.75, 1].map((efficiency, index) =>
+      efficiencyCall(`session-${index}`, start + index * 10, efficiency)
+    ),
+    start,
+    end,
+  );
+  const distribution = result.openai.weeks[0].efficiency!;
+
+  strictEqual(distribution.lowerWhisker, 0);
+  strictEqual(distribution.q1, 0.25);
+  strictEqual(distribution.median, 0.5);
+  strictEqual(distribution.q3, 0.75);
+  strictEqual(distribution.upperWhisker, 1);
+  strictEqual(distribution.average, 0.5);
+  strictEqual(distribution.sampleSize, 5);
+  strictEqual(distribution.outliers, 0);
+});
+
+Deno.test("uses Tukey whiskers and reports efficiency outliers", () => {
+  const start = new Date(2026, 2, 2).getTime();
+  const end = new Date(2026, 2, 8, 23, 59).getTime();
+  const result = aggregatePerformance(
+    [0, 0.5, 0.5, 0.5, 1].map((efficiency, index) =>
+      efficiencyCall(`session-${index}`, start + index * 10, efficiency)
+    ),
+    start,
+    end,
+  );
+  const distribution = result.openai.weeks[0].efficiency!;
+
+  strictEqual(distribution.lowerWhisker, 0.5);
+  strictEqual(distribution.upperWhisker, 0.5);
+  strictEqual(distribution.outliers, 2);
 });

--- a/src/server/performanceAnalytics.test.ts
+++ b/src/server/performanceAnalytics.test.ts
@@ -1,0 +1,55 @@
+import { strictEqual } from "node:assert/strict";
+import { aggregatePerformance } from "./performanceAnalytics.ts";
+import type { UsageCall } from "./usage.ts";
+
+function call(
+  session: string,
+  turn: number,
+  startedAt: number,
+  cacheRead: number,
+  cacheWrite?: number,
+): UsageCall {
+  return {
+    harness: "codex",
+    session: { id: session, rootID: session },
+    cacheChainID: session,
+    turnID: `${session}:${turn}`,
+    sessionStartedAt: startedAt - turn,
+    provider: "openai",
+    model: "gpt-5.4",
+    startedAt,
+    tokens: {
+      uncachedInput: cacheWrite === undefined ? 100 : 0,
+      cacheRead,
+      cacheWrite,
+      freshPrompt: 100,
+      output: 0,
+      reasoning: 0,
+      processed: 100 + cacheRead + (cacheWrite ?? 0),
+    },
+  };
+}
+
+Deno.test("aggregates weekly session and turn cache miss rates by model", () => {
+  const start = new Date(2026, 2, 2).getTime();
+  const end = new Date(2026, 2, 8, 23, 59).getTime();
+  const result = aggregatePerformance([
+    call("missed", 1, start + 10, 0, 100),
+    call("missed", 2, start + 20, 0),
+    call("clean", 1, start + 30, 0, 100),
+    call("partial", 1, start + 32, 0, 100),
+    call("partial", 2, start + 34, 50),
+    call("compacted", 1, start + 40, 0, 100),
+    { ...call("compacted", 2, start + 50, 0), followsCompaction: true },
+    call("expired", 1, start + 60, 0, 100),
+    call("expired", 2, start + 2 * 60 * 60 * 1_000, 0),
+  ], start, end, "gpt-5.4", "all");
+
+  strictEqual(result.openai.sessions, 5);
+  strictEqual(result.openai.sessionsWithMiss, 2);
+  strictEqual(result.openai.turns, 9);
+  strictEqual(result.openai.turnsWithMiss, 2);
+  strictEqual(result.openai.weeks.length, 1);
+  strictEqual(result.openai.weeks[0].sessions, 5);
+  strictEqual(result.anthropic.sessions, 0);
+});

--- a/src/server/performanceAnalytics.ts
+++ b/src/server/performanceAnalytics.ts
@@ -1,5 +1,6 @@
 import type { PerformanceResponse } from "../shared/sessionSchemas.ts";
 import {
+  contextRange,
   contextSize,
   hasInputContext,
 } from "../shared/contextMetrics.ts";
@@ -40,6 +41,30 @@ export const PERFORMANCE_MODELS = {
 type Vendor = keyof typeof PERFORMANCE_MODELS;
 type ImageCohort = PerformanceResponse[Vendor]["imageCohorts"][number]["cohort"];
 type Week = PerformanceResponse[Vendor]["weeks"][number];
+
+const CACHE_LOSS_BUCKETS = ["0-16k", "16-64k", "64-128k", "128k+"] as const;
+type CacheLossBucket = (typeof CACHE_LOSS_BUCKETS)[number];
+
+type CacheLossBucketTotals = {
+  requests: number;
+  unretainedTokens: number;
+};
+
+function cacheLossBucket(tokens: number): CacheLossBucket {
+  if (tokens < 16_000) return "0-16k";
+  if (tokens < 64_000) return "16-64k";
+  if (tokens < 128_000) return "64-128k";
+  return "128k+";
+}
+
+function emptyCacheLossBuckets(): Record<CacheLossBucket, CacheLossBucketTotals> {
+  return {
+    "0-16k": { requests: 0, unretainedTokens: 0 },
+    "16-64k": { requests: 0, unretainedTokens: 0 },
+    "64-128k": { requests: 0, unretainedTokens: 0 },
+    "128k+": { requests: 0, unretainedTokens: 0 },
+  };
+}
 
 function vendorFor(call: UsageCall): Vendor | undefined {
   const provider = call.provider.toLowerCase();
@@ -153,12 +178,29 @@ function providerResult(
     call.sessionStartedAt >= start && call.sessionStartedAt <= end &&
     hasInputContext(call.tokens)
   );
+  const retentionCalls = calls.filter((call) =>
+    vendorFor(call) === vendor &&
+    (selectedModel === "all" || call.model === selectedModel) &&
+    call.startedAt >= start && call.startedAt <= end &&
+    hasInputContext(call.tokens)
+  );
   const weeks = weeksBetween(start, end);
   const sessions = Map.groupBy(
     matching,
     (call) => `${call.harness}:${call.session.rootID}`,
   );
   const efficiencyByWeek = new Map<string, number[]>();
+  const finalContextShareByWeek = new Map<string, number[]>();
+  const cacheRetentionByWeek = new Map<string, {
+    comparableRequests: number;
+    requestsWithLoss: number;
+    partialHits: number;
+    fullMisses: number;
+    retainedTokens: number;
+    unretainedTokens: number;
+    losses: number[];
+    lossBuckets: Record<CacheLossBucket, CacheLossBucketTotals>;
+  }>();
   const imageResults: PerformanceResponse[Vendor]["imageCohorts"] = [
     { cohort: "no-image", sessions: 0, sessionsWithMiss: 0 },
     { cohort: "first-turn-image", sessions: 0, sessionsWithMiss: 0 },
@@ -178,12 +220,19 @@ function providerResult(
       0,
     );
     if (totalInput > 0) {
-      const values = efficiencyByWeek.get(sessionWeek) ?? [];
-      values.push(
+      const cacheEfficiency = efficiencyByWeek.get(sessionWeek) ?? [];
+      cacheEfficiency.push(
         sessionCalls.reduce((sum, call) => sum + call.tokens.cacheRead, 0) /
           totalInput,
       );
-      efficiencyByWeek.set(sessionWeek, values);
+      efficiencyByWeek.set(sessionWeek, cacheEfficiency);
+
+      const finalContext = contextRange(sessionCalls).latest;
+      if (finalContext) {
+        const shares = finalContextShareByWeek.get(sessionWeek) ?? [];
+        shares.push(finalContext.size / totalInput);
+        finalContextShareByWeek.set(sessionWeek, shares);
+      }
     }
     const sessionMiss = sessionCalls.some((call) =>
       call.cacheAssessment.cause === undefined &&
@@ -218,9 +267,75 @@ function providerResult(
     }
   }
 
+  for (const call of retentionCalls) {
+    const assessment = call.cacheAssessment;
+    const previousReusable = assessment.previousReusableTokens;
+    if (
+      previousReusable === undefined || assessment.cause !== undefined ||
+      !["hit", "partial-hit", "full-miss"].includes(assessment.status)
+    ) continue;
+
+    const date = weekKey(call.startedAt);
+    const bucket = cacheRetentionByWeek.get(date) ?? {
+      comparableRequests: 0,
+      requestsWithLoss: 0,
+      partialHits: 0,
+      fullMisses: 0,
+      retainedTokens: 0,
+      unretainedTokens: 0,
+      losses: [],
+      lossBuckets: emptyCacheLossBuckets(),
+    };
+    const retained = Math.min(call.tokens.cacheRead, previousReusable);
+    const unretained = Math.max(previousReusable - retained, 0);
+    bucket.comparableRequests++;
+    bucket.retainedTokens += retained;
+    bucket.unretainedTokens += unretained;
+    bucket.losses.push(unretained);
+    // The chart intentionally excludes hits, including small shortfalls below
+    // the 10% miss threshold, because they can represent fresh input.
+    if (assessment.status !== "hit" && unretained > 0) {
+      const lossBucket = bucket.lossBuckets[cacheLossBucket(unretained)];
+      lossBucket.requests++;
+      lossBucket.unretainedTokens += unretained;
+    }
+    if (assessment.status === "partial-hit") {
+      bucket.requestsWithLoss++;
+      bucket.partialHits++;
+    } else if (assessment.status === "full-miss") {
+      bucket.requestsWithLoss++;
+      bucket.fullMisses++;
+    }
+    cacheRetentionByWeek.set(date, bucket);
+  }
+
   for (const [date, values] of efficiencyByWeek) {
     const week = weeks.get(date);
     if (week) week.efficiency = efficiencyDistribution(values);
+  }
+  for (const [date, values] of finalContextShareByWeek) {
+    const week = weeks.get(date);
+    if (week) week.finalContextShare = efficiencyDistribution(values);
+  }
+  for (const [date, retention] of cacheRetentionByWeek) {
+    const week = weeks.get(date);
+    if (!week) continue;
+    const totalReusable = retention.retainedTokens + retention.unretainedTokens;
+    week.cacheRetention = {
+      comparableRequests: retention.comparableRequests,
+      requestsWithLoss: retention.requestsWithLoss,
+      partialHits: retention.partialHits,
+      fullMisses: retention.fullMisses,
+      retainedTokens: retention.retainedTokens,
+      unretainedTokens: retention.unretainedTokens,
+      retainedShare: totalReusable === 0 ? 0 : retention.retainedTokens / totalReusable,
+      lossRequestRate: retention.requestsWithLoss / retention.comparableRequests,
+      p90UnretainedTokens: percentile(retention.losses.toSorted((a, b) => a - b), 0.9),
+      lossBuckets: CACHE_LOSS_BUCKETS.map((bucket) => ({
+        bucket,
+        ...retention.lossBuckets[bucket],
+      })),
+    };
   }
 
   return {

--- a/src/server/performanceAnalytics.ts
+++ b/src/server/performanceAnalytics.ts
@@ -1,4 +1,5 @@
 import type { PerformanceResponse } from "../shared/sessionSchemas.ts";
+import { contextSize } from "../shared/contextMetrics.ts";
 import {
   categorizeUsageCallCache,
   type AssessedUsageCall,
@@ -62,6 +63,37 @@ function weekKey(value: number) {
   return date.subtract({ days: date.dayOfWeek - 1 }).toString();
 }
 
+function percentile(values: number[], quantile: number) {
+  const index = (values.length - 1) * quantile;
+  const lower = Math.floor(index);
+  const remainder = index - lower;
+  return values[lower] + (values[lower + 1] - values[lower]) * remainder ||
+    values[lower];
+}
+
+function efficiencyDistribution(values: number[]) {
+  const sorted = values.toSorted((a, b) => a - b);
+  const q1 = percentile(sorted, 0.25);
+  const median = percentile(sorted, 0.5);
+  const q3 = percentile(sorted, 0.75);
+  const iqr = q3 - q1;
+  const lowerFence = q1 - 1.5 * iqr;
+  const upperFence = q3 + 1.5 * iqr;
+  const included = sorted.filter((value) =>
+    value >= lowerFence && value <= upperFence
+  );
+  return {
+    lowerWhisker: included[0],
+    q1,
+    median,
+    q3,
+    upperWhisker: included.at(-1)!,
+    average: sorted.reduce((sum, value) => sum + value, 0) / sorted.length,
+    sampleSize: sorted.length,
+    outliers: sorted.length - included.length,
+  };
+}
+
 function emptyWeek(date: string): Week {
   return {
     date,
@@ -104,14 +136,28 @@ function providerResult(
     matching,
     (call) => `${call.harness}:${call.session.rootID}`,
   );
+  const efficiencyByWeek = new Map<string, number[]>();
   let sessionsWithMiss = 0;
   let turns = 0;
   let turnsWithMiss = 0;
 
   for (const sessionCalls of sessions.values()) {
-    const bucket = weeks.get(weekKey(sessionCalls[0].sessionStartedAt));
+    const sessionWeek = weekKey(sessionCalls[0].sessionStartedAt);
+    const bucket = weeks.get(sessionWeek);
     if (!bucket) continue;
     bucket.sessions++;
+    const totalInput = sessionCalls.reduce(
+      (sum, call) => sum + contextSize(call.tokens),
+      0,
+    );
+    if (totalInput > 0) {
+      const values = efficiencyByWeek.get(sessionWeek) ?? [];
+      values.push(
+        sessionCalls.reduce((sum, call) => sum + call.tokens.cacheRead, 0) /
+          totalInput,
+      );
+      efficiencyByWeek.set(sessionWeek, values);
+    }
     const sessionMiss = sessionCalls.some((call) =>
       call.cacheAssessment.cause === undefined &&
       (call.cacheAssessment.status === "partial-hit" ||
@@ -137,6 +183,11 @@ function providerResult(
         bucket.turnsWithMiss++;
       }
     }
+  }
+
+  for (const [date, values] of efficiencyByWeek) {
+    const week = weeks.get(date);
+    if (week) week.efficiency = efficiencyDistribution(values);
   }
 
   return {

--- a/src/server/performanceAnalytics.ts
+++ b/src/server/performanceAnalytics.ts
@@ -1,5 +1,8 @@
 import type { PerformanceResponse } from "../shared/sessionSchemas.ts";
-import { contextSize } from "../shared/contextMetrics.ts";
+import {
+  contextSize,
+  hasInputContext,
+} from "../shared/contextMetrics.ts";
 import {
   categorizeUsageCallCache,
   type AssessedUsageCall,
@@ -35,6 +38,7 @@ export const PERFORMANCE_MODELS = {
 } as const;
 
 type Vendor = keyof typeof PERFORMANCE_MODELS;
+type ImageCohort = PerformanceResponse[Vendor]["imageCohorts"][number]["cohort"];
 type Week = PerformanceResponse[Vendor]["weeks"][number];
 
 function vendorFor(call: UsageCall): Vendor | undefined {
@@ -119,8 +123,25 @@ function weeksBetween(start: number, end: number) {
   return weeks;
 }
 
+function imageCohorts(calls: AssessedUsageCall[]) {
+  const cohorts = new Map<string, ImageCohort>();
+  for (const call of calls) {
+    const key = `${call.harness}:${call.session.rootID}`;
+    if (!cohorts.has(key)) cohorts.set(key, "no-image");
+    if (
+      call.session.id !== call.session.rootID || (call.images ?? 0) === 0
+    ) continue;
+    if (call.turnOrdinal === 1) cohorts.set(key, "first-turn-image");
+    else if (cohorts.get(key) !== "first-turn-image") {
+      cohorts.set(key, "later-turn-image");
+    }
+  }
+  return cohorts;
+}
+
 function providerResult(
   calls: AssessedUsageCall[],
+  cohorts: Map<string, ImageCohort>,
   vendor: Vendor,
   selectedModel: string,
   start: number,
@@ -129,7 +150,8 @@ function providerResult(
   const matching = calls.filter((call) =>
     vendorFor(call) === vendor &&
     (selectedModel === "all" || call.model === selectedModel) &&
-    call.sessionStartedAt >= start && call.sessionStartedAt <= end
+    call.sessionStartedAt >= start && call.sessionStartedAt <= end &&
+    hasInputContext(call.tokens)
   );
   const weeks = weeksBetween(start, end);
   const sessions = Map.groupBy(
@@ -137,6 +159,11 @@ function providerResult(
     (call) => `${call.harness}:${call.session.rootID}`,
   );
   const efficiencyByWeek = new Map<string, number[]>();
+  const imageResults: PerformanceResponse[Vendor]["imageCohorts"] = [
+    { cohort: "no-image", sessions: 0, sessionsWithMiss: 0 },
+    { cohort: "first-turn-image", sessions: 0, sessionsWithMiss: 0 },
+    { cohort: "later-turn-image", sessions: 0, sessionsWithMiss: 0 },
+  ];
   let sessionsWithMiss = 0;
   let turns = 0;
   let turnsWithMiss = 0;
@@ -167,6 +194,12 @@ function providerResult(
       sessionsWithMiss++;
       bucket.sessionsWithMiss++;
     }
+    const sessionKey = `${sessionCalls[0].harness}:${sessionCalls[0].session.rootID}`;
+    const imageResult = imageResults.find((result) =>
+      result.cohort === (cohorts.get(sessionKey) ?? "no-image")
+    )!;
+    imageResult.sessions++;
+    if (sessionMiss) imageResult.sessionsWithMiss++;
     const sessionTurns = Map.groupBy(
       sessionCalls,
       (call) => `${call.session.id}:${call.turnID}`,
@@ -197,6 +230,7 @@ function providerResult(
     sessionsWithMiss,
     turns,
     turnsWithMiss,
+    imageCohorts: imageResults,
     weeks: [...weeks.values()],
   };
 }
@@ -209,15 +243,24 @@ export function aggregatePerformance(
   anthropicModel = "all",
 ): PerformanceResponse {
   const assessed = categorizeUsageCallCache(calls);
+  const cohorts = imageCohorts(assessed);
   return {
     rangeDays: PERFORMANCE_RANGE_DAYS,
     models: {
       openai: [...PERFORMANCE_MODELS.openai],
       anthropic: [...PERFORMANCE_MODELS.anthropic],
     },
-    openai: providerResult(assessed, "openai", openaiModel, start, end),
+    openai: providerResult(
+      assessed,
+      cohorts,
+      "openai",
+      openaiModel,
+      start,
+      end,
+    ),
     anthropic: providerResult(
       assessed,
+      cohorts,
       "anthropic",
       anthropicModel,
       start,

--- a/src/server/performanceAnalytics.ts
+++ b/src/server/performanceAnalytics.ts
@@ -1,0 +1,176 @@
+import type { PerformanceResponse } from "../shared/sessionSchemas.ts";
+import {
+  categorizeUsageCallCache,
+  type AssessedUsageCall,
+} from "./cacheAnalysis.ts";
+import type { UsageCall } from "./usage.ts";
+
+export const PERFORMANCE_RANGE_DAYS = 90;
+
+export const PERFORMANCE_MODELS = {
+  openai: [
+    "gpt-5.2-codex",
+    "gpt-5.2-codex-low",
+    "gpt-5.2-codex-medium",
+    "gpt-5.3-codex",
+    "gpt-5.4",
+    "gpt-5.5",
+    "gpt-5.6-luna",
+    "gpt-5.6-sol",
+    "gpt-5.6-terra",
+  ],
+  anthropic: [
+    "claude-fable-5",
+    "claude-haiku-4-5",
+    "claude-haiku-4-5-20251001",
+    "claude-opus-4-5",
+    "claude-opus-4-6",
+    "claude-opus-4-7",
+    "claude-opus-4-8",
+    "claude-sonnet-4-5",
+    "claude-sonnet-4-5-20250929",
+    "claude-sonnet-5",
+  ],
+} as const;
+
+type Vendor = keyof typeof PERFORMANCE_MODELS;
+type Week = PerformanceResponse[Vendor]["weeks"][number];
+
+function vendorFor(call: UsageCall): Vendor | undefined {
+  const provider = call.provider.toLowerCase();
+  const model = call.model.toLowerCase();
+  if (provider.includes("anthropic") || model.startsWith("claude-")) {
+    return "anthropic";
+  }
+  if (provider.startsWith("openai") || model.startsWith("gpt-")) {
+    return "openai";
+  }
+  return undefined;
+}
+
+function localDate(value: number) {
+  const date = new Date(value);
+  return Temporal.PlainDate.from({
+    year: date.getFullYear(),
+    month: date.getMonth() + 1,
+    day: date.getDate(),
+  });
+}
+
+function weekKey(value: number) {
+  const date = localDate(value);
+  return date.subtract({ days: date.dayOfWeek - 1 }).toString();
+}
+
+function emptyWeek(date: string): Week {
+  return {
+    date,
+    endDate: Temporal.PlainDate.from(date).add({ days: 6 }).toString(),
+    sessions: 0,
+    sessionsWithMiss: 0,
+    turns: 0,
+    turnsWithMiss: 0,
+  };
+}
+
+function weeksBetween(start: number, end: number) {
+  const first = Temporal.PlainDate.from(weekKey(start));
+  const last = Temporal.PlainDate.from(weekKey(end));
+  const weeks = new Map<string, Week>();
+  for (
+    let date = first;
+    Temporal.PlainDate.compare(date, last) <= 0;
+    date = date.add({ weeks: 1 })
+  ) {
+    weeks.set(date.toString(), emptyWeek(date.toString()));
+  }
+  return weeks;
+}
+
+function providerResult(
+  calls: AssessedUsageCall[],
+  vendor: Vendor,
+  selectedModel: string,
+  start: number,
+  end: number,
+): PerformanceResponse[Vendor] {
+  const matching = calls.filter((call) =>
+    vendorFor(call) === vendor &&
+    (selectedModel === "all" || call.model === selectedModel) &&
+    call.sessionStartedAt >= start && call.sessionStartedAt <= end
+  );
+  const weeks = weeksBetween(start, end);
+  const sessions = Map.groupBy(
+    matching,
+    (call) => `${call.harness}:${call.session.rootID}`,
+  );
+  let sessionsWithMiss = 0;
+  let turns = 0;
+  let turnsWithMiss = 0;
+
+  for (const sessionCalls of sessions.values()) {
+    const bucket = weeks.get(weekKey(sessionCalls[0].sessionStartedAt));
+    if (!bucket) continue;
+    bucket.sessions++;
+    const sessionMiss = sessionCalls.some((call) =>
+      call.cacheAssessment.cause === undefined &&
+      (call.cacheAssessment.status === "partial-hit" ||
+        call.cacheAssessment.status === "full-miss")
+    );
+    if (sessionMiss) {
+      sessionsWithMiss++;
+      bucket.sessionsWithMiss++;
+    }
+    const sessionTurns = Map.groupBy(
+      sessionCalls,
+      (call) => `${call.session.id}:${call.turnID}`,
+    );
+    turns += sessionTurns.size;
+    bucket.turns += sessionTurns.size;
+    for (const turnCalls of sessionTurns.values()) {
+      if (turnCalls.some((call) =>
+        call.cacheAssessment.cause === undefined &&
+        (call.cacheAssessment.status === "partial-hit" ||
+          call.cacheAssessment.status === "full-miss")
+      )) {
+        turnsWithMiss++;
+        bucket.turnsWithMiss++;
+      }
+    }
+  }
+
+  return {
+    provider: vendor,
+    selectedModel,
+    sessions: sessions.size,
+    sessionsWithMiss,
+    turns,
+    turnsWithMiss,
+    weeks: [...weeks.values()],
+  };
+}
+
+export function aggregatePerformance(
+  calls: UsageCall[],
+  start: number,
+  end: number,
+  openaiModel = "all",
+  anthropicModel = "all",
+): PerformanceResponse {
+  const assessed = categorizeUsageCallCache(calls);
+  return {
+    rangeDays: PERFORMANCE_RANGE_DAYS,
+    models: {
+      openai: [...PERFORMANCE_MODELS.openai],
+      anthropic: [...PERFORMANCE_MODELS.anthropic],
+    },
+    openai: providerResult(assessed, "openai", openaiModel, start, end),
+    anthropic: providerResult(
+      assessed,
+      "anthropic",
+      anthropicModel,
+      start,
+      end,
+    ),
+  };
+}

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -491,6 +491,7 @@ export class SessionRepository {
       root_started_at: number | null;
       root_updated_at: number;
       follows_compaction: number;
+      turn_ordinal: number;
     };
     const rows = this.db.prepare(`
       WITH RECURSIVE session_tree(id, root_id) AS (
@@ -504,7 +505,7 @@ export class SessionRepository {
         JOIN sessions child_session ON child_session.source_session_id = child.id
         JOIN session_tree ON session_tree.id = child.parent_id
       )
-      SELECT ${callColumns}, so.harness, ss.external_id,
+      SELECT ${callColumns}, t.ordinal AS turn_ordinal, so.harness, ss.external_id,
         COALESCE(ss.public_id, ss.external_id) AS public_id,
         COALESCE(root.public_id, root.external_id) AS root_public_id,
         COALESCE(parent.public_id, parent.external_id) AS parent_public_id,
@@ -550,6 +551,7 @@ export class SessionRepository {
         parentID: optional(row.parent_public_id),
       },
       cacheChainID: row.external_id,
+      turnID: `${row.public_id}:${row.turn_ordinal}`,
       sessionStartedAt: row.root_started_at ?? row.root_updated_at,
       provider: row.provider,
       model: row.model,

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -552,6 +552,8 @@ export class SessionRepository {
       },
       cacheChainID: row.external_id,
       turnID: `${row.public_id}:${row.turn_ordinal}`,
+      turnOrdinal: row.turn_ordinal,
+      images: optional(row.images),
       sessionStartedAt: row.root_started_at ?? row.root_updated_at,
       provider: row.provider,
       model: row.model,

--- a/src/server/ttlMissAnalytics.test.ts
+++ b/src/server/ttlMissAnalytics.test.ts
@@ -22,6 +22,7 @@ function call(
     session: { id: session, rootID: root },
     cacheChainID: options.chain ?? session,
     turnID: `${session}:${startedAt}`,
+    turnOrdinal: 1,
     sessionStartedAt: options.sessionStartedAt ?? start,
     provider: "anthropic",
     model: options.model ?? "claude-sonnet-4-5",

--- a/src/server/ttlMissAnalytics.test.ts
+++ b/src/server/ttlMissAnalytics.test.ts
@@ -21,6 +21,7 @@ function call(
     harness: "claude-code",
     session: { id: session, rootID: root },
     cacheChainID: options.chain ?? session,
+    turnID: `${session}:${startedAt}`,
     sessionStartedAt: options.sessionStartedAt ?? start,
     provider: "anthropic",
     model: options.model ?? "claude-sonnet-4-5",

--- a/src/server/ttlMissAnalytics.ts
+++ b/src/server/ttlMissAnalytics.ts
@@ -1,6 +1,5 @@
 import type { TtlMissMetrics } from "../shared/sessionSchemas.ts";
-import { assessCache, ttlExpired } from "./cacheAnalysis.ts";
-import { hasInputContext } from "../shared/contextMetrics.ts";
+import { categorizeUsageCallCache } from "./cacheAnalysis.ts";
 import { computeModelCallCost, estimateModelCacheMissCost } from "./pricing.ts";
 import type { UsageCall } from "./usage.ts";
 
@@ -20,35 +19,29 @@ type CacheMiss = {
 
 function cacheMisses(calls: UsageCall[]) {
   const misses: CacheMiss[] = [];
-  for (
-    const chain of Map.groupBy(calls, (call) => call.cacheChainID).values()
-  ) {
-    let previous: UsageCall | undefined;
-    for (const call of chain.sort((a, b) => a.startedAt - b.startedAt)) {
-      const assessment = assessCache(previous, call);
-      if (
-        previous && (assessment.status === "partial-hit" ||
-          assessment.status === "full-miss")
-      ) {
-        const estimate = estimateModelCacheMissCost(
-          previous.tokens,
-          call.tokens,
-          call.model,
-          call.startedAt,
-        );
-        misses.push({
-          gap: call.startedAt - previous.startedAt,
-          status: assessment.status,
-          ttl: !call.followsCompaction && ttlExpired(previous, call),
-          compaction: call.followsCompaction === true,
-          attributedCost: estimate?.actualMissedCost,
-          expectedReadCost: estimate?.expectedReadCost,
-          estimatedExtraCost: estimate?.estimatedExtraCost,
-          missedTokens: estimate?.missedTokens,
-        });
-      }
-      if (hasInputContext(call.tokens)) previous = call;
-    }
+  for (const call of categorizeUsageCallCache(calls)) {
+    const previous = call.previousComparableCall;
+    const assessment = call.cacheAssessment;
+    if (
+      !previous || (assessment.status !== "partial-hit" &&
+        assessment.status !== "full-miss")
+    ) continue;
+    const estimate = estimateModelCacheMissCost(
+      previous.tokens,
+      call.tokens,
+      call.model,
+      call.startedAt,
+    );
+    misses.push({
+      gap: call.startedAt - previous.startedAt,
+      status: assessment.status,
+      ttl: assessment.cause === "ttl",
+      compaction: assessment.cause === "compaction",
+      attributedCost: estimate?.actualMissedCost,
+      expectedReadCost: estimate?.expectedReadCost,
+      estimatedExtraCost: estimate?.estimatedExtraCost,
+      missedTokens: estimate?.missedTokens,
+    });
   }
   return misses;
 }

--- a/src/server/usage.ts
+++ b/src/server/usage.ts
@@ -12,6 +12,7 @@ export type UsageCall = {
     parentID?: string;
   };
   cacheChainID: string;
+  turnID: string;
   sessionStartedAt: number;
   provider: string;
   model: string;
@@ -36,6 +37,7 @@ export function usageCallsFromSession(
           parentID: session.parentID,
         },
         cacheChainID: session.id,
+        turnID: `${session.id}:${turn.number}`,
         sessionStartedAt: root.startedAt ?? root.updatedAt,
         provider: call.provider,
         model: call.model,

--- a/src/server/usage.ts
+++ b/src/server/usage.ts
@@ -13,6 +13,8 @@ export type UsageCall = {
   };
   cacheChainID: string;
   turnID: string;
+  turnOrdinal: number;
+  images?: number;
   sessionStartedAt: number;
   provider: string;
   model: string;
@@ -38,6 +40,8 @@ export function usageCallsFromSession(
         },
         cacheChainID: session.id,
         turnID: `${session.id}:${turn.number}`,
+        turnOrdinal: turn.number,
+        images: call.activity.images,
         sessionStartedAt: root.startedAt ?? root.updatedAt,
         provider: call.provider,
         model: call.model,

--- a/src/server/usageAnalytics.test.ts
+++ b/src/server/usageAnalytics.test.ts
@@ -11,6 +11,7 @@ function usageCall(
     harness: "opencode",
     session: { id: session, rootID: session },
     cacheChainID: session,
+    turnID: `${session}:${sessionStartedAt}`,
     sessionStartedAt,
     provider: "anthropic",
     model: "claude-sonnet-4-5",

--- a/src/server/usageAnalytics.test.ts
+++ b/src/server/usageAnalytics.test.ts
@@ -12,6 +12,7 @@ function usageCall(
     session: { id: session, rootID: session },
     cacheChainID: session,
     turnID: `${session}:${sessionStartedAt}`,
+    turnOrdinal: 1,
     sessionStartedAt,
     provider: "anthropic",
     model: "claude-sonnet-4-5",

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -281,6 +281,16 @@ const performanceWeekSchema = z.object({
   sessionsWithMiss: z.number().int().nonnegative(),
   turns: z.number().int().nonnegative(),
   turnsWithMiss: z.number().int().nonnegative(),
+  efficiency: z.object({
+    lowerWhisker: z.number().min(0).max(1),
+    q1: z.number().min(0).max(1),
+    median: z.number().min(0).max(1),
+    q3: z.number().min(0).max(1),
+    upperWhisker: z.number().min(0).max(1),
+    average: z.number().min(0).max(1),
+    sampleSize: z.number().int().positive(),
+    outliers: z.number().int().nonnegative(),
+  }).optional(),
 });
 
 const performanceProviderSchema = z.object({

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -274,6 +274,36 @@ export const overviewResponseSchema = z.object({
   })),
 });
 
+const performanceDistributionSchema = z.object({
+  lowerWhisker: z.number().min(0).max(1),
+  q1: z.number().min(0).max(1),
+  median: z.number().min(0).max(1),
+  q3: z.number().min(0).max(1),
+  upperWhisker: z.number().min(0).max(1),
+  average: z.number().min(0).max(1),
+  sampleSize: z.number().int().positive(),
+  outliers: z.number().int().nonnegative(),
+});
+
+const cacheLossBucketSchema = z.object({
+  bucket: z.enum(["0-16k", "16-64k", "64-128k", "128k+"]),
+  requests: z.number().int().nonnegative(),
+  unretainedTokens: z.number().int().nonnegative(),
+});
+
+const cacheRetentionSchema = z.object({
+  comparableRequests: z.number().int().positive(),
+  requestsWithLoss: z.number().int().nonnegative(),
+  partialHits: z.number().int().nonnegative(),
+  fullMisses: z.number().int().nonnegative(),
+  retainedTokens: z.number().int().nonnegative(),
+  unretainedTokens: z.number().int().nonnegative(),
+  retainedShare: z.number().min(0).max(1),
+  lossRequestRate: z.number().min(0).max(1),
+  p90UnretainedTokens: z.number().nonnegative(),
+  lossBuckets: z.array(cacheLossBucketSchema),
+});
+
 const performanceWeekSchema = z.object({
   date: z.string(),
   endDate: z.string(),
@@ -281,16 +311,9 @@ const performanceWeekSchema = z.object({
   sessionsWithMiss: z.number().int().nonnegative(),
   turns: z.number().int().nonnegative(),
   turnsWithMiss: z.number().int().nonnegative(),
-  efficiency: z.object({
-    lowerWhisker: z.number().min(0).max(1),
-    q1: z.number().min(0).max(1),
-    median: z.number().min(0).max(1),
-    q3: z.number().min(0).max(1),
-    upperWhisker: z.number().min(0).max(1),
-    average: z.number().min(0).max(1),
-    sampleSize: z.number().int().positive(),
-    outliers: z.number().int().nonnegative(),
-  }).optional(),
+  efficiency: performanceDistributionSchema.optional(),
+  finalContextShare: performanceDistributionSchema.optional(),
+  cacheRetention: cacheRetentionSchema.optional(),
 });
 
 const imageCohortSchema = z.object({

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -274,6 +274,35 @@ export const overviewResponseSchema = z.object({
   })),
 });
 
+const performanceWeekSchema = z.object({
+  date: z.string(),
+  endDate: z.string(),
+  sessions: z.number().int().nonnegative(),
+  sessionsWithMiss: z.number().int().nonnegative(),
+  turns: z.number().int().nonnegative(),
+  turnsWithMiss: z.number().int().nonnegative(),
+});
+
+const performanceProviderSchema = z.object({
+  provider: z.enum(["openai", "anthropic"]),
+  selectedModel: z.string(),
+  sessions: z.number().int().nonnegative(),
+  sessionsWithMiss: z.number().int().nonnegative(),
+  turns: z.number().int().nonnegative(),
+  turnsWithMiss: z.number().int().nonnegative(),
+  weeks: z.array(performanceWeekSchema),
+});
+
+export const performanceResponseSchema = z.object({
+  rangeDays: z.number().int().positive(),
+  models: z.object({
+    openai: z.array(z.string()),
+    anthropic: z.array(z.string()),
+  }),
+  openai: performanceProviderSchema,
+  anthropic: performanceProviderSchema,
+});
+
 export const ttlMissMetricsSchema = z.object({
   rangeDays: z.number().int().positive(),
   sessions: z.number().int().nonnegative(),
@@ -367,4 +396,5 @@ export type SessionSummary = z.infer<typeof sessionSummarySchema>;
 export type TokenUsage = z.infer<typeof tokenUsageSchema>;
 export type UsageResponse = z.infer<typeof usageResponseSchema>;
 export type OverviewResponse = z.infer<typeof overviewResponseSchema>;
+export type PerformanceResponse = z.infer<typeof performanceResponseSchema>;
 export type TtlMissMetrics = z.infer<typeof ttlMissMetricsSchema>;

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -293,6 +293,12 @@ const performanceWeekSchema = z.object({
   }).optional(),
 });
 
+const imageCohortSchema = z.object({
+  cohort: z.enum(["no-image", "first-turn-image", "later-turn-image"]),
+  sessions: z.number().int().nonnegative(),
+  sessionsWithMiss: z.number().int().nonnegative(),
+});
+
 const performanceProviderSchema = z.object({
   provider: z.enum(["openai", "anthropic"]),
   selectedModel: z.string(),
@@ -300,6 +306,7 @@ const performanceProviderSchema = z.object({
   sessionsWithMiss: z.number().int().nonnegative(),
   turns: z.number().int().nonnegative(),
   turnsWithMiss: z.number().int().nonnegative(),
+  imageCohorts: z.array(imageCohortSchema),
   weeks: z.array(performanceWeekSchema),
 });
 


### PR DESCRIPTION
## Overview
The Performance tab compares OpenAI and Anthropic cache behavior over the recent reporting window. Provider model and harness filters apply across the views.

It includes weekly session and turn miss rates, session-level cache-efficiency distributions, context-efficiency distributions, image-use cohorts, and unexpected cache-miss volume grouped by inferred loss size.

The cache-miss volume view considers comparable requests, excludes known compaction and cache-expiry causes, and buckets only partial or full misses.

## Checks
- `deno test --allow-env --allow-read --allow-write src/server/performanceAnalytics.test.ts`
- `deno check src/server/main.ts src/client/main.tsx vite.config.ts`