### PR TITLE
Prototype pooled SQLite readers

### DIFF
--- a/docs/sqlite-concurrency-experiment.md
+++ b/docs/sqlite-concurrency-experiment.md
@@ -1,0 +1,200 @@
+# SQLite Concurrency Experiment
+
+## Goal
+
+The dashboard starts four independent requests for sessions, usage, TTL misses,
+and overview. The server previously executed archive reads through one
+synchronous `node:sqlite` connection on Deno's main JavaScript thread. Although
+the browser initiated the requests concurrently, synchronous repository work
+blocked the event loop and made their database work effectively serial.
+
+The experiment tested whether a bounded pool of read-only SQLite connections in
+Deno workers would make the initial dashboard complete closer to the duration
+of its slowest endpoint rather than the sum of all endpoint durations.
+
+## Implementation Tried
+
+The experimental implementation:
+
+- Retained the existing writable `SessionRepository` on the main thread for
+  imports and synchronization.
+- Added a generic five-worker reader pool.
+- Opened one read-only `node:sqlite` connection per worker.
+- Reused the existing synchronous `SessionRepository` inside each worker.
+- Added an asynchronous `SessionReadPool` facade for `listSessions`,
+  `getSession`, and `listUsageCalls`.
+- Converted archive-backed API handlers to await pooled reads.
+- Kept existing SQL, response schemas, and repository read behavior.
+
+Relevant experimental files:
+
+- `src/server/readerPool.ts`
+- `src/server/sessionReadPool.ts`
+- `src/server/sessionReadWorker.ts`
+- `src/server/sessionReadPool.test.ts`
+- `src/server/database.ts`
+- `src/server/main.ts`
+
+## Result: Requests Overlapped
+
+The browser network waterfall confirmed that Sessions, Usage, TTL, and
+Overview began at approximately the same time. The responses completed
+progressively, with Sessions first and Overview last. This proved that moving
+synchronous SQLite work into workers allowed the HTTP handlers to overlap.
+
+The frontend was already initiating these requests independently through React
+`useEffect` hooks. It was not explicitly sequencing them.
+
+## Result: Overall Performance Regressed
+
+Representative timings before the pool:
+
+| Endpoint | Duration |
+| --- | ---: |
+| Sessions | 31 ms |
+| TTL misses | 125 ms |
+| Usage | 87 ms |
+| Overview | 451 ms |
+
+Representative timings with the five-reader pool:
+
+| Endpoint | Duration | Change |
+| --- | ---: | ---: |
+| Sessions | 98 ms | 3.2x slower |
+| TTL misses | 225 ms | 1.8x slower |
+| Usage | 292 ms | 3.4x slower |
+| Overview | 825 ms | 1.8x slower |
+
+The approximate pre-experiment serialized total was 694 ms. The experimental
+parallel completion time was governed by the 825 ms Overview request, so the
+page completed more slowly despite successful overlap.
+
+The compared data sets differed slightly (8,073 versus 8,148 usage calls and
+240 versus 242 overview roots), but not enough to explain the regression.
+
+## Likely Causes
+
+### Repository calls were too fine-grained
+
+The pool operated at the repository-method boundary rather than the complete
+API-job boundary. Overview continued to list pages and hydrate each qualifying
+root individually. Its 242 `getSession` operations each crossed the worker
+message boundary.
+
+Sessions similarly listed one page and then performed individual detail reads
+for enrichment.
+
+### Large intermediate values were cloned
+
+Usage and TTL each loaded more than 8,000 `UsageCall` objects in a worker and
+returned that unaggregated object graph to the main thread. Deno had to
+structured-clone and deserialize those values before pricing and aggregation.
+The final HTTP responses were much smaller than these internal intermediate
+values.
+
+### Concurrent readers contended for shared resources
+
+The five workers concurrently traversed the same SQLite tables and consumed CPU,
+memory bandwidth, page cache, and garbage-collection capacity. WAL permits
+concurrent readers, but does not guarantee that each reader retains its isolated
+latency under load.
+
+Main-thread aggregation also became slower while workers continued consuming
+resources. TTL aggregation increased from about 15 ms to 27 ms, and Usage
+aggregation increased from about 24 ms to 43 ms.
+
+## Frontend Startup Observation
+
+A development-mode browser waterfall showed that the four API calls did not
+start until approximately 500 ms after navigation. The trace showed Vite
+serving TypeScript modules and loading the lazily imported `SessionsPage` before
+React effects initiated the requests.
+
+The same trace showed these browser request durations:
+
+| Endpoint | Browser duration |
+| --- | ---: |
+| Sessions | 113 ms |
+| TTL misses | 265 ms |
+| Usage | 330 ms |
+| Overview | 866 ms |
+
+This produced approximately 1.4 seconds from navigation to the final Overview
+response. Production should be measured separately because Vite's development
+ES-module graph can add startup latency. If production retains a meaningful
+delay, the default Sessions page could be eagerly loaded or its data fetching
+could move to a router loader.
+
+## Repository Structure Observation
+
+When `FRUGAL_TOKENS_DATABASE_URL` is configured, all UI reads come from the
+canonical archive. The harness-specific `repository`, `claudeRepository`,
+`piRepository`, and `codexRepository` variables in `main.ts` are wrappers around
+the same archive reader. Their direct-source alternatives are fallback behavior
+for running without the archive.
+
+If `FRUGAL_TOKENS_DATABASE_URL` is required in practice, a later cleanup can
+remove direct-source API reads and expose one application-facing reader:
+
+```ts
+sessionReader.listSessions(page, pageSize, harness);
+sessionReader.getSession(harness, id);
+sessionReader.listUsageCalls(start, harness);
+```
+
+Source-specific code would remain in the import path, while API reads would use
+only the archive. This cleanup would reduce complexity but would not by itself
+solve the measured performance regression. The dominant problems are
+fine-grained hydration, large worker transfers, and duplicated analytics reads.
+
+## Better Direction for a Future Experiment
+
+If worker-based concurrency is revisited, use coarse API or analytics jobs:
+
+```ts
+analyticsPool.sessions({ page, pageSize, harness });
+analyticsPool.usage({ range, harness });
+analyticsPool.ttlMisses({ range, harness });
+analyticsPool.overview({ range, harness });
+```
+
+Each worker should perform the complete operation:
+
+1. Read SQLite.
+2. Hydrate required data.
+3. Apply pricing.
+4. Aggregate analytics.
+5. Return only the compact API response.
+
+This would avoid transferring large intermediate call arrays, remove hundreds
+of Overview worker messages, and move synchronous aggregation off the main
+event loop. It would still require measurement because concurrent scans can
+contend.
+
+Additional follow-up opportunities:
+
+- Batch Overview hydration rather than issuing one detail query per root.
+- Avoid independently loading equivalent call sets for Usage and TTL.
+- Measure isolated pooled endpoint latency versus concurrent latency to separate
+  worker-transfer overhead from reader contention.
+- Record worker queue wait, worker execution, transfer, and aggregation as
+  distinct timing phases.
+- Compare development and production frontend startup waterfalls.
+
+## Recommendation
+
+Shelf or revert the current fine-grained repository pool rather than shipping it
+as a performance improvement. It successfully demonstrated concurrent request
+execution, but representative total page completion regressed. Preserve this
+experiment and its measurements as input to a future coarse-job worker design.
+
+## Verification Performed
+
+During the experiment, the following checks passed:
+
+- `deno task check`
+- Reader-pool integration test
+- Database tests
+- Session repository tests
+
+The full test suite was not run.

--- a/src/server/database.ts
+++ b/src/server/database.ts
@@ -38,3 +38,16 @@ export function openArchiveDatabase(path: string) {
     throw error;
   }
 }
+
+export function openArchiveReader(path: string) {
+  const db = new DatabaseSync(path, { readOnly: true });
+  try {
+    db.exec("PRAGMA foreign_keys = ON");
+    db.exec("PRAGMA busy_timeout = 5000");
+    db.exec("PRAGMA query_only = ON");
+    return db;
+  } catch (error) {
+    db.close();
+    throw error;
+  }
+}

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -39,6 +39,7 @@ import {
   sqlitePath,
 } from "./database.ts";
 import { SessionRepository } from "./sessionRepository.ts";
+import { SessionReadPool } from "./sessionReadPool.ts";
 import { syncPiSessions } from "./piImporter.ts";
 import { syncCodexSessions } from "./codexImporter.ts";
 import { syncClaudeCodeSessions } from "./claudeCodeImporter.ts";
@@ -97,11 +98,15 @@ const codexDirectory = configuredPath(
   (path) => path,
 );
 const archiveURL = Deno.env.get("FRUGAL_TOKENS_DATABASE_URL");
-const archiveDatabase = archiveURL
-  ? openArchiveDatabase(sqlitePath(archiveURL))
+const archivePath = archiveURL ? sqlitePath(archiveURL) : undefined;
+const archiveDatabase = archivePath
+  ? openArchiveDatabase(archivePath)
   : undefined;
 const archiveRepository = archiveDatabase
   ? new SessionRepository(archiveDatabase)
+  : undefined;
+const archiveReader = archivePath
+  ? new SessionReadPool(archivePath, 5)
   : undefined;
 const syncIntervalSeconds = (() => {
   const value = Deno.env.get("FRUGAL_TOKENS_SYNC_INTERVAL_SECONDS");
@@ -202,46 +207,46 @@ async function syncSourcesPeriodically(intervalSeconds: number) {
     }
   }
 }
-const claudeRepository = archiveRepository
+const claudeRepository = archiveReader
   ? {
     listSessions: (page: number, pageSize: number) =>
-      archiveRepository.listSessions(page, pageSize, "claude-code"),
-    getSession: (id: string) => archiveRepository.getSession("claude-code", id),
+      archiveReader.listSessions(page, pageSize, "claude-code"),
+    getSession: (id: string) => archiveReader.getSession("claude-code", id),
     listUsageCalls: (startedAt?: number) =>
-      archiveRepository.listUsageCalls(startedAt, "claude-code"),
+      archiveReader.listUsageCalls(startedAt, "claude-code"),
   }
   : claudeDirectory
   ? new ClaudeCodeRepository(claudeDirectory)
   : undefined;
-const piRepository = archiveRepository
+const piRepository = archiveReader
   ? {
     listSessions: (page: number, pageSize: number) =>
-      archiveRepository.listSessions(page, pageSize, "pi"),
-    getSession: (id: string) => archiveRepository.getSession("pi", id),
+      archiveReader.listSessions(page, pageSize, "pi"),
+    getSession: (id: string) => archiveReader.getSession("pi", id),
     listUsageCalls: (startedAt?: number) =>
-      archiveRepository.listUsageCalls(startedAt, "pi"),
+      archiveReader.listUsageCalls(startedAt, "pi"),
   }
   : piDirectory
   ? new PiRepository(piDirectory)
   : undefined;
-const codexRepository = archiveRepository
+const codexRepository = archiveReader
   ? {
     listSessions: (page: number, pageSize: number) =>
-      archiveRepository.listSessions(page, pageSize, "codex"),
-    getSession: (id: string) => archiveRepository.getSession("codex", id),
+      archiveReader.listSessions(page, pageSize, "codex"),
+    getSession: (id: string) => archiveReader.getSession("codex", id),
     listUsageCalls: (startedAt?: number) =>
-      archiveRepository.listUsageCalls(startedAt, "codex"),
+      archiveReader.listUsageCalls(startedAt, "codex"),
   }
   : codexDirectory
   ? new CodexRepository(codexDirectory)
   : undefined;
-const repository = archiveRepository
+const repository = archiveReader
   ? {
     listSessions: (page: number, pageSize: number) =>
-      archiveRepository.listSessions(page, pageSize, "opencode"),
-    getSession: (id: string) => archiveRepository.getSession("opencode", id),
+      archiveReader.listSessions(page, pageSize, "opencode"),
+    getSession: (id: string) => archiveReader.getSession("opencode", id),
     listUsageCalls: (startedAt?: number) =>
-      archiveRepository.listUsageCalls(startedAt, "opencode"),
+      archiveReader.listUsageCalls(startedAt, "opencode"),
   }
   : openCodePath
   ? new OpenCodeRepository(openCodePath)
@@ -388,10 +393,16 @@ function compactionCount(session: SessionDetail): number {
     );
 }
 
-function priceSummaries(items: SessionSummary[]) {
-  return items.map((item) => {
-    const detail = repositoryForHarness(item.harness)?.getSession(item.id);
-    if (!detail) return item;
+async function priceSummaries(items: SessionSummary[]) {
+  const results: SessionSummary[] = [];
+  for (const item of items) {
+    const detail = await repositoryForHarness(item.harness)?.getSession(
+      item.id,
+    );
+    if (!detail) {
+      results.push(item);
+      continue;
+    }
     const priced = priceSessionDetail(detail);
     const analyzed = analyzeSessionCache(priced);
     const subagents = subagentTotals(priced.subagents);
@@ -406,7 +417,7 @@ function priceSummaries(items: SessionSummary[]) {
         }))
       ),
     );
-    return {
+    const result = {
       ...item,
       userTurns: priced.userTurns,
       modelCalls: priced.modelCalls,
@@ -427,21 +438,23 @@ function priceSummaries(items: SessionSummary[]) {
       inclusiveImageInputs: inclusive.imageInputs,
       inclusiveTokens: inclusive.tokens,
     };
-  });
+    results.push(result);
+  }
+  return results;
 }
 
-function listSessions(
+async function listSessions(
   source: ReturnType<typeof repositoryForHarness>,
   page: number,
   pageSize: number,
 ) {
-  return source?.listSessions(page, pageSize) ?? {
+  return await source?.listSessions(page, pageSize) ?? {
     items: [],
     pagination: { page, pageSize, totalItems: 0, totalPages: 0 },
   };
 }
 
-function overviewSessions(start: number, harness: string) {
+async function overviewSessions(start: number, harness: string) {
   const harnesses = harness === "all"
     ? (["opencode", "claude-code", "pi", "codex"] as const)
     : [harness as SessionSummary["harness"]];
@@ -451,10 +464,10 @@ function overviewSessions(start: number, harness: string) {
     if (!source) continue;
     const pageSize = 100;
     for (let page = 1;; page++) {
-      const result = source.listSessions(page, pageSize);
+      const result = await source.listSessions(page, pageSize);
       for (const summary of result.items) {
         if (summary.updatedAt < start) continue;
-        const detail = source.getSession(summary.id);
+        const detail = await source.getSession(summary.id);
         if (detail) sessions.push(priceSessionDetail(detail));
       }
       if (
@@ -466,7 +479,7 @@ function overviewSessions(start: number, harness: string) {
   return sessions;
 }
 
-app.get("/api/performance", (context) => {
+app.get("/api/performance", async (context) => {
   const harness = context.req.query("harness") ?? "all";
   if (!["all", "opencode", "claude-code", "pi", "codex"].includes(harness)) {
     return context.json({ error: "Invalid harness" }, 400);
@@ -495,8 +508,8 @@ app.get("/api/performance", (context) => {
   // compared with their immediately preceding context.
   const cacheStart = start - CACHE_TTL_1H_MS;
   const calls: UsageCall[] = [];
-  if (archiveRepository) {
-    calls.push(...archiveRepository.listUsageCalls(
+  if (archiveReader) {
+    calls.push(...await archiveReader.listUsageCalls(
       cacheStart,
       harness === "all" ? undefined : harness as SessionSummary["harness"],
     ));
@@ -509,7 +522,7 @@ app.get("/api/performance", (context) => {
     ] as const;
     for (const [name, source] of sources) {
       if (!source || (harness !== "all" && harness !== name)) continue;
-      calls.push(...source.listUsageCalls(cacheStart));
+      calls.push(...await source.listUsageCalls(cacheStart));
     }
   }
   return context.json(
@@ -517,7 +530,7 @@ app.get("/api/performance", (context) => {
   );
 });
 
-app.get("/api/ttl-misses", (context) => {
+app.get("/api/ttl-misses", async (context) => {
   const harness = context.req.query("harness") ?? "all";
   if (!["all", "opencode", "claude-code", "pi", "codex"].includes(harness)) {
     return context.json({ error: "Invalid harness" }, 400);
@@ -533,8 +546,8 @@ app.get("/api/ttl-misses", (context) => {
     ).getTime();
   const usageCalls: UsageCall[] = [];
 
-  if (archiveRepository) {
-    usageCalls.push(...archiveRepository.listUsageCalls(
+  if (archiveReader) {
+    usageCalls.push(...await archiveReader.listUsageCalls(
       start,
       harness === "all" ? undefined : harness as SessionSummary["harness"],
     ));
@@ -547,14 +560,14 @@ app.get("/api/ttl-misses", (context) => {
     ] as const;
     for (const [name, source] of sources) {
       if (!source || (harness !== "all" && harness !== name)) continue;
-      usageCalls.push(...source.listUsageCalls(start));
+      usageCalls.push(...await source.listUsageCalls(start));
     }
   }
 
   return context.json(aggregateTtlMisses(usageCalls, start, range));
 });
 
-app.get("/api/overview", (context) => {
+app.get("/api/overview", async (context) => {
   const harness = context.req.query("harness") ?? "all";
   if (!["all", "opencode", "claude-code", "pi", "codex"].includes(harness)) {
     return context.json({ error: "Invalid harness" }, 400);
@@ -576,7 +589,7 @@ app.get("/api/overview", (context) => {
     : "full";
   return context.json(
     aggregateOverview(
-      overviewSessions(
+      await overviewSessions(
         start - ROTATION_INACTIVITY_MINUTES * 60_000,
         harness,
       ),
@@ -588,7 +601,7 @@ app.get("/api/overview", (context) => {
   );
 });
 
-app.get("/api/usage", (context) => {
+app.get("/api/usage", async (context) => {
   const requestStartedAt = performance.now();
   const harness = context.req.query("harness") ?? "all";
   if (!["all", "opencode", "claude-code", "pi", "codex"].includes(harness)) {
@@ -605,9 +618,9 @@ app.get("/api/usage", (context) => {
   const usageCalls: UsageCall[] = [];
 
   const detailDurations = new Map<string, number>();
-  if (archiveRepository) {
+  if (archiveReader) {
     const detailStartedAt = performance.now();
-    const calls = archiveRepository.listUsageCalls(
+    const calls = await archiveReader.listUsageCalls(
       start,
       harness === "all" ? undefined : harness as SessionSummary["harness"],
     );
@@ -634,7 +647,7 @@ app.get("/api/usage", (context) => {
       if (harness !== "all" && harness !== name) continue;
       if (!source) continue;
       const detailStartedAt = performance.now();
-      for (const call of source.listUsageCalls(start)) {
+      for (const call of await source.listUsageCalls(start)) {
         const pricedCall = {
           ...call,
           computedCost: call.computedCost ?? computeModelCallCost(
@@ -677,7 +690,7 @@ app.get("/api/usage", (context) => {
   return context.json(aggregated.response);
 });
 
-app.get("/api/sessions", (context) => {
+app.get("/api/sessions", async (context) => {
   const requestStartedAt = performance.now();
   const page = Math.max(
     1,
@@ -692,23 +705,25 @@ app.get("/api/sessions", (context) => {
   }
   const queryStartedAt = performance.now();
   let result: SessionListResponse;
-  if (archiveRepository) {
-    result = archiveRepository.listSessions(
+  if (archiveReader) {
+    result = await archiveReader.listSessions(
       page,
       pageSize,
       harness === "all" ? undefined : harness as SessionSummary["harness"],
     );
   } else if (harness !== "all") {
-    result = listSessions(
+    result = await listSessions(
       repositoryForHarness(harness as SessionSummary["harness"]),
       page,
       pageSize,
     );
   } else {
-    const openCode = listSessions(repository, 1, page * pageSize);
-    const claude = listSessions(claudeRepository, 1, page * pageSize);
-    const pi = listSessions(piRepository, 1, page * pageSize);
-    const codex = listSessions(codexRepository, 1, page * pageSize);
+    const [openCode, claude, pi, codex] = await Promise.all([
+      listSessions(repository, 1, page * pageSize),
+      listSessions(claudeRepository, 1, page * pageSize),
+      listSessions(piRepository, 1, page * pageSize),
+      listSessions(codexRepository, 1, page * pageSize),
+    ]);
     const totalItems = openCode.pagination.totalItems +
       claude.pagination.totalItems + pi.pagination.totalItems +
       codex.pagination.totalItems;
@@ -730,7 +745,7 @@ app.get("/api/sessions", (context) => {
   }
   const queryDuration = performance.now() - queryStartedAt;
   const enrichmentStartedAt = performance.now();
-  const items = priceSummaries(result.items);
+  const items = await priceSummaries(result.items);
   const enrichmentDuration = performance.now() - enrichmentStartedAt;
   const totalDuration = performance.now() - requestStartedAt;
   context.header(
@@ -749,15 +764,15 @@ app.get("/api/sessions", (context) => {
   return context.json({ ...result, items });
 });
 
-app.get("/api/sessions/:id", (context) => {
+app.get("/api/sessions/:id", async (context) => {
   const harness = context.req.query("harness");
-  const session = harness === "claude-code"
+  const session = await (harness === "claude-code"
     ? claudeRepository?.getSession(context.req.param("id"))
     : harness === "pi"
     ? piRepository?.getSession(context.req.param("id"))
     : harness === "codex"
     ? codexRepository?.getSession(context.req.param("id"))
-    : repository?.getSession(context.req.param("id"));
+    : repository?.getSession(context.req.param("id")));
   return session
     ? context.json(analyzeSessionCache(priceSessionDetail(session)))
     : context.json({ error: "Session not found" }, 404);

--- a/src/server/readerPool.ts
+++ b/src/server/readerPool.ts
@@ -1,0 +1,139 @@
+type PoolTask<Request, Result> = {
+  id: number;
+  request: Request;
+  resolve: (result: Result) => void;
+  reject: (error: Error) => void;
+};
+
+type WorkerSlot<Request, Result> = {
+  worker: Worker;
+  ready: boolean;
+  active?: PoolTask<Request, Result>;
+};
+
+type WorkerResponse<Result> =
+  | { type: "ready" }
+  | { type: "result"; id: number; result: Result }
+  | { type: "error"; id?: number; message: string; stack?: string };
+
+/** A bounded task pool for module workers that implement the reader protocol. */
+export class ReaderPool<Request, Result> {
+  readonly #slots: WorkerSlot<Request, Result>[] = [];
+  readonly #queue: PoolTask<Request, Result>[] = [];
+  #nextID = 1;
+  #failure?: Error;
+  #closed = false;
+
+  constructor(
+    size: number,
+    createWorker: () => Worker,
+    initialize: unknown,
+  ) {
+    if (!Number.isInteger(size) || size < 1) {
+      throw new RangeError("reader pool size must be a positive integer");
+    }
+
+    try {
+      for (let index = 0; index < size; index++) {
+        const worker = createWorker();
+        const slot: WorkerSlot<Request, Result> = { worker, ready: false };
+        worker.onmessage = (event: MessageEvent<WorkerResponse<Result>>) => {
+          this.#receive(slot, event.data);
+        };
+        worker.onerror = (event) => {
+          event.preventDefault();
+          this.#fail(new Error(event.message || "Reader worker failed"));
+        };
+        worker.onmessageerror = () => {
+          this.#fail(new Error("Reader worker returned an invalid message"));
+        };
+        this.#slots.push(slot);
+        worker.postMessage({ type: "initialize", value: initialize });
+      }
+    } catch (error) {
+      this.close();
+      throw error;
+    }
+  }
+
+  execute(request: Request): Promise<Result> {
+    if (this.#closed) {
+      return Promise.reject(new Error("Reader pool is closed"));
+    }
+    if (this.#failure) return Promise.reject(this.#failure);
+
+    return new Promise((resolve, reject) => {
+      this.#queue.push({ id: this.#nextID++, request, resolve, reject });
+      this.#dispatch();
+    });
+  }
+
+  close() {
+    if (this.#closed) return;
+    this.#closed = true;
+    const error = this.#failure ?? new Error("Reader pool is closed");
+    for (const slot of this.#slots) {
+      slot.active?.reject(error);
+      slot.worker.terminate();
+    }
+    for (const task of this.#queue.splice(0)) task.reject(error);
+  }
+
+  #receive(
+    slot: WorkerSlot<Request, Result>,
+    response: WorkerResponse<Result>,
+  ) {
+    if (this.#closed || this.#failure) return;
+    if (response.type === "ready") {
+      slot.ready = true;
+      this.#dispatch();
+      return;
+    }
+    if (response.type === "error" && response.id === undefined) {
+      this.#fail(this.#error(response));
+      return;
+    }
+
+    const task = slot.active;
+    if (!task || response.id !== task.id) {
+      this.#fail(new Error("Reader worker returned an unexpected response"));
+      return;
+    }
+    slot.active = undefined;
+    if (response.type === "result") task.resolve(response.result);
+    else task.reject(this.#error(response));
+    this.#dispatch();
+  }
+
+  #dispatch() {
+    if (this.#closed || this.#failure) return;
+    for (const slot of this.#slots) {
+      if (!slot.ready || slot.active) continue;
+      const task = this.#queue.shift();
+      if (!task) return;
+      slot.active = task;
+      slot.worker.postMessage({
+        type: "execute",
+        id: task.id,
+        request: task.request,
+      });
+    }
+  }
+
+  #fail(error: Error) {
+    if (this.#failure || this.#closed) return;
+    this.#failure = error;
+    for (const slot of this.#slots) {
+      slot.active?.reject(error);
+      slot.active = undefined;
+      slot.worker.terminate();
+    }
+    for (const task of this.#queue.splice(0)) task.reject(error);
+  }
+
+  #error(response: Extract<WorkerResponse<Result>, { type: "error" }>) {
+    const error = new Error(response.message);
+    if (response.stack) error.stack = response.stack;
+    return error;
+  }
+}

--- a/src/server/sessionReadPool.test.ts
+++ b/src/server/sessionReadPool.test.ts
@@ -1,0 +1,28 @@
+import { deepStrictEqual } from "node:assert/strict";
+import { openArchiveDatabase } from "./database.ts";
+import { migrateTestDatabase } from "./databaseTestUtils.ts";
+import { SessionReadPool } from "./sessionReadPool.ts";
+
+Deno.test("serves archive reads through multiple workers", async () => {
+  const directory = Deno.makeTempDirSync();
+  const path = `${directory}/archive.sqlite`;
+  const writer = openArchiveDatabase(path);
+  migrateTestDatabase(writer);
+  const readers = new SessionReadPool(path, 2);
+
+  try {
+    const [sessions, calls] = await Promise.all([
+      readers.listSessions(1, 25),
+      readers.listUsageCalls(),
+    ]);
+    deepStrictEqual(sessions, {
+      items: [],
+      pagination: { page: 1, pageSize: 25, totalItems: 0, totalPages: 0 },
+    });
+    deepStrictEqual(calls, []);
+  } finally {
+    readers.close();
+    writer.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});

--- a/src/server/sessionReadPool.ts
+++ b/src/server/sessionReadPool.ts
@@ -1,0 +1,77 @@
+import type {
+  SessionDetail,
+  SessionListResponse,
+  SessionSummary,
+} from "../shared/sessionSchemas.ts";
+import type { UsageCall } from "./usage.ts";
+import { ReaderPool } from "./readerPool.ts";
+
+type Harness = SessionSummary["harness"];
+
+export type SessionReadRequest =
+  | {
+    operation: "listSessions";
+    page: number;
+    pageSize: number;
+    harness?: Harness;
+  }
+  | { operation: "getSession"; harness: Harness; id: string }
+  | { operation: "listUsageCalls"; startedAt?: number; harness?: Harness };
+
+type SessionReadResult =
+  | SessionListResponse
+  | SessionDetail
+  | UsageCall[]
+  | undefined;
+
+export interface SessionReader {
+  listSessions(
+    page: number,
+    pageSize: number,
+    harness?: Harness,
+  ): Promise<SessionListResponse>;
+  getSession(harness: Harness, id: string): Promise<SessionDetail | undefined>;
+  listUsageCalls(startedAt?: number, harness?: Harness): Promise<UsageCall[]>;
+}
+
+export class SessionReadPool implements SessionReader {
+  readonly #pool: ReaderPool<SessionReadRequest, SessionReadResult>;
+
+  constructor(path: string, size: number) {
+    const workerURL = new URL("./sessionReadWorker.ts", import.meta.url).href;
+    this.#pool = new ReaderPool(
+      size,
+      () => new Worker(workerURL, { type: "module" }),
+      { path },
+    );
+  }
+
+  async listSessions(page: number, pageSize: number, harness?: Harness) {
+    return await this.#pool.execute({
+      operation: "listSessions",
+      page,
+      pageSize,
+      harness,
+    }) as SessionListResponse;
+  }
+
+  async getSession(harness: Harness, id: string) {
+    return await this.#pool.execute({
+      operation: "getSession",
+      harness,
+      id,
+    }) as SessionDetail | undefined;
+  }
+
+  async listUsageCalls(startedAt?: number, harness?: Harness) {
+    return await this.#pool.execute({
+      operation: "listUsageCalls",
+      startedAt,
+      harness,
+    }) as UsageCall[];
+  }
+
+  close() {
+    this.#pool.close();
+  }
+}

--- a/src/server/sessionReadWorker.ts
+++ b/src/server/sessionReadWorker.ts
@@ -1,0 +1,52 @@
+/// <reference lib="deno.worker" />
+
+import { openArchiveReader } from "./database.ts";
+import { SessionRepository } from "./sessionRepository.ts";
+import type { SessionReadRequest } from "./sessionReadPool.ts";
+
+let repository: SessionRepository | undefined;
+
+function errorMessage(error: unknown) {
+  return error instanceof Error
+    ? { message: error.message, stack: error.stack }
+    : { message: String(error) };
+}
+
+self.onmessage = (
+  event: MessageEvent<
+    | { type: "initialize"; value: { path: string } }
+    | { type: "execute"; id: number; request: SessionReadRequest }
+  >,
+) => {
+  const message = event.data;
+  if (message.type === "initialize") {
+    try {
+      repository = new SessionRepository(openArchiveReader(message.value.path));
+      self.postMessage({ type: "ready" });
+    } catch (error) {
+      self.postMessage({ type: "error", ...errorMessage(error) });
+    }
+    return;
+  }
+
+  try {
+    if (!repository) throw new Error("Reader worker is not initialized");
+    const request = message.request;
+    const result = request.operation === "listSessions"
+      ? repository.listSessions(
+        request.page,
+        request.pageSize,
+        request.harness,
+      )
+      : request.operation === "getSession"
+      ? repository.getSession(request.harness, request.id)
+      : repository.listUsageCalls(request.startedAt, request.harness);
+    self.postMessage({ type: "result", id: message.id, result });
+  } catch (error) {
+    self.postMessage({
+      type: "error",
+      id: message.id,
+      ...errorMessage(error),
+    });
+  }
+};


### PR DESCRIPTION
## Summary
- add a generic five-worker pool for read-only SQLite archive connections
- route archive-backed API reads through an async repository facade
- document the experiment, measured regression, and a coarse-job alternative

## Results
The browser confirmed that the dashboard requests overlap, but representative endpoint latency regressed enough that overall page completion increased. This draft preserves the experiment for review and should not be merged as a performance improvement in its current form.

## Verification
- `deno task check`
- `deno test --allow-env --allow-read --allow-write src/server/sessionReadPool.test.ts src/server/database.test.ts src/server/sessionRepository.test.ts`

## Isolation
This branch was created from `c6f601a` in a separate worktree and includes only the SQLite reader-pool experiment and its notes.