### PR TITLE
Import Codex sessions that report a null reasoning effort

### DIFF
--- a/src/server/codexRepository.test.ts
+++ b/src/server/codexRepository.test.ts
@@ -1,5 +1,8 @@
 import { deepStrictEqual, strictEqual } from "node:assert/strict";
-import { CodexRepository } from "./codexRepository.ts";
+import {
+  CodexRepository,
+  normalizeCodexSession,
+} from "./codexRepository.ts";
 import type { SessionDetail } from "../shared/sessionSchemas.ts";
 
 function repository(files: Record<string, string>) {
@@ -182,6 +185,52 @@ Deno.test("applies Codex reasoning settings to the turn that changes them", () =
     ),
     ["low", "medium"],
   );
+});
+
+Deno.test("ignores null Codex reasoning effort and falls back", () => {
+  const actual = repository({
+    "2026/07/25/rollout-null-effort.jsonl": `
+{"timestamp":"2026-07-25T18:00:00.000Z","type":"event_msg","payload":{"type":"task_started"}}
+{"timestamp":"2026-07-25T18:00:00.001Z","type":"turn_context","payload":{"model":"gpt-5.6-sol","collaboration_mode":{"mode":"default","settings":{"model":"gpt-5.6-sol","reasoning_effort":null,"developer_instructions":null}}}}
+{"timestamp":"2026-07-25T18:00:00.002Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"first"}]}}
+{"timestamp":"2026-07-25T18:00:01.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":1,"reasoning_output_tokens":0}}}}
+{"timestamp":"2026-07-25T18:00:02.000Z","type":"event_msg","payload":{"type":"task_started"}}
+{"timestamp":"2026-07-25T18:00:02.001Z","type":"turn_context","payload":{"model":"gpt-5.6-sol","collaboration_mode":{"settings":{"reasoning_effort":null}},"thread_settings":{"reasoning_effort":"low"}}}
+{"timestamp":"2026-07-25T18:00:02.002Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"second"}]}}
+{"timestamp":"2026-07-25T18:00:03.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":1,"reasoning_output_tokens":0}}}}
+`,
+  }).getSession("2026/07/25/rollout-null-effort")!;
+
+  deepStrictEqual(actual.turns.length, 2);
+  deepStrictEqual(
+    actual.turns.map((turn) => turn.reasoningSetting?.settingValue),
+    [undefined, "low"],
+  );
+  deepStrictEqual(
+    actual.turns[1].reasoningSetting?.sourceFieldPath,
+    "payload.thread_settings.reasoning_effort",
+  );
+});
+
+Deno.test("imports Codex sessions that report a null reasoning effort", () => {
+  const text = `
+{"timestamp":"2026-07-25T18:00:00.000Z","type":"event_msg","payload":{"type":"task_started"}}
+{"timestamp":"2026-07-25T18:00:00.001Z","type":"turn_context","payload":{"model":"gpt-5.6-sol","collaboration_mode":{"mode":"default","settings":{"model":"gpt-5.6-sol","reasoning_effort":null,"developer_instructions":null}}}}
+{"timestamp":"2026-07-25T18:00:00.002Z","type":"response_item","payload":{"type":"message","role":"user","content":[{"type":"input_text","text":"first"}]}}
+{"timestamp":"2026-07-25T18:00:01.000Z","type":"event_msg","payload":{"type":"token_count","info":{"last_token_usage":{"input_tokens":10,"cached_input_tokens":0,"output_tokens":1,"reasoning_output_tokens":0}}}}
+`.trim();
+
+  const actual = normalizeCodexSession({
+    id: "2026/07/25/rollout-null-effort",
+    path: "2026/07/25/rollout-null-effort.jsonl",
+    artifactPath: "2026/07/25/rollout-null-effort.jsonl",
+    updatedAt: 0,
+    size: text.length,
+  }, text);
+
+  strictEqual(actual.turns.length, 1);
+  strictEqual(actual.turns[0].reasoningSetting, undefined);
+  strictEqual(actual.summary.models[0], "gpt-5.6-sol");
 });
 
 Deno.test("infers Codex model-call timing around tool loops", () => {

--- a/src/server/codexRepository.ts
+++ b/src/server/codexRepository.ts
@@ -26,7 +26,7 @@ const contentBlockSchema = z.object({
 // Codex writes an explicit null when a scope leaves reasoning effort unset, so
 // null is read as absent rather than rejected.
 const reasoningEffortSettingsSchema = z.object({
-  reasoning_effort: z.string().nullish(),
+  reasoning_effort: z.string().nullable().optional(),
 }).passthrough();
 
 const collaborationModeSchema = z.object({

--- a/src/server/codexRepository.ts
+++ b/src/server/codexRepository.ts
@@ -23,8 +23,10 @@ const contentBlockSchema = z.object({
   image_url: z.string().optional(),
 }).passthrough();
 
+// Codex writes an explicit null when a scope leaves reasoning effort unset, so
+// null is read as absent rather than rejected.
 const reasoningEffortSettingsSchema = z.object({
-  reasoning_effort: z.string().optional(),
+  reasoning_effort: z.string().nullish(),
 }).passthrough();
 
 const collaborationModeSchema = z.object({
@@ -462,7 +464,7 @@ function codexReasoningSetting(payload: NonNullable<Record["payload"]>) {
   }
   const collaborationEffort =
     payload.collaboration_mode?.settings?.reasoning_effort;
-  if (collaborationEffort !== undefined) {
+  if (collaborationEffort != null) {
     return {
       settingName: "reasoning_effort",
       settingValue: collaborationEffort,
@@ -471,7 +473,7 @@ function codexReasoningSetting(payload: NonNullable<Record["payload"]>) {
     };
   }
   const threadEffort = payload.thread_settings?.reasoning_effort;
-  if (threadEffort !== undefined) {
+  if (threadEffort != null) {
     return {
       settingName: "reasoning_effort",
       settingValue: threadEffort,
@@ -480,7 +482,7 @@ function codexReasoningSetting(payload: NonNullable<Record["payload"]>) {
   }
   const threadCollaborationEffort = payload.thread_settings
     ?.collaboration_mode?.settings?.reasoning_effort;
-  if (threadCollaborationEffort !== undefined) {
+  if (threadCollaborationEffort != null) {
     return {
       settingName: "reasoning_effort",
       settingValue: threadCollaborationEffort,


### PR DESCRIPTION
## Context

Codex writes an explicit `"reasoning_effort": null` when a scope leaves the effort unset, e.g.

```json
{"type":"turn_context","payload":{"model":"gpt-5.6-sol","collaboration_mode":{"mode":"default","settings":{"model":"gpt-5.6-sol","reasoning_effort":null,"developer_instructions":null}}}}
```

`reasoningEffortSettingsSchema` accepted only `z.string().optional()`, so these records fail validation. In the importer the parse is strict, so a single such line fails the entire session:

```
[sync] harness=codex source=.../rollout-....jsonl failed category=import-error ZodError: [
  { "expected": "string", "code": "invalid_type",
    "path": ["payload","collaboration_mode","settings","reasoning_effort"],
    "message": "Invalid input: expected string, received null" } ]
```

On my machine this failed **all 61** local Codex sessions, leaving the OpenAI panels reading "No data". Non-strict reads hit a quieter version of the same bug: the `turn_context` line is silently dropped, losing that record's model and effort.

## Changes

- `reasoning_effort` is now `z.string().nullable().optional()`, matching how `phase`, `content`, `stop_reason`, and `parentId` already declare upstream-nullable fields.
- The three `reasoning_effort` lookups in `codexReasoningSetting` test `!= null` instead of `!== undefined`, so an explicit null is treated as *absent* and falls through to the next candidate field.

Falling through rather than passing null along matters twice: `ReasoningSettingImport.settingValue` is typed `string`, and `reasoning_setting_events.setting_value` is `NOT NULL`. A record can carry `reasoning_effort: null` in one scope and a real value in another, and the real value is still picked up.

`payload.effort` is left alone — it is a separate field and no null was observed for it.

## Tests

Two regression tests in `codexRepository.test.ts`, both failing before the change:

- `imports Codex sessions that report a null reasoning effort` — strict path, reproduces the exact ZodError.
- `ignores null Codex reasoning effort and falls back` — asserts null is skipped and `payload.thread_settings.reasoning_effort` is used instead.

## Verification

- `deno task check` passes.
- `deno test src/`: 107 passed / 4 failed before, 109 passed / 4 failed after — the same 4 failures on an unmodified checkout of this base commit, all in `claudeCodeRepository.test.ts` and `piRepository.test.ts` and unrelated to this change.
- End to end against real local sessions: `[sync] harness=codex discovered=61 imported=61 skipped=0 failed=0` (was 0 imported / 61 failed), and the Performance page OpenAI panel goes from "No data" to 61 sessions / 410 turns. 124 genuine `effort` values are still recorded.

Note: `deno fmt --check` reports `codexRepository.ts` and `codexRepository.test.ts` as unformatted both before and after, so I left the surrounding formatting alone to keep the diff minimal.
