### PR TITLE
Add interactive session details

### DIFF
--- a/src/client/SessionDetailPage.css
+++ b/src/client/SessionDetailPage.css
@@ -1,0 +1,1254 @@
+.session-detail-page {
+  --sd-page: #17181a;
+  --sd-canvas: #1c1d1f;
+  --sd-surface: #232427;
+  --sd-inset: #1f2022;
+  --sd-field: #2b2c2f;
+  --sd-hover: #2a2b2e;
+  --sd-hover-2: #313236;
+  --sd-ink: #f2f3f4;
+  --sd-ink-2: #a5a8ad;
+  --sd-ink-3: #6c6f75;
+  --sd-line: #2e3033;
+  --sd-line-strong: #3a3c40;
+  --sd-accent: #7ec0ff;
+  --sd-accent-tint: #3d9aff29;
+  --sd-green: #3dbb72;
+  --sd-red: #ee5c61;
+  --sd-orange: #f68f3c;
+  isolation: isolate;
+  display: flex;
+  height: 100dvh;
+  max-width: 1280px;
+  flex-direction: column;
+  padding-bottom: 12px;
+  overflow: hidden;
+  color: var(--sd-ink);
+  font-family: Inter, "Avenir Next", "Segoe UI", sans-serif;
+  font-feature-settings: "cv11", "ss01";
+  letter-spacing: -.01em;
+}
+
+.session-detail-page::before {
+  content: "";
+  position: fixed;
+  z-index: -1;
+  inset: 0;
+  background: var(--sd-page);
+}
+
+.sd-detail-nav {
+  display: flex;
+  min-height: 30px;
+  flex: none;
+  align-items: center;
+  margin-bottom: 10px;
+}
+
+.sd-back {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  margin: 0;
+  padding: 5px 7px;
+  border-radius: 7px;
+  color: var(--sd-ink-2);
+  font-size: 12.5px;
+  text-decoration: none;
+  transition: color 120ms ease, background 120ms ease;
+}
+
+.sd-back:hover {
+  background: var(--sd-hover);
+  color: var(--sd-ink);
+}
+
+.sd-shell {
+  display: flex;
+  min-height: 0;
+  flex: 1;
+  flex-direction: column;
+  overflow: hidden;
+  border-radius: 14px;
+  background: var(--sd-canvas);
+  box-shadow: 0 0 0 1px var(--sd-line), 0 18px 60px #0004;
+}
+
+.sd-session-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  padding: 24px 26px 22px;
+  border-bottom: 1px solid var(--sd-line);
+  background: var(--sd-surface);
+  flex: none;
+}
+
+.sd-session-title-row {
+  display: flex;
+  min-width: 0;
+  align-items: flex-start;
+  gap: 13px;
+}
+
+.sd-session-harness {
+  display: grid;
+  width: 38px;
+  height: 38px;
+  flex: none;
+  place-items: center;
+  border-radius: 10px;
+  background: var(--sd-field);
+  box-shadow: 0 0 0 1px var(--sd-line-strong), 0 1px 2px #0000004d;
+}
+
+.sd-harness-mark {
+  width: 19px;
+  height: 19px;
+  object-fit: contain;
+}
+
+.sd-kicker {
+  color: var(--sd-ink-3);
+  font: 11px var(--mono);
+  letter-spacing: .02em;
+}
+
+.sd-session-header h1 {
+  max-width: 780px;
+  margin-top: 5px;
+  color: var(--sd-ink);
+  font-size: clamp(20px, 2.5vw, 28px);
+  line-height: 1.18;
+  letter-spacing: -.035em;
+}
+
+.sd-session-badges {
+  display: flex;
+  flex: none;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  gap: 7px;
+}
+
+.sd-session-badges span,
+.sd-input-chips span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  min-height: 24px;
+  padding: 0 8px;
+  border-radius: 999px;
+  background: var(--sd-field);
+  color: var(--sd-ink-2);
+  box-shadow: 0 0 0 1px var(--sd-line-strong);
+  font-size: 11.5px;
+}
+
+.sd-session-badges span:first-child {
+  background: #3dbb721e;
+  color: #72d89c;
+  box-shadow: 0 0 0 1px #3dbb7240;
+}
+
+.sd-metrics {
+  display: grid;
+  grid-template-columns: repeat(5, minmax(0, 1fr));
+  border-bottom: 1px solid var(--sd-line);
+  background: var(--sd-inset);
+  flex: none;
+}
+
+.sd-metric {
+  min-width: 0;
+  padding: 14px 18px 15px;
+}
+
+.sd-metric + .sd-metric {
+  border-left: 1px solid var(--sd-line);
+}
+
+.sd-metric > span {
+  display: block;
+  color: var(--sd-ink-3);
+  font-size: 10.5px;
+}
+
+.sd-metric strong {
+  display: block;
+  margin-top: 5px;
+  overflow: hidden;
+  color: var(--sd-ink);
+  font: 600 15px/1.2 var(--mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sd-metric small {
+  display: block;
+  margin-top: 3px;
+  overflow: hidden;
+  color: var(--sd-ink-3);
+  font: 10.5px var(--mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sd-layout {
+  display: grid;
+  min-height: 0;
+  flex: 1;
+  grid-template-columns: 34px minmax(0, 1fr) 268px;
+  align-items: start;
+  overflow: visible;
+}
+
+.sd-session-nav {
+  position: relative;
+  z-index: 4;
+  align-self: stretch;
+  height: 100%;
+  min-height: 100%;
+  overflow: visible;
+  border-right: 1px solid var(--sd-line);
+}
+
+.sd-session-nav > .sd-session-nav-scroll {
+  position: absolute;
+  z-index: 2;
+  inset: 0;
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 6px;
+  padding: 16px 0 16px 9px;
+  overflow-x: hidden;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-width: none;
+}
+
+.sd-session-nav-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+.sd-session-nav button {
+  width: 7px;
+  height: 2px;
+  flex: none;
+  min-height: 1px;
+  padding: 0;
+  border: 0;
+  border-radius: 2px;
+  cursor: pointer;
+  opacity: .72;
+  transition: width 160ms cubic-bezier(.23, 1, .32, 1), opacity 120ms ease,
+    box-shadow 120ms ease;
+}
+
+.sd-session-nav button.is-depth-0 {
+  width: 13px;
+  height: 3px;
+  min-height: 2px;
+}
+
+.sd-session-nav button.is-depth-1 {
+  margin-left: 6px;
+}
+
+.sd-session-nav button.is-depth-0:hover,
+.sd-session-nav button.is-depth-0:focus-visible,
+.sd-session-nav button.is-depth-0.is-active {
+  width: 20px;
+  opacity: 1;
+  box-shadow: 0 0 0 1px #ffffff1f;
+}
+
+.sd-session-nav button.is-depth-1:hover,
+.sd-session-nav button.is-depth-1:focus-visible,
+.sd-session-nav button.is-depth-1.is-active {
+  width: 13px;
+  opacity: 1;
+  box-shadow: 0 0 0 1px #ffffff1f;
+}
+
+.sd-session-nav button:focus-visible {
+  outline: 2px solid var(--sd-accent);
+  outline-offset: 3px;
+}
+
+.sd-crumb-popover {
+  position: absolute;
+  z-index: 10;
+  left: calc(100% + 9px);
+  display: grid;
+  width: 238px;
+  grid-template-columns: 3px minmax(0, 1fr);
+  gap: 10px;
+  padding: 10px;
+  border-radius: 9px;
+  background: var(--sd-surface);
+  box-shadow: 0 0 0 1px var(--sd-line-strong), 0 8px 24px #0008;
+  pointer-events: none;
+  animation: sd-crumb-pop 140ms cubic-bezier(.23, 1, .32, 1) both;
+}
+
+.sd-crumb-popover > span {
+  width: 3px;
+  min-height: 100%;
+  border-radius: 3px;
+}
+
+.sd-crumb-popover strong {
+  display: block;
+  color: var(--sd-ink);
+  font-size: 11.5px;
+}
+
+.sd-crumb-popover p {
+  display: -webkit-box;
+  margin: 4px 0 5px;
+  overflow: hidden;
+  color: var(--sd-ink-2);
+  font-size: 11px;
+  line-height: 1.4;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 2;
+}
+
+.sd-crumb-popover small {
+  color: var(--sd-ink-3);
+  font: 9.5px var(--mono);
+}
+
+@keyframes sd-crumb-pop {
+  from {
+    opacity: 0;
+    transform: translateX(-4px) scale(.98);
+  }
+  to {
+    opacity: 1;
+    transform: translateX(0) scale(1);
+  }
+}
+
+.sd-transcript {
+  min-width: 0;
+  height: 100%;
+  padding: 10px 28px 54px 22px;
+  overflow-y: auto;
+  overscroll-behavior: contain;
+  scrollbar-color: var(--sd-line-strong) transparent;
+  scrollbar-width: thin;
+}
+
+.sd-transcript.is-nested {
+  height: auto;
+  padding: 8px 0 4px;
+  overflow: visible;
+}
+
+.sd-turn {
+  scroll-margin-top: 20px;
+  padding: 24px 0 28px;
+}
+
+.sd-turn + .sd-turn {
+  border-top: 1px dashed var(--sd-line-strong);
+}
+
+.sd-turn.is-collapsed {
+  padding-bottom: 16px;
+}
+
+.sd-user-message {
+  display: grid;
+  grid-template-columns: 27px minmax(0, 1fr);
+  gap: 10px;
+  margin: 0 -12px;
+  padding: 12px 14px 13px 12px;
+  border-left: 2px solid var(--sd-turn-color, #3d9aff70);
+  border-radius: 9px;
+  background: linear-gradient(
+    100deg,
+    color-mix(in srgb, var(--sd-turn-color, #3d9aff) 16%, transparent),
+    transparent 58%
+  ), var(--sd-inset);
+  box-shadow: inset 0 0 0 1px var(--sd-line);
+}
+
+.sd-user-avatar,
+.sd-agent-avatar {
+  display: grid;
+  width: 24px;
+  height: 24px;
+  place-items: center;
+  border-radius: 7px;
+  background: var(--sd-field);
+  color: var(--sd-ink-2);
+  box-shadow: 0 0 0 1px var(--sd-line-strong);
+}
+
+.sd-user-avatar {
+  background: color-mix(
+    in srgb,
+    var(--sd-turn-color, var(--sd-accent)) 18%,
+    transparent
+  );
+  color: var(--sd-turn-color, var(--sd-accent));
+  box-shadow: 0 0 0 1px
+    color-mix(in srgb, var(--sd-turn-color, #3d9aff) 55%, transparent);
+}
+
+.sd-user-message > div {
+  min-width: 0;
+  padding: 1px 0 0;
+}
+
+.sd-user-message header {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  margin-bottom: 8px;
+}
+
+.sd-user-message header strong {
+  color: var(--sd-ink);
+  font-size: 13px;
+}
+
+.sd-user-message header span:first-of-type {
+  color: var(--sd-turn-color, var(--sd-accent));
+}
+
+.sd-user-message header span,
+.sd-user-message header time {
+  color: var(--sd-ink-3);
+  font: 10.5px var(--mono);
+}
+
+.sd-user-message header time {
+  margin-left: auto;
+}
+
+.sd-turn-toggle {
+  display: grid;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  place-items: center;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--sd-ink-3);
+  cursor: pointer;
+  transition: color 100ms ease, background 100ms ease;
+}
+
+.sd-turn-toggle:hover,
+.sd-turn-toggle:focus-visible {
+  background: var(--sd-hover-2);
+  color: var(--sd-ink);
+}
+
+.sd-turn-toggle svg {
+  transition: transform 220ms cubic-bezier(.23, 1, .32, 1);
+}
+
+.sd-turn.is-collapsed .sd-turn-toggle svg {
+  transform: rotate(-90deg);
+}
+
+.sd-turn-collapsed-preview {
+  margin: 0;
+  overflow: hidden;
+  color: var(--sd-ink-2);
+  font-size: 12.5px;
+  line-height: 1.5;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sd-turn-detail-grid {
+  display: grid;
+  grid-template-rows: 1fr;
+  opacity: 1;
+  transition: grid-template-rows 300ms cubic-bezier(.23, 1, .32, 1), opacity
+    180ms ease;
+}
+
+.sd-turn-detail-grid > div {
+  overflow: hidden;
+}
+
+.sd-turn.is-collapsed .sd-turn-detail-grid {
+  grid-template-rows: 0fr;
+  opacity: 0;
+}
+
+.sd-expandable-text > div {
+  display: -webkit-box;
+  overflow: hidden;
+  color: var(--sd-ink);
+  font-size: 13px;
+  line-height: 1.625;
+  overflow-wrap: anywhere;
+  white-space: pre-wrap;
+  -webkit-box-orient: vertical;
+  -webkit-line-clamp: 7;
+}
+
+.sd-expandable-text > div.is-expanded {
+  display: block;
+  -webkit-line-clamp: unset;
+}
+
+.sd-expandable-text.is-mono > div {
+  color: #c9ccd1;
+  font: 11.5px/1.65 var(--mono);
+}
+
+.sd-text-actions {
+  display: flex;
+  align-items: center;
+  gap: 9px;
+  margin-top: 7px;
+}
+
+.sd-text-actions:empty {
+  display: none;
+}
+
+.sd-text-actions button {
+  padding: 2px 0;
+  border: 0;
+  background: transparent;
+  color: var(--sd-accent);
+  cursor: pointer;
+  font-size: 11.5px;
+}
+
+.sd-text-actions button:hover {
+  text-decoration: underline;
+}
+
+.sd-text-actions small {
+  color: var(--sd-ink-3);
+  font: 10.5px var(--mono);
+}
+
+.sd-input-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin-top: 11px;
+}
+
+.sd-non-text-input {
+  margin: 0;
+  color: var(--sd-ink-3);
+  font-size: 13px;
+}
+
+.sd-agent-sequence {
+  position: relative;
+  margin: 19px 0 0 12px;
+  padding-left: 25px;
+}
+
+.sd-agent-sequence::before {
+  content: "";
+  position: absolute;
+  top: -5px;
+  bottom: 5px;
+  left: 0;
+  width: 1px;
+  background: var(--sd-line-strong);
+}
+
+.sd-call {
+  position: relative;
+  scroll-margin-top: 20px;
+  padding-bottom: 24px;
+}
+
+.sd-call:last-child {
+  padding-bottom: 0;
+}
+
+.sd-call-heading {
+  display: flex;
+  min-height: 26px;
+  align-items: center;
+  gap: 8px;
+  color: var(--sd-ink-3);
+  font: 10.5px var(--mono);
+}
+
+.sd-call-heading .sd-agent-avatar {
+  position: absolute;
+  left: -37px;
+  background: var(--sd-surface);
+  color: var(--sd-accent);
+}
+
+.sd-call-heading strong {
+  color: var(--sd-ink-2);
+  font: 600 12.5px Inter, "Avenir Next", sans-serif;
+}
+
+.sd-call-heading b {
+  padding: 3px 6px;
+  border-radius: 5px;
+  background: #f68f3c1c;
+  color: #f3a86a;
+  font-size: 10px;
+  font-weight: 500;
+}
+
+.sd-call-effort {
+  padding: 3px 6px;
+  border-radius: 5px;
+  background: var(--sd-field);
+  color: var(--sd-ink-2);
+  box-shadow: 0 0 0 1px var(--sd-line-strong);
+  font-size: 10px;
+  font-style: normal;
+  font-weight: 500;
+}
+
+.sd-call-body {
+  margin-top: 5px;
+}
+
+.sd-context-events {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  margin: 8px 0;
+}
+
+.sd-context-events > span {
+  display: inline-flex;
+  align-items: center;
+  gap: 5px;
+  padding: 4px 7px;
+  border-radius: 6px;
+  background: #f68f3c1c;
+  color: #f3a86a;
+  font-size: 11px;
+}
+
+.sd-context-events small {
+  color: var(--sd-ink-3);
+  font: 10px var(--mono);
+}
+
+.sd-disclosure > button {
+  display: flex;
+  width: fit-content;
+  max-width: 100%;
+  align-items: center;
+  gap: 7px;
+  margin-left: -6px;
+  padding: 5px 6px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--sd-ink-2);
+  cursor: pointer;
+  text-align: left;
+  transition: color 100ms ease, background 100ms ease;
+}
+
+.sd-disclosure > button:hover {
+  background: var(--sd-hover-2);
+  color: var(--sd-ink);
+}
+
+.sd-disclosure-label {
+  overflow: hidden;
+  font-size: 12.5px;
+  font-weight: 500;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sd-disclosure-meta {
+  color: var(--sd-ink-3);
+  font: 10.5px var(--mono);
+  white-space: nowrap;
+}
+
+.sd-disclosure-chevron {
+  flex: none;
+  color: var(--sd-ink-3);
+  transition: transform 300ms cubic-bezier(.23, 1, .32, 1);
+}
+
+.sd-disclosure.is-open > button .sd-disclosure-chevron {
+  transform: rotate(180deg);
+}
+
+.sd-disclosure-grid,
+.sd-tool-detail-grid {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition: grid-template-rows 300ms cubic-bezier(.23, 1, .32, 1), opacity
+    220ms ease;
+}
+
+.sd-disclosure.is-open > .sd-disclosure-grid,
+.sd-tool-event.is-open > .sd-tool-detail-grid {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+.sd-disclosure-grid > div,
+.sd-tool-detail-grid > div {
+  overflow: hidden;
+}
+
+.sd-disclosure-content {
+  padding: 2px 0 4px 17px;
+  border-left: 1px solid var(--sd-line-strong);
+}
+
+.sd-thinking {
+  margin: 5px 0 4px;
+}
+
+.sd-thinking > button svg:first-child {
+  color: var(--sd-ink-2);
+}
+
+.sd-thinking-trace {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 4px 0 7px 4px;
+}
+
+.sd-thinking-trace span {
+  display: flex;
+  min-height: 28px;
+  align-items: center;
+  gap: 8px;
+  color: var(--sd-ink-2);
+  font-size: 12px;
+}
+
+.sd-thinking-trace small {
+  padding: 4px 0;
+  color: var(--sd-ink-3);
+  font-size: 11px;
+}
+
+.sd-tool-group {
+  margin-top: 3px;
+}
+
+.sd-tool-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 3px 0 5px;
+}
+
+.sd-tool-event > button {
+  display: grid;
+  width: 100%;
+  min-height: 30px;
+  grid-template-columns: 18px minmax(80px, auto) minmax(0, 1fr) auto 14px;
+  align-items: center;
+  gap: 7px;
+  padding: 3px 6px;
+  border: 0;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--sd-ink-2);
+  cursor: pointer;
+  text-align: left;
+  transition: background 100ms ease;
+}
+
+.sd-tool-event > button:hover:not(:disabled),
+.sd-tool-event.is-open > button {
+  background: var(--sd-hover-2);
+}
+
+.sd-tool-event > button:disabled {
+  cursor: default;
+}
+
+.sd-tool-status {
+  display: grid;
+  width: 17px;
+  height: 17px;
+  place-items: center;
+  border-radius: 50%;
+  background: #3dbb7226;
+  color: #65cf90;
+}
+
+.sd-tool-status.is-failed {
+  background: #ee5c6122;
+  color: #f37b80;
+}
+
+.sd-tool-event strong {
+  color: var(--sd-ink);
+  font-size: 12.5px;
+  font-weight: 500;
+}
+
+.sd-tool-event code {
+  min-width: 0;
+  overflow: hidden;
+  padding: 3px 6px;
+  border-radius: 6px;
+  background: var(--sd-field);
+  color: var(--sd-ink-2);
+  box-shadow: 0 0 0 1px var(--sd-line-strong);
+  font: 11px var(--mono);
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sd-tool-event > button small {
+  color: var(--sd-ink-3);
+  font: 10.5px var(--mono);
+}
+
+.sd-tool-event > button > svg:last-child {
+  color: var(--sd-ink-3);
+  transition: transform 200ms ease;
+}
+
+.sd-tool-event.is-open > button > svg:last-child {
+  transform: rotate(180deg);
+}
+
+.sd-tool-detail {
+  margin: 3px 4px 8px 14px;
+  padding: 8px 10px 9px 13px;
+  border-left: 1px solid var(--sd-line-strong);
+  border-radius: 0 8px 8px 0;
+  background: var(--sd-inset);
+}
+
+.sd-tool-detail section + section {
+  margin-top: 10px;
+  padding-top: 10px;
+  border-top: 1px solid var(--sd-line);
+}
+
+.sd-tool-detail section > span {
+  display: block;
+  margin-bottom: 4px;
+  color: var(--sd-ink-3);
+  font: 10px var(--mono);
+  text-transform: uppercase;
+}
+
+.sd-assistant-copy {
+  margin-top: 8px;
+  padding: 12px 14px;
+  border-radius: 10px;
+  background: var(--sd-surface);
+  box-shadow: 0 0 0 1px var(--sd-line), 0 1px 2px #0003;
+}
+
+.sd-call-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 14px;
+  margin-top: 8px;
+  color: var(--sd-ink-3);
+  font: 10.5px var(--mono);
+}
+
+.sd-subagent-disclosure {
+  margin-top: 10px;
+  padding: 2px 7px 4px;
+  border-radius: 10px;
+  background: var(--sd-surface);
+  box-shadow: 0 0 0 1px var(--sd-line);
+}
+
+.sd-subagent-disclosure > button {
+  width: 100%;
+  margin-left: 0;
+}
+
+.sd-subagent-disclosure > button .sd-disclosure-chevron {
+  margin-left: auto;
+}
+
+.sd-subagent-disclosure > .sd-disclosure-grid .sd-disclosure-content {
+  margin: 0 5px 4px;
+  padding: 6px 10px 4px 13px;
+}
+
+.sd-subagent-heading {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 4px 0 8px;
+  border-bottom: 1px solid var(--sd-line);
+}
+
+.sd-subagent-heading strong {
+  font-size: 12.5px;
+}
+
+.sd-subagent-heading span {
+  color: var(--sd-ink-3);
+  font: 10.5px var(--mono);
+}
+
+.sd-metadata {
+  height: 100%;
+  min-width: 0;
+  overflow-y: auto;
+  border-left: 1px solid var(--sd-line);
+  overscroll-behavior: contain;
+  scrollbar-color: var(--sd-line-strong) transparent;
+  scrollbar-width: thin;
+}
+
+.sd-metadata section {
+  padding: 18px;
+}
+
+.sd-metadata section + section {
+  border-top: 1px solid var(--sd-line);
+}
+
+.sd-metadata h2 {
+  margin: 0 0 12px;
+  color: var(--sd-ink-3);
+  font-size: 10.5px;
+  font-weight: 500;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+}
+
+.sd-metadata-row {
+  display: grid;
+  grid-template-columns: 82px minmax(0, 1fr);
+  gap: 10px;
+  padding: 5px 0;
+  font-size: 11.5px;
+}
+
+.sd-metadata-row > span {
+  color: var(--sd-ink-3);
+}
+
+.sd-metadata-row strong {
+  min-width: 0;
+  overflow: hidden;
+  color: var(--sd-ink-2);
+  font-weight: 500;
+  overflow-wrap: anywhere;
+}
+
+.sd-metadata-row strong.is-mono {
+  font: 10.5px/1.5 var(--mono);
+}
+
+.sd-model-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.sd-model-list span {
+  padding: 4px 7px;
+  border-radius: 6px;
+  background: var(--sd-field);
+  color: var(--sd-ink-2);
+  box-shadow: 0 0 0 1px var(--sd-line-strong);
+  font: 10.5px var(--mono);
+}
+
+.sd-setting {
+  display: grid;
+  gap: 6px;
+}
+
+.sd-setting + .sd-setting {
+  margin-top: 12px;
+}
+
+.sd-setting > span:first-child,
+.sd-cost-scenario-result > span {
+  color: var(--sd-ink-3);
+  font-size: 10.5px;
+}
+
+.sd-setting select {
+  width: 100%;
+  min-width: 0;
+  height: 30px;
+  padding: 0 28px 0 8px;
+  border: 0;
+  border-radius: 7px;
+  background: var(--sd-field);
+  color: var(--sd-ink-2);
+  box-shadow: 0 0 0 1px var(--sd-line-strong), 0 1px 2px #0000004d;
+  font: 11px var(--mono);
+}
+
+.sd-setting-segmented {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  padding: 2px;
+  border-radius: 8px;
+  background: var(--sd-field);
+  box-shadow: 0 0 0 1px var(--sd-line-strong);
+}
+
+.sd-setting-segmented button {
+  height: 26px;
+  padding: 0 7px;
+  border: 0;
+  border-radius: 6px;
+  background: transparent;
+  color: var(--sd-ink-3);
+  cursor: pointer;
+  font-size: 11px;
+}
+
+.sd-setting-segmented button:hover {
+  color: var(--sd-ink-2);
+}
+
+.sd-setting-segmented button.is-active {
+  background: var(--sd-surface);
+  color: var(--sd-ink);
+  box-shadow: 0 0 0 1px var(--sd-line-strong), 0 1px 2px #0005;
+}
+
+.sd-cost-scenario-result {
+  display: grid;
+  gap: 3px;
+  margin-top: 14px;
+  padding: 10px;
+  border-radius: 8px;
+  background: var(--sd-inset);
+  box-shadow: 0 0 0 1px var(--sd-line);
+}
+
+.sd-cost-scenario-result strong {
+  color: var(--sd-ink);
+  font: 600 15px var(--mono);
+}
+
+.sd-cost-scenario-result small {
+  color: var(--sd-ink-3);
+  font: 10px/1.45 var(--mono);
+}
+
+.sd-cost-scenario-result small.is-higher {
+  color: #f3a86a;
+}
+
+.sd-cost-scenario-result small.is-lower {
+  color: #72d89c;
+}
+
+.sd-scenario-note {
+  margin: 9px 0 0;
+  color: var(--sd-ink-3);
+  font-size: 10.5px;
+  line-height: 1.45;
+}
+
+.sd-loading,
+.sd-error {
+  display: flex;
+  min-height: 420px;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  color: var(--sd-ink-2);
+  font-size: 13px;
+}
+
+.sd-error {
+  color: #f37b80;
+}
+
+.sd-pixel-loader {
+  display: grid;
+  grid-template-columns: repeat(3, 4px);
+  gap: 2px;
+}
+
+.sd-pixel-loader i {
+  width: 4px;
+  height: 4px;
+  border-radius: 1px;
+  background: var(--sd-accent);
+  opacity: .15;
+  animation: sd-pixel-on 650ms ease-in-out infinite;
+}
+
+.sd-pixel-loader i:nth-child(2n) {
+  animation-delay: 90ms;
+}
+.sd-pixel-loader i:nth-child(3n) {
+  animation-delay: 180ms;
+}
+
+@keyframes sd-pixel-on {
+  0%,
+  100% {
+    opacity: .15;
+  }
+  50% {
+    opacity: 1;
+  }
+}
+
+@media (max-width: 900px) {
+  .session-detail-page {
+    height: auto;
+    min-height: 100dvh;
+    padding-bottom: 40px;
+    overflow: visible;
+  }
+
+  .sd-shell {
+    height: auto;
+    min-height: 0;
+    flex: none;
+    overflow: visible;
+  }
+
+  .sd-layout {
+    grid-template-columns: 1fr;
+    overflow: visible;
+  }
+
+  .sd-session-nav {
+    display: none;
+  }
+
+  .sd-transcript {
+    height: auto;
+    overflow: visible;
+  }
+
+  .sd-metadata {
+    position: static;
+    display: grid;
+    height: auto;
+    grid-column: 1 / -1;
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    border-top: 1px solid var(--sd-line);
+    border-left: 0;
+    overflow: visible;
+  }
+
+  .sd-metadata section {
+    border-top: 1px solid var(--sd-line);
+  }
+
+  .sd-metadata section + section {
+    border-left: 0;
+  }
+
+  .sd-metadata section:nth-child(even) {
+    border-left: 1px solid var(--sd-line);
+  }
+
+  .sd-metadata section:nth-child(-n + 2) {
+    border-top: 0;
+  }
+}
+
+@media (max-width: 680px) {
+  .sd-session-header {
+    flex-direction: column;
+    padding: 20px;
+  }
+
+  .sd-session-badges {
+    justify-content: flex-start;
+  }
+
+  .sd-metrics {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+  }
+
+  .sd-metric + .sd-metric {
+    border-left: 0;
+  }
+
+  .sd-metric:nth-child(even) {
+    border-left: 1px solid var(--sd-line);
+  }
+
+  .sd-metric:nth-child(n + 3) {
+    border-top: 1px solid var(--sd-line);
+  }
+
+  .sd-transcript {
+    padding: 6px 16px 38px;
+  }
+
+  .sd-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .sd-session-nav {
+    display: none;
+  }
+
+  .sd-agent-sequence {
+    margin-left: 9px;
+    padding-left: 20px;
+  }
+
+  .sd-call-heading .sd-agent-avatar {
+    left: -32px;
+  }
+
+  .sd-call-heading {
+    flex-wrap: wrap;
+  }
+
+  .sd-tool-event > button {
+    grid-template-columns: 18px minmax(70px, auto) minmax(0, 1fr) 14px;
+  }
+
+  .sd-tool-event > button small {
+    display: none;
+  }
+
+  .sd-metadata {
+    grid-column: auto;
+    display: block;
+  }
+
+  .sd-metadata section + section {
+    border-top: 1px solid var(--sd-line);
+    border-left: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .session-detail-page *,
+  .session-detail-page *::before,
+  .session-detail-page *::after {
+    scroll-behavior: auto !important;
+    animation-duration: .01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: .01ms !important;
+  }
+}

--- a/src/client/SessionDetailPage.tsx
+++ b/src/client/SessionDetailPage.tsx
@@ -1,0 +1,1590 @@
+import {
+  createContext,
+  type CSSProperties,
+  type ReactNode,
+  useContext,
+  useEffect,
+  useRef,
+  useState,
+} from "react";
+import { getRouteApi } from "@tanstack/react-router";
+import {
+  ArrowLeft,
+  Bot,
+  Brain,
+  Check,
+  ChevronDown,
+  CircleAlert,
+  FileText,
+  Image,
+  Sparkles,
+  TerminalSquare,
+  User,
+  Wrench,
+  X,
+} from "lucide-react";
+import type {
+  ModelCall,
+  SessionDetail,
+  TokenUsage,
+} from "../shared/sessionSchemas.ts";
+import { contextSize } from "../shared/contextMetrics.ts";
+import { canonicalModelId, displayModelName } from "../shared/modelNames.ts";
+import { rollupCosts } from "../shared/costMetrics.ts";
+import {
+  computeModelCallCost,
+  counterfactualModelIDs,
+} from "../shared/modelPricing.ts";
+import { getSession } from "./api.ts";
+import claudeCodeIcon from "./assets/icons/claudecode-color.svg";
+import codexIcon from "./assets/icons/codex-logo-light.svg";
+import openCodeIcon from "./assets/icons/opencode-logo-light.svg";
+import piIcon from "./assets/icons/pi-logo.svg";
+import "./SessionDetailPage.css";
+
+const route = getRouteApi("/sessions/$harness/$sessionId");
+
+type PathMode = "absolute" | "relative";
+type ColorMetric = "none" | "time" | "cost" | "input" | "output";
+type CostScenario = "recorded" | string;
+
+const TurnCollapseContext = createContext<{
+  collapsedTurnIDs: Set<string>;
+  turnColors: Map<string, string>;
+  toggleTurn: (id: string) => void;
+}>({
+  collapsedTurnIDs: new Set(),
+  turnColors: new Map(),
+  toggleTurn: () => {},
+});
+
+const compact = new Intl.NumberFormat("en-US", {
+  notation: "compact",
+  maximumFractionDigits: 1,
+});
+const integer = new Intl.NumberFormat("en-US");
+const money = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 4,
+});
+const timestamp = new Intl.DateTimeFormat(undefined, {
+  month: "short",
+  day: "numeric",
+  hour: "numeric",
+  minute: "2-digit",
+});
+const fullTimestamp = new Intl.DateTimeFormat(undefined, {
+  dateStyle: "medium",
+  timeStyle: "medium",
+});
+
+function elapsed(startedAt?: number, completedAt?: number) {
+  if (startedAt === undefined || completedAt === undefined) return undefined;
+  const milliseconds = completedAt - startedAt;
+  if (milliseconds <= 0) return undefined;
+  if (milliseconds < 1_000) return `${milliseconds}ms`;
+  const seconds = Math.round(milliseconds / 1_000);
+  if (seconds < 60) return `${seconds}s`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ${seconds % 60}s`;
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}m`;
+}
+
+function harnessName(harness: SessionDetail["harness"]) {
+  if (harness === "claude-code") return "Claude Code";
+  if (harness === "codex") return "Codex";
+  if (harness === "pi") return "PI";
+  return "OpenCode";
+}
+
+function HarnessMark({ harness }: { harness: SessionDetail["harness"] }) {
+  const src = harness === "claude-code"
+    ? claudeCodeIcon
+    : harness === "codex"
+    ? codexIcon
+    : harness === "pi"
+    ? piIcon
+    : openCodeIcon;
+  return <img className="sd-harness-mark" src={src} alt="" />;
+}
+
+function sessionTree(session: SessionDetail): SessionDetail[] {
+  return [session, ...session.subagents.flatMap(sessionTree)];
+}
+
+function callsInTree(session: SessionDetail) {
+  return sessionTree(session).flatMap((item) =>
+    item.turns.flatMap((turn) => turn.calls)
+  );
+}
+
+function sessionBounds(session: SessionDetail) {
+  const tree = sessionTree(session);
+  const starts = tree.flatMap((item) => [
+    ...(item.startedAt === undefined ? [] : [item.startedAt]),
+    ...item.turns.map((turn) => turn.startedAt),
+  ]);
+  const ends = tree.flatMap((item) => [
+    ...(item.endedAt === undefined ? [] : [item.endedAt]),
+    ...item.turns.flatMap((turn) =>
+      turn.calls.map((call) => call.completedAt ?? call.startedAt)
+    ),
+  ]);
+  return {
+    start: starts.length === 0 ? undefined : Math.min(...starts),
+    end: ends.length === 0 ? undefined : Math.max(...ends),
+  };
+}
+
+function inclusiveTokens(session: SessionDetail): TokenUsage {
+  if (session.inclusiveTokens) return session.inclusiveTokens;
+  const tree = sessionTree(session);
+  return {
+    uncachedInput: tree.reduce(
+      (sum, item) => sum + item.tokens.uncachedInput,
+      0,
+    ),
+    cacheRead: tree.reduce((sum, item) => sum + item.tokens.cacheRead, 0),
+    cacheWrite: tree.reduce(
+      (sum, item) => sum + (item.tokens.cacheWrite ?? 0),
+      0,
+    ),
+    cacheWrite5m: tree.reduce(
+      (sum, item) => sum + (item.tokens.cacheWrite5m ?? 0),
+      0,
+    ),
+    cacheWrite1h: tree.reduce(
+      (sum, item) => sum + (item.tokens.cacheWrite1h ?? 0),
+      0,
+    ),
+    freshPrompt: tree.reduce((sum, item) => sum + item.tokens.freshPrompt, 0),
+    output: tree.reduce((sum, item) => sum + item.tokens.output, 0),
+    reasoning: tree.reduce((sum, item) => sum + item.tokens.reasoning, 0),
+    processed: tree.reduce((sum, item) => sum + item.tokens.processed, 0),
+  };
+}
+
+function relativePathText(
+  value: string,
+  rootDirectory: string | undefined,
+  pathMode: PathMode,
+) {
+  if (pathMode === "absolute" || !rootDirectory) return value;
+  const root = rootDirectory.replace(/\/+$/, "");
+  const candidates = new Set([root]);
+  if (root.startsWith("~/")) {
+    const suffix = root.slice(2);
+    let offset = 0;
+    while (offset < value.length) {
+      const index = value.indexOf(suffix, offset);
+      if (index < 0) break;
+      let start = index;
+      while (
+        start > 0 && !['"', "'", " ", "\n", "\t"].includes(value[start - 1])
+      ) start--;
+      const candidate = value.slice(start, index + suffix.length);
+      if (candidate.includes("/")) candidates.add(candidate);
+      offset = index + suffix.length;
+    }
+  }
+  let result = value;
+  for (const candidate of [...candidates].sort((a, b) => b.length - a.length)) {
+    result = result.replaceAll(`${candidate}/`, "").replaceAll(candidate, ".");
+  }
+  return result;
+}
+
+function scenarioTokens(
+  tokens: TokenUsage,
+  targetModel: string,
+  thinking: string,
+  sourceProvider: string,
+): TokenUsage {
+  const reasoning = thinking === "off" ? 0 : tokens.reasoning;
+  if (
+    canonicalModelId(targetModel).startsWith("claude-") ||
+    !sourceProvider.toLowerCase().includes("anthropic") ||
+    tokens.cacheWrite === undefined
+  ) return { ...tokens, reasoning };
+  const cacheWrite = tokens.cacheWrite;
+  return {
+    uncachedInput: tokens.uncachedInput + cacheWrite,
+    cacheRead: tokens.cacheRead,
+    freshPrompt: tokens.freshPrompt,
+    output: tokens.output,
+    reasoning,
+    processed: tokens.processed,
+  };
+}
+
+function scenarioCallCost(
+  call: ModelCall,
+  model: CostScenario,
+  thinking: string,
+) {
+  const targetModel = model === "recorded" ? call.model : model;
+  return computeModelCallCost(
+    scenarioTokens(call.tokens, targetModel, thinking, call.provider),
+    targetModel,
+    call.startedAt,
+  );
+}
+
+function scenarioCost(
+  calls: ModelCall[],
+  model: CostScenario,
+  thinking: string,
+) {
+  return rollupCosts(
+    calls.map((call) => scenarioCallCost(call, model, thinking)),
+  );
+}
+
+function turnAnchor(sessionID: string, turn: number) {
+  return `turn-${encodeURIComponent(sessionID)}-${turn}`;
+}
+
+function callAnchor(sessionID: string, turn: number, callID: string) {
+  return `${turnAnchor(sessionID, turn)}-call-${encodeURIComponent(callID)}`;
+}
+
+function DetailMetric({ label, value, detail }: {
+  label: string;
+  value: string;
+  detail?: string;
+}) {
+  return (
+    <div className="sd-metric">
+      <span>{label}</span>
+      <strong>{value}</strong>
+      {detail && <small>{detail}</small>}
+    </div>
+  );
+}
+
+function ExpandableText({
+  text,
+  truncated = false,
+  mono = false,
+  threshold = 420,
+}: {
+  text: string;
+  truncated?: boolean;
+  mono?: boolean;
+  threshold?: number;
+}) {
+  const [expanded, setExpanded] = useState(false);
+  const canExpand = text.length > threshold;
+  return (
+    <div className={`sd-expandable-text${mono ? " is-mono" : ""}`}>
+      <div className={expanded ? "is-expanded" : undefined}>{text}</div>
+      <span className="sd-text-actions">
+        {canExpand && (
+          <button
+            type="button"
+            aria-expanded={expanded}
+            onClick={() => setExpanded((current) => !current)}
+          >
+            {expanded ? "Show less" : "Show more"}
+          </button>
+        )}
+        {truncated && <small>Archive preview truncated</small>}
+      </span>
+    </div>
+  );
+}
+
+function Disclosure({
+  open,
+  onToggle,
+  icon,
+  label,
+  meta,
+  children,
+  className = "",
+}: {
+  open: boolean;
+  onToggle: () => void;
+  icon: ReactNode;
+  label: ReactNode;
+  meta?: ReactNode;
+  children: ReactNode;
+  className?: string;
+}) {
+  return (
+    <div className={`sd-disclosure ${className}${open ? " is-open" : ""}`}>
+      <button type="button" aria-expanded={open} onClick={onToggle}>
+        {icon}
+        <span className="sd-disclosure-label">{label}</span>
+        {meta && <span className="sd-disclosure-meta">{meta}</span>}
+        <ChevronDown className="sd-disclosure-chevron" size={14} />
+      </button>
+      <div className="sd-disclosure-grid">
+        <div>
+          <div className="sd-disclosure-content">{children}</div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+type BreadcrumbEntry = {
+  id: string;
+  label: string;
+  description: string;
+  depth: 0 | 1;
+  value: number;
+  formattedValue: string;
+};
+
+function breadcrumbDescription(value: string | undefined, fallback: string) {
+  if (!value) return fallback;
+  const normalized = value.replaceAll(/\s+/g, " ").trim();
+  return normalized.length <= 96 ? normalized : `${normalized.slice(0, 95)}…`;
+}
+
+function breadcrumbMetricLabel(metric: ColorMetric) {
+  if (metric === "cost") return "Cost";
+  if (metric === "input") return "Input processed";
+  if (metric === "output") return "Output";
+  return "Time spent";
+}
+
+function breadcrumbMetric(
+  calls: ModelCall[],
+  duration: number,
+  metric: ColorMetric,
+  model: CostScenario,
+  thinking: string,
+) {
+  const cost = scenarioCost(calls, model, thinking).cost ?? 0;
+  const input = calls.reduce((sum, call) => sum + call.tokens.processed, 0);
+  const output = calls.reduce(
+    (sum, call) => sum + call.tokens.output + call.tokens.reasoning,
+    0,
+  );
+  const value = metric === "cost"
+    ? cost
+    : metric === "input"
+    ? input
+    : metric === "output"
+    ? output
+    : duration;
+  const formattedValue = metric === "cost"
+    ? money.format(cost)
+    : metric === "input" || metric === "output"
+    ? `${compact.format(value)} tokens`
+    : elapsed(0, duration) ?? "Unavailable";
+  return { value, formattedValue };
+}
+
+function breadcrumbEntries(
+  session: SessionDetail,
+  metric: ColorMetric,
+  model: CostScenario,
+  thinking: string,
+  collapsedTurnIDs: Set<string>,
+): BreadcrumbEntry[] {
+  return session.turns.flatMap((turn) => {
+    const childIDs = new Set(
+      turn.calls.flatMap((call) =>
+        call.activity.tools.flatMap((tool) =>
+          tool.childSessionID ? [tool.childSessionID] : []
+        )
+      ),
+    );
+    const children = session.subagents.filter((child) =>
+      childIDs.has(child.id)
+    );
+    const calls = [...turn.calls, ...children.flatMap(callsInTree)];
+    const end = calls.reduce(
+      (latest, call) => Math.max(latest, call.completedAt ?? call.startedAt),
+      turn.startedAt,
+    );
+    const duration = Math.max(0, end - turn.startedAt);
+    const turnMetric = breadcrumbMetric(
+      calls,
+      duration,
+      metric,
+      model,
+      thinking,
+    );
+    const id = turnAnchor(session.id, turn.number);
+    const turnEntry = {
+      id,
+      label: `Turn ${turn.number}`,
+      description: breadcrumbDescription(
+        (turn.inputs ?? []).find((input) => input.kind === "text")?.preview,
+        `${turn.calls.length} direct model call${
+          turn.calls.length === 1 ? "" : "s"
+        }`,
+      ),
+      depth: 0 as const,
+      ...turnMetric,
+    };
+    if (collapsedTurnIDs.has(id)) return [turnEntry];
+    return [
+      turnEntry,
+      ...turn.calls.map((call) => {
+        const callDuration = Math.max(
+          0,
+          (call.completedAt ?? call.startedAt) - call.startedAt,
+        );
+        return {
+          id: callAnchor(session.id, turn.number, call.id),
+          label: `Turn ${turn.number}, call ${call.callWithinTurn}`,
+          description: breadcrumbDescription(
+            call.preview,
+            `${
+              displayModelName(call.model)
+            } · ${call.activity.tools.length} tool call${
+              call.activity.tools.length === 1 ? "" : "s"
+            }`,
+          ),
+          depth: 1 as const,
+          ...breadcrumbMetric(
+            [call],
+            callDuration,
+            metric,
+            model,
+            thinking,
+          ),
+        };
+      }),
+    ];
+  });
+}
+
+function breadcrumbColor(value: number, values: number[], enabled: boolean) {
+  if (!enabled) return "var(--sd-ink-3)";
+  const minimum = Math.min(...values);
+  const maximum = Math.max(...values);
+  const ratio = maximum === minimum
+    ? 0.5
+    : (value - minimum) / (maximum - minimum);
+  return `hsl(${Math.round(142 - ratio * 142)} 62% 52%)`;
+}
+
+function SessionNavigator({
+  session,
+  metric,
+  model,
+  thinking,
+}: {
+  session: SessionDetail;
+  metric: ColorMetric;
+  model: CostScenario;
+  thinking: string;
+}) {
+  const { collapsedTurnIDs } = useContext(TurnCollapseContext);
+  const entries = breadcrumbEntries(
+    session,
+    metric,
+    model,
+    thinking,
+    collapsedTurnIDs,
+  );
+  const navRef = useRef<HTMLDivElement>(null);
+  const [activeID, setActiveID] = useState(entries[0]?.id);
+  const [preview, setPreview] = useState<{
+    entry: BreadcrumbEntry;
+    top: number;
+    color: string;
+  }>();
+  const entryKey = entries.map((entry) => entry.id).join("|");
+
+  useEffect(() => {
+    if (!activeID || entries.some((entry) => entry.id === activeID)) return;
+    const parent = entries.find((entry) =>
+      entry.depth === 0 && activeID.startsWith(entry.id)
+    );
+    setActiveID(parent?.id ?? entries[0]?.id);
+  }, [entryKey, activeID]);
+
+  useEffect(() => {
+    const transcript = document.querySelector<HTMLElement>(
+      ".sd-layout > .sd-transcript",
+    );
+    const depthByID = new Map(entries.map((entry) => [entry.id, entry.depth]));
+    const elements = entries.flatMap((entry) => {
+      const element = document.getElementById(entry.id);
+      return element ? [element] : [];
+    });
+    if (elements.length === 0 || typeof IntersectionObserver === "undefined") {
+      return;
+    }
+    const observer = new IntersectionObserver(
+      (observations) => {
+        const visible = observations.filter((item) => item.isIntersecting)
+          .sort((a, b) =>
+            (depthByID.get(b.target.id) ?? 0) -
+              (depthByID.get(a.target.id) ?? 0) ||
+            Math.abs(a.boundingClientRect.top) -
+              Math.abs(b.boundingClientRect.top)
+          );
+        if (visible[0]) setActiveID(visible[0].target.id);
+      },
+      { root: transcript, rootMargin: "-18% 0px -70%", threshold: 0 },
+    );
+    elements.forEach((element) => observer.observe(element));
+    return () => observer.disconnect();
+  }, [entryKey]);
+
+  useEffect(() => {
+    const nav = navRef.current;
+    if (!nav || !activeID) return;
+    const button = [...nav.querySelectorAll<HTMLButtonElement>("button")].find(
+      (candidate) => candidate.dataset.target === activeID,
+    );
+    if (!button) return;
+    const top = button.offsetTop - nav.clientHeight / 2 +
+      button.offsetHeight / 2;
+    nav.scrollTo({ top, behavior: "smooth" });
+  }, [activeID]);
+
+  function showPreview(entry: BreadcrumbEntry, button: HTMLButtonElement) {
+    const nav = navRef.current;
+    if (!nav) return;
+    const buttonBounds = button.getBoundingClientRect();
+    const navBounds = nav.getBoundingClientRect();
+    const top = Math.max(
+      8,
+      Math.min(
+        nav.clientHeight - 96,
+        buttonBounds.top - navBounds.top + buttonBounds.height / 2 - 36,
+      ),
+    );
+    setPreview({
+      entry,
+      top,
+      color: breadcrumbColor(
+        entry.value,
+        entries.filter((candidate) => candidate.depth === entry.depth).map(
+          (candidate) => candidate.value,
+        ),
+        metric !== "none",
+      ),
+    });
+  }
+
+  return (
+    <nav className="sd-session-nav" aria-label="Session turns">
+      <div ref={navRef} className="sd-session-nav-scroll">
+        {entries.map((entry) => (
+          <button
+            key={entry.id}
+            type="button"
+            className={`is-depth-${entry.depth}${
+              activeID === entry.id ? " is-active" : ""
+            }`}
+            data-target={entry.id}
+            style={{
+              backgroundColor: breadcrumbColor(
+                entry.value,
+                entries.filter((candidate) => candidate.depth === entry.depth)
+                  .map((candidate) => candidate.value),
+                metric !== "none",
+              ),
+            }}
+            aria-label={`${entry.label}, ${entry.formattedValue}`}
+            onPointerEnter={(event) => showPreview(entry, event.currentTarget)}
+            onPointerLeave={() => setPreview(undefined)}
+            onFocus={(event) => showPreview(entry, event.currentTarget)}
+            onBlur={() => setPreview(undefined)}
+            onClick={() => {
+              setActiveID(entry.id);
+              const target = document.getElementById(entry.id);
+              const transcript = target?.closest<HTMLElement>(".sd-transcript");
+              if (!target || !transcript) return;
+              const top = transcript.scrollTop +
+                target.getBoundingClientRect().top -
+                transcript.getBoundingClientRect().top - 16;
+              transcript.scrollTo({
+                behavior: "smooth",
+                top,
+              });
+            }}
+          />
+        ))}
+      </div>
+      {preview && (
+        <div className="sd-crumb-popover" style={{ top: preview.top }}>
+          <span style={{ backgroundColor: preview.color }} />
+          <div>
+            <strong>{preview.entry.label}</strong>
+            <p>{preview.entry.description}</p>
+            <small>
+              {breadcrumbMetricLabel(metric)} · {preview.entry.formattedValue}
+            </small>
+          </div>
+        </div>
+      )}
+    </nav>
+  );
+}
+
+function cacheLabel(call: ModelCall) {
+  const assessment = call.cacheAssessment;
+  if (!assessment) return undefined;
+  if (assessment.cause === "ttl") return "TTL miss";
+  if (assessment.cause === "thinking-change") return "Thinking change";
+  if (assessment.cause === "compaction") return "Compaction miss";
+  if (assessment.status === "full-miss") return "Full miss";
+  if (assessment.status === "partial-hit") return "Partial hit";
+  if (assessment.status === "hit") return "Cache hit";
+  return undefined;
+}
+
+function toolTarget(value?: string) {
+  if (!value) return undefined;
+  try {
+    const parsed = JSON.parse(value);
+    if (typeof parsed === "string") return parsed;
+    if (parsed && typeof parsed === "object") {
+      for (
+        const key of [
+          "description",
+          "prompt",
+          "task",
+          "command",
+          "filePath",
+          "name",
+          "path",
+          "pattern",
+          "query",
+        ]
+      ) {
+        const candidate = (parsed as Record<string, unknown>)[key];
+        if (typeof candidate === "string") return candidate;
+      }
+    }
+  } catch {
+    return value;
+  }
+  return undefined;
+}
+
+function ToolEvent({
+  tool,
+  child,
+  depth,
+  pathMode,
+  rootDirectory,
+}: {
+  tool: ModelCall["activity"]["tools"][number];
+  child?: SessionDetail;
+  depth: number;
+  pathMode: PathMode;
+  rootDirectory?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const hasDetails = Boolean(tool.inputPreview || tool.outputPreview || child);
+  const failed = ["error", "failed", "cancelled"].includes(
+    tool.status.toLowerCase(),
+  );
+  const inputPreview = tool.inputPreview === undefined
+    ? undefined
+    : relativePathText(tool.inputPreview, rootDirectory, pathMode);
+  const outputPreview = tool.outputPreview === undefined
+    ? undefined
+    : relativePathText(tool.outputPreview, rootDirectory, pathMode);
+  const target = toolTarget(inputPreview);
+  return (
+    <div className={`sd-tool-event${open ? " is-open" : ""}`}>
+      <button
+        type="button"
+        aria-expanded={hasDetails ? open : undefined}
+        disabled={!hasDetails}
+        onClick={() => hasDetails && setOpen((current) => !current)}
+      >
+        <span className={`sd-tool-status${failed ? " is-failed" : ""}`}>
+          {failed ? <X size={12} /> : <Check size={12} />}
+        </span>
+        <strong>{tool.name}</strong>
+        {target && <code>{target}</code>}
+        <small>
+          {elapsed(tool.startedAt, tool.completedAt) ?? tool.status}
+        </small>
+        {hasDetails && <ChevronDown size={13} />}
+      </button>
+      {hasDetails && (
+        <div className="sd-tool-detail-grid">
+          <div>
+            <div className="sd-tool-detail">
+              {inputPreview && (
+                <section>
+                  <span>Input</span>
+                  <ExpandableText text={inputPreview} mono threshold={260} />
+                </section>
+              )}
+              {outputPreview && (
+                <section>
+                  <span>Output</span>
+                  <ExpandableText text={outputPreview} mono threshold={260} />
+                </section>
+              )}
+              {child && (
+                <SubagentDisclosure
+                  session={child}
+                  depth={depth + 1}
+                  pathMode={pathMode}
+                  rootDirectory={rootDirectory}
+                />
+              )}
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ToolGroup({
+  call,
+  session,
+  depth,
+  pathMode,
+  rootDirectory,
+}: {
+  call: ModelCall;
+  session: SessionDetail;
+  depth: number;
+  pathMode: PathMode;
+  rootDirectory?: string;
+}) {
+  const [open, setOpen] = useState(true);
+  if (call.activity.tools.length === 0) return null;
+  const childByID = new Map(
+    session.subagents.map((child) => [child.id, child]),
+  );
+  return (
+    <Disclosure
+      open={open}
+      onToggle={() => setOpen((current) => !current)}
+      icon={<Wrench size={13} />}
+      label={`${call.activity.tools.length} tool call${
+        call.activity.tools.length === 1 ? "" : "s"
+      }`}
+      className="sd-tool-group"
+    >
+      <div className="sd-tool-list">
+        {call.activity.tools.map((tool, index) => (
+          <ToolEvent
+            key={`${tool.name}-${index}`}
+            tool={tool}
+            child={tool.childSessionID
+              ? childByID.get(tool.childSessionID)
+              : undefined}
+            depth={depth}
+            pathMode={pathMode}
+            rootDirectory={rootDirectory}
+          />
+        ))}
+      </div>
+    </Disclosure>
+  );
+}
+
+function ReasoningDisclosure({ call }: { call: ModelCall }) {
+  const [open, setOpen] = useState(false);
+  const hasReasoning = call.activity.hasReasoning ||
+    call.tokens.reasoning > 0 ||
+    call.reasoningSetting !== undefined;
+  if (!hasReasoning) return null;
+  const callDuration = elapsed(call.startedAt, call.completedAt);
+  return (
+    <Disclosure
+      open={open}
+      onToggle={() => setOpen((current) => !current)}
+      icon={<Sparkles size={15} />}
+      label={callDuration ? `Thought for ${callDuration}` : "Reasoning trace"}
+      className="sd-thinking"
+    >
+      <div className="sd-thinking-trace">
+        <span>
+          <Brain size={13} />
+          {integer.format(call.tokens.reasoning)} reasoning tokens
+        </span>
+        {call.reasoningSetting && (
+          <span>
+            <Sparkles size={13} />Thinking: {call.reasoningSetting.settingValue}
+          </span>
+        )}
+        <span>
+          <TerminalSquare size={13} />
+          {displayModelName(call.model)}
+        </span>
+        <small>Reasoning content is not retained by this harness.</small>
+      </div>
+    </Disclosure>
+  );
+}
+
+function ContextEvents({ call }: { call: ModelCall }) {
+  const events = call.contextEventsBefore ?? [];
+  if (events.length === 0) return null;
+  return (
+    <div className="sd-context-events">
+      {events.map((event) => (
+        <span key={`${event.sourceOrder}-${event.type}`}>
+          <CircleAlert size={12} />
+          {event.type === "compaction" ? "Context compacted" : event.type}
+          {event.compaction?.preContextTokens !== undefined &&
+            event.compaction.postContextTokens !== undefined && (
+            <small>
+              {compact.format(event.compaction.preContextTokens)} →{" "}
+              {compact.format(
+                event.compaction.postContextTokens,
+              )}
+            </small>
+          )}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+function CallBlock({
+  call,
+  session,
+  turnNumber,
+  effort,
+  depth,
+  pathMode,
+  rootDirectory,
+}: {
+  call: ModelCall;
+  session: SessionDetail;
+  turnNumber: number;
+  effort?: string;
+  depth: number;
+  pathMode: PathMode;
+  rootDirectory?: string;
+}) {
+  const input = contextSize(call.tokens);
+  const assessment = cacheLabel(call);
+  return (
+    <section
+      className="sd-call"
+      id={callAnchor(session.id, turnNumber, call.id)}
+    >
+      <div className="sd-call-heading">
+        <span className="sd-agent-avatar">
+          <Bot size={13} />
+        </span>
+        <strong>{displayModelName(call.model)}</strong>
+        <span>Call {call.callWithinTurn}</span>
+        <span>
+          {elapsed(call.startedAt, call.completedAt) ?? "Timing unavailable"}
+        </span>
+        {effort && <em className="sd-call-effort">{effort}</em>}
+        {assessment && <b>{assessment}</b>}
+      </div>
+      <div className="sd-call-body">
+        <ContextEvents call={call} />
+        <ReasoningDisclosure call={call} />
+        <ToolGroup
+          call={call}
+          session={session}
+          depth={depth}
+          pathMode={pathMode}
+          rootDirectory={rootDirectory}
+        />
+        {call.responsePreview && (
+          <div className="sd-assistant-copy">
+            <ExpandableText
+              text={call.responsePreview}
+              truncated={call.responseTruncated}
+              threshold={560}
+            />
+          </div>
+        )}
+        <div className="sd-call-stats">
+          <span>{compact.format(input)} context</span>
+          <span>{compact.format(call.tokens.cacheRead)} cached</span>
+          <span>{compact.format(call.tokens.output)} output</span>
+          <span>
+            {call.computedCost === undefined
+              ? "Unpriced"
+              : money.format(call.computedCost)}
+          </span>
+        </div>
+      </div>
+    </section>
+  );
+}
+
+function TurnBlock({
+  turn,
+  session,
+  depth,
+  pathMode,
+  rootDirectory,
+}: {
+  turn: SessionDetail["turns"][number];
+  session: SessionDetail;
+  depth: number;
+  pathMode: PathMode;
+  rootDirectory?: string;
+}) {
+  const { collapsedTurnIDs, toggleTurn, turnColors } = useContext(
+    TurnCollapseContext,
+  );
+  const id = turnAnchor(session.id, turn.number);
+  const collapsed = collapsedTurnIDs.has(id);
+  const turnColor = turnColors.get(id);
+  const text = (turn.inputs ?? []).filter((input) => input.kind === "text")
+    .map((input) => input.preview).filter((value): value is string =>
+      Boolean(value)
+    )
+    .join("\n");
+  const images = (turn.inputs ?? []).filter((input) => input.kind === "image");
+  const attachments = (turn.inputs ?? []).filter((input) =>
+    input.kind !== "text" && input.kind !== "image"
+  );
+  const textTruncated = (turn.inputs ?? []).some((input) =>
+    input.kind === "text" && input.truncated
+  );
+  return (
+    <article
+      className={`sd-turn${collapsed ? " is-collapsed" : ""}`}
+      id={id}
+      style={turnColor
+        ? ({ "--sd-turn-color": turnColor } as CSSProperties)
+        : undefined}
+    >
+      <div className="sd-user-message">
+        <span className="sd-user-avatar">
+          <User size={13} />
+        </span>
+        <div>
+          <header>
+            <strong>You</strong>
+            <span>Turn {turn.number}</span>
+            <time title={fullTimestamp.format(turn.startedAt)}>
+              {timestamp.format(turn.startedAt)}
+            </time>
+            <button
+              type="button"
+              className="sd-turn-toggle"
+              aria-expanded={!collapsed}
+              aria-label={`${
+                collapsed ? "Expand" : "Collapse"
+              } turn ${turn.number}`}
+              onClick={() => toggleTurn(id)}
+            >
+              <ChevronDown size={14} />
+            </button>
+          </header>
+          {collapsed
+            ? (
+              <p className="sd-turn-collapsed-preview">
+                {text || "Non-text input"}
+              </p>
+            )
+            : text
+            ? (
+              <ExpandableText
+                text={text}
+                truncated={textTruncated}
+                threshold={520}
+              />
+            )
+            : <p className="sd-non-text-input">Non-text input</p>}
+          {!collapsed && (images.length > 0 || attachments.length > 0) && (
+            <div className="sd-input-chips">
+              {images.map((input, index) => (
+                <span key={`image-${index}`}>
+                  <Image size={12} />
+                  {input.mimeType ?? "Image"}
+                </span>
+              ))}
+              {attachments.map((input, index) => (
+                <span key={`${input.kind}-${index}`}>
+                  <FileText size={12} />
+                  {input.kind}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+      </div>
+      <div className="sd-turn-detail-grid">
+        <div>
+          <div className="sd-agent-sequence">
+            {turn.calls.map((call) => (
+              <CallBlock
+                key={call.id}
+                call={call}
+                session={session}
+                turnNumber={turn.number}
+                effort={call.reasoningSetting?.settingValue ??
+                  turn.reasoningSetting?.settingValue}
+                depth={depth}
+                pathMode={pathMode}
+                rootDirectory={rootDirectory}
+              />
+            ))}
+          </div>
+        </div>
+      </div>
+    </article>
+  );
+}
+
+function SubagentDisclosure({
+  session,
+  depth,
+  pathMode,
+  rootDirectory,
+}: {
+  session: SessionDetail;
+  depth: number;
+  pathMode: PathMode;
+  rootDirectory?: string;
+}) {
+  const [open, setOpen] = useState(false);
+  const calls = callsInTree(session).length;
+  return (
+    <Disclosure
+      open={open}
+      onToggle={() => setOpen((current) => !current)}
+      icon={<Bot size={14} />}
+      label={session.agent ?? "Subagent"}
+      meta={`${session.turns.length} turns · ${calls} calls`}
+      className="sd-subagent-disclosure"
+    >
+      <div className="sd-subagent-heading">
+        <strong>{session.title}</strong>
+        <span>{session.models.map(displayModelName).join(" · ")}</span>
+      </div>
+      <SessionTranscript
+        session={session}
+        depth={depth}
+        pathMode={pathMode}
+        rootDirectory={rootDirectory}
+      />
+    </Disclosure>
+  );
+}
+
+function SessionTranscript({
+  session,
+  depth = 0,
+  pathMode,
+  rootDirectory,
+}: {
+  session: SessionDetail;
+  depth?: number;
+  pathMode: PathMode;
+  rootDirectory?: string;
+}) {
+  const launched = new Set(
+    session.turns.flatMap((turn) =>
+      turn.calls.flatMap((call) =>
+        call.activity.tools.flatMap((tool) =>
+          tool.childSessionID ? [tool.childSessionID] : []
+        )
+      )
+    ),
+  );
+  const unlinkedSubagents = session.subagents.filter((child) =>
+    !launched.has(child.id)
+  );
+  return (
+    <div className={`sd-transcript${depth > 0 ? " is-nested" : ""}`}>
+      {session.turns.map((turn) => (
+        <TurnBlock
+          key={turn.number}
+          turn={turn}
+          session={session}
+          depth={depth}
+          pathMode={pathMode}
+          rootDirectory={rootDirectory}
+        />
+      ))}
+      {unlinkedSubagents.map((child) => (
+        <SubagentDisclosure
+          key={child.id}
+          session={child}
+          depth={depth + 1}
+          pathMode={pathMode}
+          rootDirectory={rootDirectory}
+        />
+      ))}
+    </div>
+  );
+}
+
+function MetadataRow({ label, children, mono = false }: {
+  label: string;
+  children: ReactNode;
+  mono?: boolean;
+}) {
+  return (
+    <div className="sd-metadata-row">
+      <span>{label}</span>
+      <strong className={mono ? "is-mono" : undefined}>{children}</strong>
+    </div>
+  );
+}
+
+function Metadata({
+  session,
+  pathMode,
+  colorMetric,
+  model,
+  thinking,
+  estimatedCost,
+  estimateIncomplete,
+  actualCost,
+  onPathModeChange,
+  onColorMetricChange,
+  onModelChange,
+  onThinkingChange,
+}: {
+  session: SessionDetail;
+  pathMode: PathMode;
+  colorMetric: ColorMetric;
+  model: CostScenario;
+  thinking: string;
+  estimatedCost?: number;
+  estimateIncomplete: boolean;
+  actualCost?: number;
+  onPathModeChange: (value: PathMode) => void;
+  onColorMetricChange: (value: ColorMetric) => void;
+  onModelChange: (value: CostScenario) => void;
+  onThinkingChange: (value: string) => void;
+}) {
+  const tokens = inclusiveTokens(session);
+  const calls = callsInTree(session);
+  const cacheInput = tokens.uncachedInput + tokens.cacheRead +
+    (tokens.cacheWrite ?? 0);
+  const reuse = cacheInput === 0 ? undefined : tokens.cacheRead / cacheInput;
+  const cacheMisses =
+    calls.filter((call) =>
+      call.cacheAssessment?.status === "partial-hit" ||
+      call.cacheAssessment?.status === "full-miss"
+    ).length;
+  const observedThinking = [
+    ...(session.thinking?.values ?? []),
+    ...calls.flatMap((call) =>
+      call.reasoningSetting ? [call.reasoningSetting.settingValue] : []
+    ),
+  ].filter((value, index, values) => values.indexOf(value) === index);
+  const openAIModels = counterfactualModelIDs.filter((value) =>
+    value.startsWith("gpt-")
+  );
+  const anthropicModels = counterfactualModelIDs.filter((value) =>
+    value.startsWith("claude-")
+  );
+  const otherModels = counterfactualModelIDs.filter((value) =>
+    !value.startsWith("gpt-") && !value.startsWith("claude-")
+  );
+  const delta = estimatedCost === undefined || actualCost === undefined
+    ? undefined
+    : estimatedCost - actualCost;
+  return (
+    <aside className="sd-metadata">
+      <section>
+        <h2>Run</h2>
+        <MetadataRow label="Harness">
+          {harnessName(session.harness)}
+        </MetadataRow>
+        <MetadataRow label="Agent">{session.agent ?? "Default"}</MetadataRow>
+        <MetadataRow label="Session ID" mono>{session.id}</MetadataRow>
+        {session.workingDirectory && (
+          <MetadataRow label="Working directory" mono>
+            {session.workingDirectory}
+          </MetadataRow>
+        )}
+        {session.sourcePath && (
+          <MetadataRow label="Source" mono>{session.sourcePath}</MetadataRow>
+        )}
+      </section>
+      <section>
+        <h2>Models</h2>
+        <div className="sd-model-list">
+          {session.models.map((model) => (
+            <span key={model}>{displayModelName(model)}</span>
+          ))}
+        </div>
+      </section>
+      <section>
+        <h2>Context</h2>
+        <MetadataRow label="Latest">
+          {session.contextLatest === undefined
+            ? "Unavailable"
+            : compact.format(session.contextLatest)}
+        </MetadataRow>
+        <MetadataRow label="Peak">
+          {session.contextPeak === undefined
+            ? "Unavailable"
+            : compact.format(session.contextPeak)}
+        </MetadataRow>
+        <MetadataRow label="Token reuse">
+          {reuse === undefined ? "Unavailable" : `${(reuse * 100).toFixed(1)}%`}
+        </MetadataRow>
+        <MetadataRow label="Cache misses">
+          {integer.format(cacheMisses)}
+        </MetadataRow>
+      </section>
+      <section>
+        <h2>View</h2>
+        <label className="sd-setting">
+          <span>Paths</span>
+          <span className="sd-setting-segmented">
+            {(["absolute", "relative"] as const).map((value) => (
+              <button
+                key={value}
+                type="button"
+                className={pathMode === value ? "is-active" : undefined}
+                aria-pressed={pathMode === value}
+                onClick={() => onPathModeChange(value)}
+              >
+                {value === "absolute" ? "Full" : "Relative"}
+              </button>
+            ))}
+          </span>
+        </label>
+        <label className="sd-setting">
+          <span>Turn color</span>
+          <select
+            value={colorMetric}
+            onChange={(event) =>
+              onColorMetricChange(event.target.value as ColorMetric)}
+          >
+            <option value="none">None</option>
+            <option value="time">Time spent</option>
+            <option value="cost">Cost</option>
+            <option value="input">Input processed</option>
+            <option value="output">Output</option>
+          </select>
+        </label>
+      </section>
+      <section>
+        <h2>Cost scenario</h2>
+        <label className="sd-setting">
+          <span>Model</span>
+          <select
+            value={model}
+            onChange={(event) => onModelChange(event.target.value)}
+          >
+            <option value="recorded">Recorded models</option>
+            <optgroup label="OpenAI">
+              {openAIModels.map((value) => (
+                <option key={value} value={value}>
+                  {displayModelName(value)}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="Anthropic">
+              {anthropicModels.map((value) => (
+                <option key={value} value={value}>
+                  {displayModelName(value)}
+                </option>
+              ))}
+            </optgroup>
+            <optgroup label="Other">
+              {otherModels.map((value) => (
+                <option key={value} value={value}>
+                  {displayModelName(value)}
+                </option>
+              ))}
+            </optgroup>
+          </select>
+        </label>
+        <label className="sd-setting">
+          <span>Thinking</span>
+          <select
+            value={thinking}
+            onChange={(event) => onThinkingChange(event.target.value)}
+          >
+            <option value="recorded">
+              Recorded{session.thinking?.latest
+                ? ` (${session.thinking.latest})`
+                : ""}
+            </option>
+            <option value="off">Off</option>
+            {observedThinking.filter((value) => value !== "off").map((
+              value,
+            ) => (
+              <option key={value} value={`level:${value}`}>
+                {value} (same tokens)
+              </option>
+            ))}
+          </select>
+        </label>
+        <div className="sd-cost-scenario-result">
+          <span>Estimated cost</span>
+          <strong>
+            {estimatedCost === undefined
+              ? "Unavailable"
+              : money.format(estimatedCost)}
+          </strong>
+          {delta !== undefined && Math.abs(delta) > 0.00005 && (
+            <small className={delta > 0 ? "is-higher" : "is-lower"}>
+              {delta > 0 ? "+" : "−"}
+              {money.format(Math.abs(delta))} vs recorded
+            </small>
+          )}
+          {estimateIncomplete && <small>Some calls could not be priced</small>}
+        </div>
+        <p className="sd-scenario-note">
+          Non-off thinking levels retain the recorded reasoning tokens.
+        </p>
+      </section>
+    </aside>
+  );
+}
+
+function LoadingSession() {
+  return (
+    <div className="sd-loading">
+      <span className="sd-pixel-loader" aria-hidden="true">
+        {Array.from({ length: 9 }, (_, index) => <i key={index} />)}
+      </span>
+      <span>Reading session</span>
+    </div>
+  );
+}
+
+function DetailNavigation({ backHref }: { backHref: string }) {
+  return (
+    <nav className="sd-detail-nav" aria-label="Session navigation">
+      <a className="sd-back" href={backHref}>
+        <ArrowLeft size={14} />Sessions
+      </a>
+    </nav>
+  );
+}
+
+export function SessionDetailPage() {
+  const { harness, sessionId } = route.useParams();
+  const { misses, paths, color, model, thinking } = route.useSearch();
+  const navigate = route.useNavigate();
+  const [session, setSession] = useState<SessionDetail>();
+  const [error, setError] = useState<string>();
+  const [collapsedTurnIDs, setCollapsedTurnIDs] = useState<Set<string>>(
+    () => new Set(),
+  );
+
+  useEffect(() => {
+    let active = true;
+    setSession(undefined);
+    setError(undefined);
+    getSession(sessionId, harness).then((result) => {
+      if (active) {
+        setSession(result);
+        setCollapsedTurnIDs(new Set());
+      }
+    }).catch((reason) => {
+      if (active) {
+        setError(
+          reason instanceof Error ? reason.message : "Unable to load session",
+        );
+      }
+    });
+    return () => {
+      active = false;
+    };
+  }, [harness, sessionId]);
+
+  const backQuery = new URLSearchParams({ harness });
+  if (misses) backQuery.set("misses", misses);
+  const backHref = `/?${backQuery}`;
+  if (!session) {
+    return (
+      <main className="session-detail-page">
+        <DetailNavigation backHref={backHref} />
+        <div className="sd-shell">
+          {error ? <div className="sd-error">{error}</div> : <LoadingSession />}
+        </div>
+      </main>
+    );
+  }
+
+  const tree = sessionTree(session);
+  const calls = callsInTree(session);
+  const tokens = inclusiveTokens(session);
+  const bounds = sessionBounds(session);
+  const computed = rollupCosts(tree.map((item) => item.computedCost)).cost;
+  const cost = session.inclusiveComputedCost ?? computed;
+  const subagents = tree.length - 1;
+  const selectedModel = model === "recorded" ||
+      counterfactualModelIDs.includes(
+        model as typeof counterfactualModelIDs[number],
+      )
+    ? model
+    : "recorded";
+  const estimate = scenarioCost(calls, selectedModel, thinking);
+  const scenarioChanged = selectedModel !== "recorded" ||
+    thinking !== "recorded";
+  const estimatedCost = scenarioChanged ? estimate.cost : cost;
+  const costDelta = estimatedCost === undefined || cost === undefined
+    ? undefined
+    : estimatedCost - cost;
+  const scenarioDetail = scenarioChanged
+    ? [
+      selectedModel === "recorded"
+        ? "Recorded models"
+        : displayModelName(selectedModel),
+      thinking === "off"
+        ? "thinking off"
+        : thinking.startsWith("level:")
+        ? `thinking ${thinking.slice("level:".length)}`
+        : undefined,
+      costDelta === undefined
+        ? undefined
+        : `${costDelta >= 0 ? "+" : "−"}${money.format(Math.abs(costDelta))}`,
+    ].filter(Boolean).join(" · ")
+    : subagents > 0
+    ? `${subagents} subagent${subagents === 1 ? "" : "s"}`
+    : undefined;
+  const rootBreadcrumbs = breadcrumbEntries(
+    session,
+    color,
+    selectedModel,
+    thinking,
+    collapsedTurnIDs,
+  ).filter((entry) => entry.depth === 0);
+  const rootValues = rootBreadcrumbs.map((entry) => entry.value);
+  const turnColors = new Map(
+    color === "none" ? [] : rootBreadcrumbs.map((entry) => [
+      entry.id,
+      breadcrumbColor(entry.value, rootValues, true),
+    ]),
+  );
+  return (
+    <main className="session-detail-page">
+      <DetailNavigation backHref={backHref} />
+      <div className="sd-shell">
+        <header className="sd-session-header">
+          <div className="sd-session-title-row">
+            <span className="sd-session-harness">
+              <HarnessMark harness={session.harness} />
+            </span>
+            <div>
+              <span className="sd-kicker">
+                {harnessName(session.harness)} session
+              </span>
+              <h1>{session.title}</h1>
+            </div>
+          </div>
+          <div className="sd-session-badges">
+            <span>
+              <Check size={12} />Archived
+            </span>
+            {session.thinking?.latest && (
+              <span>
+                <Sparkles size={12} />Thinking {session.thinking.latest}
+              </span>
+            )}
+          </div>
+        </header>
+
+        <div className="sd-metrics">
+          <DetailMetric
+            label="Elapsed"
+            value={elapsed(bounds.start, bounds.end) ?? "Unavailable"}
+            detail={bounds.start === undefined
+              ? undefined
+              : timestamp.format(bounds.start)}
+          />
+          <DetailMetric
+            label="Activity"
+            value={`${integer.format(calls.length)} calls`}
+            detail={`${
+              integer.format(
+                tree.reduce((sum, item) => sum + item.turns.length, 0),
+              )
+            } turns`}
+          />
+          <DetailMetric
+            label="Input processed"
+            value={compact.format(tokens.processed)}
+            detail={`${compact.format(tokens.cacheRead)} cached`}
+          />
+          <DetailMetric
+            label="Output"
+            value={compact.format(tokens.output)}
+            detail={tokens.reasoning > 0
+              ? `${compact.format(tokens.reasoning)} reasoning`
+              : undefined}
+          />
+          <DetailMetric
+            label={scenarioChanged ? "Estimated cost" : "Cost"}
+            value={estimatedCost === undefined
+              ? "Unpriced"
+              : money.format(estimatedCost)}
+            detail={scenarioDetail}
+          />
+        </div>
+
+        <TurnCollapseContext.Provider
+          value={{
+            collapsedTurnIDs,
+            turnColors,
+            toggleTurn: (id) =>
+              setCollapsedTurnIDs((current) => {
+                const next = new Set(current);
+                if (next.has(id)) next.delete(id);
+                else next.add(id);
+                return next;
+              }),
+          }}
+        >
+          <div className="sd-layout">
+            <SessionNavigator
+              session={session}
+              metric={color}
+              model={selectedModel}
+              thinking={thinking}
+            />
+            <SessionTranscript
+              session={session}
+              pathMode={paths}
+              rootDirectory={session.workingDirectory}
+            />
+            <Metadata
+              session={session}
+              pathMode={paths}
+              colorMetric={color}
+              model={selectedModel}
+              thinking={thinking}
+              estimatedCost={estimatedCost}
+              estimateIncomplete={scenarioChanged && estimate.hasUnpricedCost}
+              actualCost={cost}
+              onPathModeChange={(value) =>
+                navigate({
+                  search: (current) => ({ ...current, paths: value }),
+                  replace: true,
+                  resetScroll: false,
+                })}
+              onColorMetricChange={(value) =>
+                navigate({
+                  search: (current) => ({ ...current, color: value }),
+                  replace: true,
+                  resetScroll: false,
+                })}
+              onModelChange={(value) =>
+                navigate({
+                  search: (current) => ({ ...current, model: value }),
+                  replace: true,
+                  resetScroll: false,
+                })}
+              onThinkingChange={(value) =>
+                navigate({
+                  search: (current) => ({ ...current, thinking: value }),
+                  replace: true,
+                  resetScroll: false,
+                })}
+            />
+          </div>
+        </TurnCollapseContext.Provider>
+      </div>
+    </main>
+  );
+}

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -1,6 +1,13 @@
 import { Fragment, useEffect, useRef, useState } from "react";
 import { getRouteApi } from "@tanstack/react-router";
-import { Check, ChevronDown, Image, RefreshCw, Share } from "lucide-react";
+import {
+  Check,
+  ChevronDown,
+  ChevronRight,
+  Image,
+  RefreshCw,
+  Share,
+} from "lucide-react";
 import type {
   CacheAssessment,
   CacheIssue,
@@ -8,13 +15,13 @@ import type {
   ModelCall,
   OverviewResponse,
   SessionDetail,
-  SessionMissFilter,
   SessionListResponse,
+  SessionMissFilter,
   SessionSummary,
-  TtlMissMetrics,
   TokenUsage,
-  UsageResponse,
+  TtlMissMetrics,
   TurnInput,
+  UsageResponse,
 } from "../shared/sessionSchemas.ts";
 import {
   parseSessionMissFilters,
@@ -23,7 +30,7 @@ import {
 import { contextRange, contextSize } from "../shared/contextMetrics.ts";
 import { displayModelName } from "../shared/modelNames.ts";
 import { rollupCosts } from "../shared/costMetrics.ts";
-import { getOverview, getSession, getSessions, syncSessions } from "./api.ts";
+import { getOverview, getSessions, syncSessions } from "./api.ts";
 import claudeCodeIcon from "./assets/icons/claudecode-color.svg";
 import codexIcon from "./assets/icons/codex-logo-light.svg";
 import openCodeIcon from "./assets/icons/opencode-logo-light.svg";
@@ -199,7 +206,9 @@ function SessionThinkingSummary(
   const classified = thinking?.classifiedCalls ?? 0;
   const title = classified === 0
     ? "No requested thinking setting was exposed by the harness"
-    : `Latest: ${latest} · Used: ${values.join(" → ")} · ${classified} of ${modelCalls} calls classified`;
+    : `Latest: ${latest} · Used: ${
+      values.join(" → ")
+    } · ${classified} of ${modelCalls} calls classified`;
   return (
     <span className="session-thinking-summary" title={title}>
       <small>Thinking: {latest}</small>
@@ -373,7 +382,9 @@ function ThinkingChangeBadge({ count = 1 }: { count?: number }) {
   return (
     <span
       className="cache-issue-badge thinking-change-badge"
-      title={`${count} cache miss${count === 1 ? "" : "es"} after a thinking level change`}
+      title={`${count} cache miss${
+        count === 1 ? "" : "es"
+      } after a thinking level change`}
     >
       Thinking
     </span>
@@ -383,8 +394,8 @@ function ThinkingChangeBadge({ count = 1 }: { count?: number }) {
 function hasCacheOutcome(summary?: CacheSummary) {
   return summary !== undefined &&
     summary.hits + summary.partialHits + summary.fullMisses + summary.unknown +
-      summary.compactionRelatedMisses + summary.ttlRelatedMisses +
-      summary.thinkingChangeRelatedMisses > 0;
+          summary.compactionRelatedMisses + summary.ttlRelatedMisses +
+          summary.thinkingChangeRelatedMisses > 0;
 }
 
 function CacheSummaryBadge({ summary }: { summary?: CacheSummary }) {
@@ -448,9 +459,8 @@ function SessionCacheStatus({
       issue.status === "partial-hit" && issue.cause === undefined
     ) ?? [];
   const ttl = issues?.filter((issue) => issue.cause === "ttl") ?? [];
-  const thinkingChange = issues?.filter((issue) =>
-    issue.cause === "thinking-change"
-  ) ?? [];
+  const thinkingChange =
+    issues?.filter((issue) => issue.cause === "thinking-change") ?? [];
   if (
     !summary ||
     (full.length === 0 && partial.length === 0 && ttl.length === 0 &&
@@ -469,7 +479,9 @@ function SessionCacheStatus({
       ? `TTL miss turns:\n${ttl.map(cacheIssueLabel).join("\n")}`
       : undefined,
     thinkingChange.length > 0
-      ? `Thinking-change miss turns:\n${thinkingChange.map(cacheIssueLabel).join("\n")}`
+      ? `Thinking-change miss turns:\n${
+        thinkingChange.map(cacheIssueLabel).join("\n")
+      }`
       : undefined,
     `Call totals: ${cacheSummaryTitle(summary)}`,
   ].filter(Boolean).join("\n\n");
@@ -886,7 +898,8 @@ function SubagentSummary({
                 <small>
                   {launcher ? `Launched by ${launcher.name} · ` : ""}
                   {total.userTurns} turn{total.userTurns === 1 ? "" : "s"} ·
-                  {" "}{hasDescendants
+                  {" "}
+                  {hasDescendants
                     ? `${session.modelCalls} direct calls · ${session.subagents.length} nested subagent${
                       session.subagents.length === 1 ? "" : "s"
                     }`
@@ -1133,7 +1146,11 @@ function SessionMissFilterControl({
         <ChevronDown size={13} aria-hidden="true" />
       </button>
       {open && (
-        <div className="session-filter-menu" role="dialog" aria-label="Session miss filters">
+        <div
+          className="session-filter-menu"
+          role="dialog"
+          aria-label="Session miss filters"
+        >
           <label className="session-filter-option session-filter-all">
             <input
               type="checkbox"
@@ -1378,7 +1395,8 @@ function AssistantResponse({ call }: { call: ModelCall }) {
           type="button"
           className="assistant-response-toggle"
           aria-expanded={expanded}
-          onClick={() => setExpanded((current) => !current)}
+          onClick={() =>
+            setExpanded((current) => !current)}
         >
           {expanded ? "Show less" : "Show more"}
         </button>
@@ -1525,9 +1543,9 @@ function CallTable({
             const outcome = call.id === responseCallID
               ? "Assistant response"
               : call.preview ??
-              (previewTool && target
-                ? `${previewTool.name}: ${target}`
-                : activitySummary(call));
+                (previewTool && target
+                  ? `${previewTool.name}: ${target}`
+                  : activitySummary(call));
             const secondaryMechanics = call.preview || target ? mechanics : "";
             return (
               <Fragment key={call.id}>
@@ -1535,9 +1553,7 @@ function CallTable({
                   className={`call-row${hasDetails ? " has-details" : ""}${
                     expanded ? " row-open" : ""
                   }`}
-                  onClick={hasDetails
-                    ? () => toggleCall(call.id)
-                    : undefined}
+                  onClick={hasDetails ? () => toggleCall(call.id) : undefined}
                 >
                   <td
                     className="call-identity"
@@ -1551,7 +1567,10 @@ function CallTable({
                         >
                           {hasDetails ? (expanded ? "▾" : "▸") : ""}
                         </span>
-                        <strong>{nested ? "Subagent Call" : "Call"} {call.callWithinTurn}</strong>
+                        <strong>
+                          {nested ? "Subagent Call" : "Call"}{" "}
+                          {call.callWithinTurn}
+                        </strong>
                       </span>
                       <small>{sessionStarted.format(call.startedAt)}</small>
                     </span>
@@ -1622,7 +1641,9 @@ function CallTable({
                           />
                         )}
                         <TtlMissBadge count={ttlMisses.length} />
-                        <ThinkingChangeBadge count={thinkingChangeMisses.length} />
+                        <ThinkingChangeBadge
+                          count={thinkingChangeMisses.length}
+                        />
                         <CompactionBadge count={compactions} />
                       </span>
                     )}
@@ -1686,7 +1707,9 @@ function CallTable({
                                         title={tool.inputPreview}
                                       >
                                         <span className="tool-details-preview">
-                                          {toolTargetPreview(tool.inputPreview) ??
+                                          {toolTargetPreview(
+                                            tool.inputPreview,
+                                          ) ??
                                             "—"}
                                         </span>
                                       </td>
@@ -1856,14 +1879,19 @@ function SessionBreakdown({
                           >
                             {open ? "▾" : "▸"}
                           </button>
-                          <strong>{nested ? "Subagent Turn" : "Turn"} {turn.number}</strong>
+                          <strong>
+                            {nested ? "Subagent Turn" : "Turn"} {turn.number}
+                          </strong>
                         </span>
                         <small>{sessionStarted.format(turn.startedAt)}</small>
                       </span>
                     </td>
                     <td className="turn-model-cell">
                       <span className="model-leading-layout">
-                        <span className="model-leading-slot" aria-hidden="true" />
+                        <span
+                          className="model-leading-slot"
+                          aria-hidden="true"
+                        />
                         <span className="model-thinking-stack">
                           {turnModels.length > 0
                             ? <ModelSummary models={turnModels} />
@@ -1988,7 +2016,9 @@ function SessionBreakdown({
                             toggleSubagent={toggleSubagent}
                             nested={nested}
                           />
-                          {responseCall && <AssistantResponse call={responseCall} />}
+                          {responseCall && (
+                            <AssistantResponse call={responseCall} />
+                          )}
                         </div>
                       </td>
                     </tr>
@@ -2021,11 +2051,9 @@ export function SessionsPage() {
   const [shareCacheMisses, setShareCacheMisses] = useState<TtlMissMetrics>();
   const [shareUsage, setShareUsage] = useState<UsageResponse>();
   const [shareUsageRange, setShareUsageRange] = useState<ReportRange>(30);
-  const [shareState, setShareState] = useState<"idle" | "copied" | "error">("idle");
-  const [expandedIDs, setExpandedIDs] = useState<Set<string>>(
-    () => new Set(),
+  const [shareState, setShareState] = useState<"idle" | "copied" | "error">(
+    "idle",
   );
-  const [details, setDetails] = useState<Record<string, SessionDetail>>({});
   const [error, setError] = useState<string>();
   const [loadingMore, setLoadingMore] = useState(false);
   const [loadMoreError, setLoadMoreError] = useState<string>();
@@ -2068,8 +2096,6 @@ export function SessionsPage() {
     getSessions(1, harness, missFilters).then((result) => {
       if (!active) return;
       setData(result);
-      setExpandedIDs(new Set());
-      setDetails({});
     })
       .catch(
         (reason) => {
@@ -2171,34 +2197,6 @@ export function SessionsPage() {
     missFilterKey,
   ]);
 
-  async function toggleSession(id: string) {
-    if (expandedIDs.has(id)) {
-      setExpandedIDs((current) => {
-        const next = new Set(current);
-        next.delete(id);
-        return next;
-      });
-      return;
-    }
-    setExpandedIDs((current) => new Set(current).add(id));
-    if (details[id]) return;
-    try {
-      const summary = data?.items.find((session) => session.id === id);
-      if (!summary) return;
-      const detail = await getSession(id, summary.harness);
-      setDetails((current) => ({ ...current, [id]: detail }));
-    } catch (reason) {
-      setExpandedIDs((current) => {
-        const next = new Set(current);
-        next.delete(id);
-        return next;
-      });
-      setError(
-        reason instanceof Error ? reason.message : "Unable to load session",
-      );
-    }
-  }
-
   async function shareReport() {
     if (!overview || !shareCacheMisses || !shareUsage) return;
     try {
@@ -2239,10 +2237,14 @@ export function SessionsPage() {
         action={
           <button
             type="button"
-            className={`share-report-button${shareState === "error" ? " error" : ""}`}
+            className={`share-report-button${
+              shareState === "error" ? " error" : ""
+            }`}
             onClick={shareReport}
             disabled={!overview || !shareCacheMisses || !shareUsage}
-            aria-label={shareState === "copied" ? "Report copied" : "Copy Markdown report"}
+            aria-label={shareState === "copied"
+              ? "Report copied"
+              : "Copy Markdown report"}
             title={shareState === "copied"
               ? "Markdown report copied"
               : shareState === "error"
@@ -2289,7 +2291,9 @@ export function SessionsPage() {
               className="session-refresh"
               onClick={refreshData}
               disabled={refreshing}
-              aria-label={refreshing ? "Refreshing sessions" : "Refresh sessions"}
+              aria-label={refreshing
+                ? "Refreshing sessions"
+                : "Refresh sessions"}
               title="Import changed sessions and reload"
             >
               <RefreshCw size={13} aria-hidden="true" />
@@ -2369,9 +2373,7 @@ export function SessionsPage() {
                 </thead>
                 <tbody>
                   {data.items.map((session) => {
-                    const expanded = expandedIDs.has(session.id);
-                    const detail = details[session.id];
-                    const span = sessionSpan(detail ?? session);
+                    const span = sessionSpan(session);
                     const sessionStart = span?.start ?? session.startedAt;
                     const sessionLocation = session.workingDirectory ??
                       session.sourcePath;
@@ -2410,172 +2412,187 @@ export function SessionsPage() {
                       provider.toLowerCase().includes("anthropic")
                     );
                     return (
-                      <Fragment key={session.id}>
-                        <tr
-                          className={`session-row${
-                            expanded ? " row-open" : ""
-                          }`}
-                          onClick={() => toggleSession(session.id)}
-                        >
-                          <td className="session-cell">
-                            <div className="session-identity">
-                              <button
-                                type="button"
-                                className="session-expand"
-                                aria-expanded={expanded}
-                                aria-label={`${
-                                  expanded ? "Collapse" : "Expand"
-                                } ${session.title}`}
-                              >
-                                {expanded ? "▾" : "▸"}
-                              </button>
-                              <div className="session-copy">
-                                <strong
-                                  className="session-title"
-                                  title={sessionTitleTooltip}
-                                >
-                                  {session.title}
-                                </strong>
-                                {sessionLocation !== undefined && (
-                                  <small
-                                    className={session.workingDirectory !==
-                                        undefined
-                                      ? "session-working-directory"
-                                      : "session-source-path"}
-                                    title={sessionLocationTitle}
-                                  >
-                                    {sessionLocation}
-                                  </small>
-                                )}
-                              </div>
-                            </div>
-                          </td>
-                          <td>
-                            <span className="model-leading-layout">
-                              <HarnessIcon harness={session.harness} />
-                              <span className="session-model-details">
-                                <ModelSummary models={session.models} />
-                                <SessionThinkingSummary
-                                  thinking={session.thinking}
-                                  modelCalls={session.modelCalls}
-                                />
-                              </span>
+                      <tr
+                        key={session.id}
+                        className="session-row"
+                        role="link"
+                        tabIndex={0}
+                        aria-label={`Open session: ${session.title}`}
+                        onClick={() =>
+                          navigate({
+                            to: "/sessions/$harness/$sessionId",
+                            params: {
+                              harness: session.harness,
+                              sessionId: session.id,
+                            },
+                            search: {
+                              misses: misses || undefined,
+                              paths: "relative",
+                              color: "time",
+                              model: "recorded",
+                              thinking: "recorded",
+                            },
+                          })}
+                        onKeyDown={(event) => {
+                          if (event.key !== "Enter" && event.key !== " ") {
+                            return;
+                          }
+                          event.preventDefault();
+                          navigate({
+                            to: "/sessions/$harness/$sessionId",
+                            params: {
+                              harness: session.harness,
+                              sessionId: session.id,
+                            },
+                            search: {
+                              misses: misses || undefined,
+                              paths: "relative",
+                              color: "time",
+                              model: "recorded",
+                              thinking: "recorded",
+                            },
+                          });
+                        }}
+                      >
+                        <td className="session-cell">
+                          <div className="session-identity">
+                            <span
+                              className="session-open-indicator"
+                              aria-hidden="true"
+                            >
+                              <ChevronRight size={15} />
                             </span>
-                          </td>
-                          <td
-                            className={span?.label ? undefined : "muted"}
-                            title={span
-                              ? `${fullTimestamp.format(span.start)} → ${
-                                fullTimestamp.format(span.end)
+                            <div className="session-copy">
+                              <strong
+                                className="session-title"
+                                title={sessionTitleTooltip}
+                              >
+                                {session.title}
+                              </strong>
+                              {sessionLocation !== undefined && (
+                                <small
+                                  className={session.workingDirectory !==
+                                      undefined
+                                    ? "session-working-directory"
+                                    : "session-source-path"}
+                                  title={sessionLocationTitle}
+                                >
+                                  {sessionLocation}
+                                </small>
+                              )}
+                            </div>
+                          </div>
+                        </td>
+                        <td>
+                          <span className="model-leading-layout">
+                            <HarnessIcon harness={session.harness} />
+                            <span className="session-model-details">
+                              <ModelSummary models={session.models} />
+                              <SessionThinkingSummary
+                                thinking={session.thinking}
+                                modelCalls={session.modelCalls}
+                              />
+                            </span>
+                          </span>
+                        </td>
+                        <td
+                          className={span?.label ? undefined : "muted"}
+                          title={span
+                            ? `${fullTimestamp.format(span.start)} → ${
+                              fullTimestamp.format(span.end)
+                            }`
+                            : undefined}
+                        >
+                          <span className="metric-stack session-elapsed">
+                            <span>{span?.label ?? "—"}</span>
+                            {sessionStart !== undefined && (
+                              <small
+                                className="session-started"
+                                title={`Started ${
+                                  fullTimestamp.format(sessionStart)
+                                }`}
+                              >
+                                {sessionStarted.format(sessionStart)}
+                              </small>
+                            )}
+                          </span>
+                        </td>
+                        <td title="Inclusive of direct and subagent turns and calls">
+                          <span className="metric-stack">
+                            <span>
+                              {session.inclusiveUserTurns ??
+                                session.userTurns} turns
+                            </span>
+                            <span>
+                              {session.inclusiveModelCalls ??
+                                session.modelCalls} calls
+                            </span>
+                            {(session.subagentCount ?? 0) > 0 && (
+                              <small>
+                                {session.subagentCount}{" "}
+                                subagent{session.subagentCount === 1 ? "" : "s"}
+                              </small>
+                            )}
+                          </span>
+                        </td>
+                        <td>
+                          <ContextMetric
+                            value={session.contextLatest}
+                            secondary={session.contextPeak}
+                            secondaryLabel="peak"
+                            title={session.contextLatest !== undefined &&
+                                session.contextPeak !== undefined
+                              ? `Latest root request: ${
+                                integer.format(session.contextLatest)
+                              } tokens · Peak root request: ${
+                                integer.format(session.contextPeak)
+                              } tokens${
+                                session.contextPeakTurn !== undefined &&
+                                  session.contextPeakCall !== undefined
+                                  ? ` (turn ${session.contextPeakTurn}, call #${session.contextPeakCall})`
+                                  : ""
                               }`
                               : undefined}
-                          >
-                            <span className="metric-stack session-elapsed">
-                              <span>{span?.label ?? "—"}</span>
-                              {sessionStart !== undefined && (
-                                <small
-                                  className="session-started"
-                                  title={`Started ${
-                                    fullTimestamp.format(sessionStart)
-                                  }`}
-                                >
-                                  {sessionStarted.format(sessionStart)}
-                                </small>
-                              )}
-                            </span>
-                          </td>
-                          <td title="Inclusive of direct and subagent turns and calls">
-                            <span className="metric-stack">
-                              <span>
-                                {session.inclusiveUserTurns ??
-                                  session.userTurns} turns
-                              </span>
-                              <span>
-                                {session.inclusiveModelCalls ??
-                                  session.modelCalls} calls
-                              </span>
-                              {(session.subagentCount ?? 0) > 0 && (
-                                <small>
-                                  {session.subagentCount}{" "}
-                                  subagent{session.subagentCount === 1
-                                    ? ""
-                                    : "s"}
-                                </small>
-                              )}
-                            </span>
-                          </td>
-                          <td>
-                            <ContextMetric
-                              value={session.contextLatest}
-                              secondary={session.contextPeak}
-                              secondaryLabel="peak"
-                              title={session.contextLatest !== undefined &&
-                                  session.contextPeak !== undefined
-                                ? `Latest root request: ${
-                                  integer.format(session.contextLatest)
-                                } tokens · Peak root request: ${
-                                  integer.format(session.contextPeak)
-                                } tokens${
-                                  session.contextPeakTurn !== undefined &&
-                                    session.contextPeakCall !== undefined
-                                    ? ` (turn ${session.contextPeakTurn}, call #${session.contextPeakCall})`
-                                    : ""
-                                }`
-                                : undefined}
-                            />
-                          </td>
-                          <td>
-                            <SessionInputMetric
-                              tokens={tokens}
-                              anthropic={anthropic}
-                            />
-                          </td>
-                          <td className="image-input-cell">
-                            <ImageInputIndicator count={imageInputs} />
-                          </td>
-                          <td>
-                            <SessionCacheStatus
-                              summary={session.cacheSummary}
-                              issues={session.cacheIssues}
-                              compactionCount={session.compactionCount}
-                            />
-                          </td>
-                          <td>
-                            <OutputMetric
-                              output={tokens.output}
-                              reasoning={tokens.reasoning}
-                            />
-                          </td>
-                          <td>
-                            <CostCell
-                              reported={hasInclusiveMetrics
-                                ? session.inclusiveReportedCost
-                                : session.reportedCost}
-                              computed={hasInclusiveMetrics
-                                ? session.inclusiveComputedCost
-                                : session.computedCost}
-                              direct={hasSubagents
-                                ? session.computedCost
-                                : undefined}
-                              subagents={subagentComputedCost}
-                              session
-                            />
-                          </td>
-                        </tr>
-                        {expanded && (
-                          <tr className="detail-row">
-                            <td colSpan={10}>
-                              {detail
-                                ? <SessionBreakdown session={detail} />
-                                : (
-                                  <div className="loading inset-loading">
-                                    Grouping model calls by turn...
-                                  </div>
-                                )}
-                            </td>
-                          </tr>
-                        )}
-                      </Fragment>
+                          />
+                        </td>
+                        <td>
+                          <SessionInputMetric
+                            tokens={tokens}
+                            anthropic={anthropic}
+                          />
+                        </td>
+                        <td className="image-input-cell">
+                          <ImageInputIndicator count={imageInputs} />
+                        </td>
+                        <td>
+                          <SessionCacheStatus
+                            summary={session.cacheSummary}
+                            issues={session.cacheIssues}
+                            compactionCount={session.compactionCount}
+                          />
+                        </td>
+                        <td>
+                          <OutputMetric
+                            output={tokens.output}
+                            reasoning={tokens.reasoning}
+                          />
+                        </td>
+                        <td>
+                          <CostCell
+                            reported={hasInclusiveMetrics
+                              ? session.inclusiveReportedCost
+                              : session.reportedCost}
+                            computed={hasInclusiveMetrics
+                              ? session.inclusiveComputedCost
+                              : session.computedCost}
+                            direct={hasSubagents
+                              ? session.computedCost
+                              : undefined}
+                            subagents={subagentComputedCost}
+                            session
+                          />
+                        </td>
+                      </tr>
                     );
                   })}
                 </tbody>

--- a/src/client/main.tsx
+++ b/src/client/main.tsx
@@ -30,19 +30,30 @@ const ToolCallsPage = lazy(() =>
     default: ToolCallsPage,
   }))
 );
+const SessionDetailPage = lazy(() =>
+  import("./SessionDetailPage.tsx").then(({ SessionDetailPage }) => ({
+    default: SessionDetailPage,
+  }))
+);
 
 function AppError({ error, reset }: { error: unknown; reset: () => void }) {
   const message = error instanceof Error ? error.message : String(error);
   const stack = error instanceof Error ? error.stack : undefined;
-  const diagnostics = JSON.stringify({
-    capturedAt: new Date().toISOString(),
-    message,
-    stack,
-    url: window.location.href,
-    userAgent: navigator.userAgent,
-    reactVersion,
-    scripts: Array.from(document.scripts, (script) => script.src).filter(Boolean),
-  }, null, 2);
+  const diagnostics = JSON.stringify(
+    {
+      capturedAt: new Date().toISOString(),
+      message,
+      stack,
+      url: window.location.href,
+      userAgent: navigator.userAgent,
+      reactVersion,
+      scripts: Array.from(document.scripts, (script) => script.src).filter(
+        Boolean,
+      ),
+    },
+    null,
+    2,
+  );
 
   return (
     <main className="app-error">
@@ -83,7 +94,9 @@ const indexRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/",
   validateSearch: z.object({
-    harness: z.enum(["all", "opencode", "claude-code", "pi", "codex"]).catch("all"),
+    harness: z.enum(["all", "opencode", "claude-code", "pi", "codex"]).catch(
+      "all",
+    ),
     misses: z.string().optional(),
   }),
   component: SessionsPage,
@@ -92,8 +105,11 @@ const newRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/new",
   validateSearch: z.object({
-    harness: z.enum(["all", "opencode", "claude-code", "pi", "codex"]).catch("all"),
-    range: z.coerce.number().pipe(z.union([z.literal(30), z.literal(90)])).catch(30),
+    harness: z.enum(["all", "opencode", "claude-code", "pi", "codex"]).catch(
+      "all",
+    ),
+    range: z.coerce.number().pipe(z.union([z.literal(30), z.literal(90)]))
+      .catch(30),
   }),
   component: NewPage,
 });
@@ -101,7 +117,9 @@ const performanceRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/performance",
   validateSearch: z.object({
-    harness: z.enum(["all", "opencode", "claude-code", "pi", "codex"]).catch("all"),
+    harness: z.enum(["all", "opencode", "claude-code", "pi", "codex"]).catch(
+      "all",
+    ),
     openai: z.string().catch("all"),
     anthropic: z.string().catch("all"),
   }),
@@ -111,8 +129,12 @@ const toolCallsRoute = createRoute({
   getParentRoute: () => rootRoute,
   path: "/tool-calls",
   validateSearch: z.object({
-    harness: z.enum(["all", "opencode", "claude-code", "pi", "codex"]).catch("all"),
-    range: z.coerce.number().pipe(z.union([z.literal(7), z.literal(30), z.literal(90)])).catch(30),
+    harness: z.enum(["all", "opencode", "claude-code", "pi", "codex"]).catch(
+      "all",
+    ),
+    range: z.coerce.number().pipe(
+      z.union([z.literal(7), z.literal(30), z.literal(90)]),
+    ).catch(30),
     expanded: z.preprocess(
       (value) => value === true || value === "true",
       z.boolean(),
@@ -120,12 +142,33 @@ const toolCallsRoute = createRoute({
   }),
   component: ToolCallsPage,
 });
+const sessionDetailRoute = createRoute({
+  getParentRoute: () => rootRoute,
+  path: "/sessions/$harness/$sessionId",
+  validateSearch: z.object({
+    misses: z.string().optional(),
+    paths: z.enum(["absolute", "relative"]).catch("relative"),
+    color: z.enum(["none", "time", "cost", "input", "output"]).catch(
+      "time",
+    ),
+    model: z.string().catch("recorded"),
+    thinking: z.string().catch("recorded"),
+  }),
+  parseParams: (params) => ({
+    harness: z.enum(["opencode", "claude-code", "pi", "codex"]).parse(
+      params.harness,
+    ),
+    sessionId: params.sessionId,
+  }),
+  component: SessionDetailPage,
+});
 const router = createRouter({
   routeTree: rootRoute.addChildren([
     indexRoute,
     newRoute,
     performanceRoute,
     toolCallsRoute,
+    sessionDetailRoute,
   ]),
 });
 

--- a/src/client/styles.css
+++ b/src/client/styles.css
@@ -431,7 +431,6 @@ h1 {
     flex-direction: column;
     gap: 3px;
   }
-
 }
 
 .ttl-miss-lead {
@@ -1544,6 +1543,12 @@ table.data-table {
   background: var(--surface-1);
 }
 
+.session-row:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: -2px;
+  background: var(--surface-1);
+}
+
 .session-row.row-open {
   background: #e8eee5;
 }
@@ -1558,6 +1563,23 @@ table.data-table {
   align-items: flex-start;
   gap: 10px;
   min-width: 0;
+}
+
+.session-open-indicator {
+  display: inline-flex;
+  width: 18px;
+  height: 18px;
+  flex: 0 0 18px;
+  align-items: center;
+  justify-content: center;
+  color: var(--muted);
+  transition: color .12s ease, transform .12s ease;
+}
+
+.session-row:hover .session-open-indicator,
+.session-row:focus-visible .session-open-indicator {
+  color: var(--accent);
+  transform: translateX(2px);
 }
 
 .session-copy {

--- a/src/server/pricing.ts
+++ b/src/server/pricing.ts
@@ -1,170 +1,12 @@
-import type {
-  SessionDetail,
-  TokenUsage,
-} from "../shared/sessionSchemas.ts";
+import type { SessionDetail } from "../shared/sessionSchemas.ts";
 import { contextSize } from "../shared/contextMetrics.ts";
-import { canonicalModelId } from "../shared/modelNames.ts";
 import { rollupCosts } from "../shared/costMetrics.ts";
+import { computeModelCallCost, modelRateCard } from "../shared/modelPricing.ts";
+export { computeModelCallCost } from "../shared/modelPricing.ts";
 import {
   type CacheMissTokens,
   estimateCacheMissCost,
 } from "./cacheMissPricing.ts";
-
-type RateCard = {
-  input: number;
-  cacheRead: number;
-  output: number;
-  cacheWrite?: number;
-  cacheWrite5m?: number;
-  cacheWrite1h?: number;
-};
-
-const standard: Record<string, RateCard> = {
-  "claude-fable-5": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50 },
-  "claude-mythos-5": { input: 10, cacheWrite5m: 12.5, cacheWrite1h: 20, cacheRead: 1, output: 50 },
-  "claude-opus-5": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25 },
-  "claude-opus-4-8": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25 },
-  "claude-opus-4-7": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25 },
-  "claude-opus-4-6": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25 },
-  "claude-opus-4-5": { input: 5, cacheWrite5m: 6.25, cacheWrite1h: 10, cacheRead: 0.5, output: 25 },
-  "claude-opus-4-1": { input: 15, cacheWrite5m: 18.75, cacheWrite1h: 30, cacheRead: 1.5, output: 75 },
-  "claude-opus-4": { input: 15, cacheWrite5m: 18.75, cacheWrite1h: 30, cacheRead: 1.5, output: 75 },
-  "claude-sonnet-4-6": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15 },
-  "claude-sonnet-4-5": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15 },
-  "claude-sonnet-4": { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15 },
-  "claude-haiku-4-5": { input: 1, cacheWrite5m: 1.25, cacheWrite1h: 2, cacheRead: 0.1, output: 5 },
-  "claude-haiku-3-5": { input: 0.8, cacheWrite5m: 1, cacheWrite1h: 1.6, cacheRead: 0.08, output: 4 },
-  "grok-4-5": { input: 2, cacheWrite5m: 0, cacheWrite1h: 0, cacheRead: 0.5, output: 6 },
-  "grok-4.5": { input: 2, cacheWrite5m: 0, cacheWrite1h: 0, cacheRead: 0.5, output: 6 },
-  "kimi-k3": { input: 3, cacheRead: 0.3, cacheWrite: 3, output: 15 },
-  "glm-5.2": { input: 1.4, cacheRead: 0.26, output: 4.4 },
-  "gpt-5.6-sol": { input: 5, cacheRead: 0.5, cacheWrite: 6.25, output: 30 },
-  "gpt-5.6-terra": { input: 2.5, cacheRead: 0.25, cacheWrite: 3.125, output: 15 },
-  "gpt-5.6-luna": { input: 1, cacheRead: 0.1, cacheWrite: 1.25, output: 6 },
-  "gpt-5.3-codex": { input: 1.75, cacheRead: 0.175, output: 14 },
-  "gpt-5.2-codex": { input: 1.75, cacheRead: 0.175, output: 14 },
-  "gpt-5.1-codex-max": { input: 1.25, cacheRead: 0.125, output: 10 },
-  "gpt-5.1-codex": { input: 1.25, cacheRead: 0.13, output: 10 },
-  "gpt-5.1-codex-mini": { input: 0.25, cacheRead: 0.025, output: 2 },
-  "gpt-5-codex": { input: 1.25, cacheRead: 0.125, output: 10 },
-  "gpt-5.5": { input: 5, cacheRead: 0.5, output: 30 },
-  "gpt-5.5-pro": { input: 30, cacheRead: 0, output: 180 },
-  "gpt-5.4": { input: 2.5, cacheRead: 0.25, output: 15 },
-  "gpt-5.4-mini": { input: 0.75, cacheRead: 0.075, output: 4.5 },
-  "gpt-5.4-nano": { input: 0.2, cacheRead: 0.02, output: 1.25 },
-  "gpt-5.4-pro": { input: 30, cacheRead: 0, output: 180 },
-};
-
-const longContext: Record<string, RateCard> = {
-  // OpenRouter publishes one rate tier for these Codex models.
-  "gpt-5.3-codex": { input: 1.75, cacheRead: 0.175, output: 14 },
-  "gpt-5.2-codex": { input: 1.75, cacheRead: 0.175, output: 14 },
-  "gpt-5.1-codex-max": { input: 1.25, cacheRead: 0.125, output: 10 },
-  "gpt-5.1-codex": { input: 1.25, cacheRead: 0.13, output: 10 },
-  "gpt-5.1-codex-mini": { input: 0.25, cacheRead: 0.025, output: 2 },
-  "gpt-5-codex": { input: 1.25, cacheRead: 0.125, output: 10 },
-  "gpt-5.6-sol": {
-    input: 10,
-    cacheRead: 1,
-    cacheWrite: 12.5,
-    output: 45,
-  },
-  "gpt-5.6-terra": {
-    input: 5,
-    cacheRead: 0.5,
-    cacheWrite: 6.25,
-    output: 22.5,
-  },
-  "gpt-5.6-luna": {
-    input: 2,
-    cacheRead: 0.2,
-    cacheWrite: 2.5,
-    output: 9,
-  },
-  "gpt-5.5": { input: 10, cacheRead: 1, output: 45 },
-  "gpt-5.5-pro": { input: 60, cacheRead: 0, output: 270 },
-  "gpt-5.4": { input: 5, cacheRead: 0.5, output: 22.5 },
-  "gpt-5.4-pro": { input: 60, cacheRead: 0, output: 270 },
-};
-
-const LONG_CONTEXT_THRESHOLD = 272_000;
-const OPENAI_LUNA_TERRA_PRICE_CUT = Date.parse("2026-07-30T20:00:00Z");
-
-const reducedLunaTerraRates: Record<string, RateCard> = {
-  "gpt-5.6-terra": { input: 2, cacheRead: 0.2, cacheWrite: 2.5, output: 12 },
-  "gpt-5.6-luna": { input: 0.2, cacheRead: 0.02, cacheWrite: 0.25, output: 1.2 },
-};
-
-const reducedLunaTerraLongContextRates: Record<string, RateCard> = {
-  "gpt-5.6-terra": { input: 4, cacheRead: 0.4, cacheWrite: 5, output: 18 },
-  "gpt-5.6-luna": { input: 0.4, cacheRead: 0.04, cacheWrite: 0.5, output: 1.8 },
-};
-
-function normalizedModel(model: string) {
-  return canonicalModelId(model);
-}
-
-function rateCard(model: string, timestamp: number, inputTokens: number) {
-  const normalized = normalizedModel(model);
-  const long = normalized.startsWith("gpt-5.") &&
-    inputTokens >= LONG_CONTEXT_THRESHOLD;
-  if (timestamp >= OPENAI_LUNA_TERRA_PRICE_CUT) {
-    const reducedRates = long
-      ? reducedLunaTerraLongContextRates[normalized]
-      : reducedLunaTerraRates[normalized];
-    if (reducedRates) return reducedRates;
-  }
-  if (
-    long
-  ) return longContext[normalized];
-  if (normalized === "claude-sonnet-5") {
-    return timestamp < Date.parse("2026-09-01T00:00:00Z")
-      ? { input: 2, cacheWrite5m: 2.5, cacheWrite1h: 4, cacheRead: 0.2, output: 10 }
-      : { input: 3, cacheWrite5m: 3.75, cacheWrite1h: 6, cacheRead: 0.3, output: 15 };
-  }
-  return standard[normalized];
-}
-
-export function computeModelCallCost(
-  tokens: TokenUsage,
-  model: string,
-  timestamp: number,
-) {
-  const categorizedTokens = tokens.uncachedInput + tokens.cacheRead +
-    (tokens.cacheWrite ?? 0) + tokens.output + tokens.reasoning;
-  if (tokens.processed > 0 && categorizedTokens === 0) return undefined;
-
-  const inputSideTokens = contextSize(tokens);
-  const rates = rateCard(model, timestamp, inputSideTokens);
-  if (!rates) return undefined;
-
-  let cacheWriteCost = 0;
-  if (tokens.cacheWrite !== undefined) {
-    if (tokens.cacheWrite5m !== undefined && tokens.cacheWrite1h !== undefined &&
-      tokens.cacheWrite5m + tokens.cacheWrite1h === tokens.cacheWrite &&
-      rates.cacheWrite5m !== undefined && rates.cacheWrite1h !== undefined) {
-      cacheWriteCost = tokens.cacheWrite5m * rates.cacheWrite5m +
-        tokens.cacheWrite1h * rates.cacheWrite1h;
-    } else if (rates.cacheWrite !== undefined) {
-      cacheWriteCost = tokens.cacheWrite * rates.cacheWrite;
-    } else if (
-      tokens.cacheWrite5m === undefined && tokens.cacheWrite1h === undefined &&
-      rates.cacheWrite5m !== undefined
-    ) {
-      // Anthropic-compatible sources may report only total cache writes. In
-      // that case, assume the default 5-minute cache TTL.
-      cacheWriteCost = tokens.cacheWrite * rates.cacheWrite5m;
-    } else {
-      return undefined;
-    }
-  }
-  return (
-    tokens.uncachedInput * rates.input +
-    tokens.cacheRead * rates.cacheRead +
-    cacheWriteCost +
-    (tokens.output + tokens.reasoning) * rates.output
-  ) / 1_000_000;
-}
 
 export function estimateModelCacheMissCost(
   before: CacheMissTokens,
@@ -174,7 +16,7 @@ export function estimateModelCacheMissCost(
 ) {
   // A hit changes the billing category, not the request's context size. Resolve
   // short- versus long-context rates from the call where the miss occurred.
-  const rates = rateCard(model, timestamp, contextSize(after));
+  const rates = modelRateCard(model, timestamp, contextSize(after));
   return rates && estimateCacheMissCost(rates, before, after);
 }
 

--- a/src/shared/modelPricing.ts
+++ b/src/shared/modelPricing.ts
@@ -1,0 +1,333 @@
+import type { TokenUsage } from "./sessionSchemas.ts";
+import { contextSize } from "./contextMetrics.ts";
+import { canonicalModelId } from "./modelNames.ts";
+
+export type ModelRateCard = {
+  input: number;
+  cacheRead: number;
+  output: number;
+  cacheWrite?: number;
+  cacheWrite5m?: number;
+  cacheWrite1h?: number;
+};
+
+const standard: Record<string, ModelRateCard> = {
+  "claude-fable-5": {
+    input: 10,
+    cacheWrite5m: 12.5,
+    cacheWrite1h: 20,
+    cacheRead: 1,
+    output: 50,
+  },
+  "claude-mythos-5": {
+    input: 10,
+    cacheWrite5m: 12.5,
+    cacheWrite1h: 20,
+    cacheRead: 1,
+    output: 50,
+  },
+  "claude-opus-5": {
+    input: 5,
+    cacheWrite5m: 6.25,
+    cacheWrite1h: 10,
+    cacheRead: 0.5,
+    output: 25,
+  },
+  "claude-opus-4-8": {
+    input: 5,
+    cacheWrite5m: 6.25,
+    cacheWrite1h: 10,
+    cacheRead: 0.5,
+    output: 25,
+  },
+  "claude-opus-4-7": {
+    input: 5,
+    cacheWrite5m: 6.25,
+    cacheWrite1h: 10,
+    cacheRead: 0.5,
+    output: 25,
+  },
+  "claude-opus-4-6": {
+    input: 5,
+    cacheWrite5m: 6.25,
+    cacheWrite1h: 10,
+    cacheRead: 0.5,
+    output: 25,
+  },
+  "claude-opus-4-5": {
+    input: 5,
+    cacheWrite5m: 6.25,
+    cacheWrite1h: 10,
+    cacheRead: 0.5,
+    output: 25,
+  },
+  "claude-opus-4-1": {
+    input: 15,
+    cacheWrite5m: 18.75,
+    cacheWrite1h: 30,
+    cacheRead: 1.5,
+    output: 75,
+  },
+  "claude-opus-4": {
+    input: 15,
+    cacheWrite5m: 18.75,
+    cacheWrite1h: 30,
+    cacheRead: 1.5,
+    output: 75,
+  },
+  "claude-sonnet-4-6": {
+    input: 3,
+    cacheWrite5m: 3.75,
+    cacheWrite1h: 6,
+    cacheRead: 0.3,
+    output: 15,
+  },
+  "claude-sonnet-4-5": {
+    input: 3,
+    cacheWrite5m: 3.75,
+    cacheWrite1h: 6,
+    cacheRead: 0.3,
+    output: 15,
+  },
+  "claude-sonnet-4": {
+    input: 3,
+    cacheWrite5m: 3.75,
+    cacheWrite1h: 6,
+    cacheRead: 0.3,
+    output: 15,
+  },
+  "claude-haiku-4-5": {
+    input: 1,
+    cacheWrite5m: 1.25,
+    cacheWrite1h: 2,
+    cacheRead: 0.1,
+    output: 5,
+  },
+  "claude-haiku-3-5": {
+    input: 0.8,
+    cacheWrite5m: 1,
+    cacheWrite1h: 1.6,
+    cacheRead: 0.08,
+    output: 4,
+  },
+  "grok-4-5": {
+    input: 2,
+    cacheWrite5m: 0,
+    cacheWrite1h: 0,
+    cacheRead: 0.5,
+    output: 6,
+  },
+  "grok-4.5": {
+    input: 2,
+    cacheWrite5m: 0,
+    cacheWrite1h: 0,
+    cacheRead: 0.5,
+    output: 6,
+  },
+  "kimi-k3": { input: 3, cacheRead: 0.3, cacheWrite: 3, output: 15 },
+  "glm-5.2": { input: 1.4, cacheRead: 0.26, output: 4.4 },
+  "gpt-5.6-sol": {
+    input: 5,
+    cacheRead: 0.5,
+    cacheWrite: 6.25,
+    output: 30,
+  },
+  "gpt-5.6-terra": {
+    input: 2.5,
+    cacheRead: 0.25,
+    cacheWrite: 3.125,
+    output: 15,
+  },
+  "gpt-5.6-luna": {
+    input: 1,
+    cacheRead: 0.1,
+    cacheWrite: 1.25,
+    output: 6,
+  },
+  "gpt-5.3-codex": { input: 1.75, cacheRead: 0.175, output: 14 },
+  "gpt-5.2-codex": { input: 1.75, cacheRead: 0.175, output: 14 },
+  "gpt-5.1-codex-max": { input: 1.25, cacheRead: 0.125, output: 10 },
+  "gpt-5.1-codex": { input: 1.25, cacheRead: 0.13, output: 10 },
+  "gpt-5.1-codex-mini": { input: 0.25, cacheRead: 0.025, output: 2 },
+  "gpt-5-codex": { input: 1.25, cacheRead: 0.125, output: 10 },
+  "gpt-5.5": { input: 5, cacheRead: 0.5, output: 30 },
+  "gpt-5.5-pro": { input: 30, cacheRead: 0, output: 180 },
+  "gpt-5.4": { input: 2.5, cacheRead: 0.25, output: 15 },
+  "gpt-5.4-mini": { input: 0.75, cacheRead: 0.075, output: 4.5 },
+  "gpt-5.4-nano": { input: 0.2, cacheRead: 0.02, output: 1.25 },
+  "gpt-5.4-pro": { input: 30, cacheRead: 0, output: 180 },
+};
+
+const longContext: Record<string, ModelRateCard> = {
+  "gpt-5.3-codex": { input: 1.75, cacheRead: 0.175, output: 14 },
+  "gpt-5.2-codex": { input: 1.75, cacheRead: 0.175, output: 14 },
+  "gpt-5.1-codex-max": { input: 1.25, cacheRead: 0.125, output: 10 },
+  "gpt-5.1-codex": { input: 1.25, cacheRead: 0.13, output: 10 },
+  "gpt-5.1-codex-mini": { input: 0.25, cacheRead: 0.025, output: 2 },
+  "gpt-5-codex": { input: 1.25, cacheRead: 0.125, output: 10 },
+  "gpt-5.6-sol": {
+    input: 10,
+    cacheRead: 1,
+    cacheWrite: 12.5,
+    output: 45,
+  },
+  "gpt-5.6-terra": {
+    input: 5,
+    cacheRead: 0.5,
+    cacheWrite: 6.25,
+    output: 22.5,
+  },
+  "gpt-5.6-luna": {
+    input: 2,
+    cacheRead: 0.2,
+    cacheWrite: 2.5,
+    output: 9,
+  },
+  "gpt-5.5": { input: 10, cacheRead: 1, output: 45 },
+  "gpt-5.5-pro": { input: 60, cacheRead: 0, output: 270 },
+  "gpt-5.4": { input: 5, cacheRead: 0.5, output: 22.5 },
+  "gpt-5.4-pro": { input: 60, cacheRead: 0, output: 270 },
+};
+
+const reducedLunaTerraRates: Record<string, ModelRateCard> = {
+  "gpt-5.6-terra": {
+    input: 2,
+    cacheRead: 0.2,
+    cacheWrite: 2.5,
+    output: 12,
+  },
+  "gpt-5.6-luna": {
+    input: 0.2,
+    cacheRead: 0.02,
+    cacheWrite: 0.25,
+    output: 1.2,
+  },
+};
+
+const reducedLunaTerraLongContextRates: Record<string, ModelRateCard> = {
+  "gpt-5.6-terra": {
+    input: 4,
+    cacheRead: 0.4,
+    cacheWrite: 5,
+    output: 18,
+  },
+  "gpt-5.6-luna": {
+    input: 0.4,
+    cacheRead: 0.04,
+    cacheWrite: 0.5,
+    output: 1.8,
+  },
+};
+
+const LONG_CONTEXT_THRESHOLD = 272_000;
+const OPENAI_LUNA_TERRA_PRICE_CUT = Date.parse("2026-07-30T20:00:00Z");
+
+export const counterfactualModelIDs = [
+  "gpt-5.6-sol",
+  "gpt-5.6-terra",
+  "gpt-5.6-luna",
+  "gpt-5.5",
+  "gpt-5.5-pro",
+  "gpt-5.4",
+  "gpt-5.4-mini",
+  "gpt-5.4-nano",
+  "gpt-5.4-pro",
+  "gpt-5.3-codex",
+  "gpt-5.2-codex",
+  "gpt-5.1-codex-max",
+  "gpt-5.1-codex",
+  "gpt-5.1-codex-mini",
+  "gpt-5-codex",
+  "claude-fable-5",
+  "claude-mythos-5",
+  "claude-opus-5",
+  "claude-opus-4-8",
+  "claude-opus-4-7",
+  "claude-opus-4-6",
+  "claude-opus-4-5",
+  "claude-opus-4-1",
+  "claude-sonnet-5",
+  "claude-sonnet-4-6",
+  "claude-sonnet-4-5",
+  "claude-haiku-4-5",
+  "claude-haiku-3-5",
+  "grok-4-5",
+  "kimi-k3",
+  "glm-5.2",
+] as const;
+
+export function modelRateCard(
+  model: string,
+  timestamp: number,
+  inputTokens: number,
+) {
+  const normalized = canonicalModelId(model);
+  const long = normalized.startsWith("gpt-5.") &&
+    inputTokens >= LONG_CONTEXT_THRESHOLD;
+  if (timestamp >= OPENAI_LUNA_TERRA_PRICE_CUT) {
+    const reducedRates = long
+      ? reducedLunaTerraLongContextRates[normalized]
+      : reducedLunaTerraRates[normalized];
+    if (reducedRates) return reducedRates;
+  }
+  if (long) return longContext[normalized];
+  if (normalized === "claude-sonnet-5") {
+    return timestamp < Date.parse("2026-09-01T00:00:00Z")
+      ? {
+        input: 2,
+        cacheWrite5m: 2.5,
+        cacheWrite1h: 4,
+        cacheRead: 0.2,
+        output: 10,
+      }
+      : {
+        input: 3,
+        cacheWrite5m: 3.75,
+        cacheWrite1h: 6,
+        cacheRead: 0.3,
+        output: 15,
+      };
+  }
+  return standard[normalized];
+}
+
+export function computeModelCallCost(
+  tokens: TokenUsage,
+  model: string,
+  timestamp: number,
+) {
+  const categorizedTokens = tokens.uncachedInput + tokens.cacheRead +
+    (tokens.cacheWrite ?? 0) + tokens.output + tokens.reasoning;
+  if (tokens.processed > 0 && categorizedTokens === 0) return undefined;
+
+  const rates = modelRateCard(model, timestamp, contextSize(tokens));
+  if (!rates) return undefined;
+
+  let cacheWriteCost = 0;
+  if (tokens.cacheWrite !== undefined) {
+    if (
+      tokens.cacheWrite5m !== undefined && tokens.cacheWrite1h !== undefined &&
+      tokens.cacheWrite5m + tokens.cacheWrite1h === tokens.cacheWrite &&
+      rates.cacheWrite5m !== undefined && rates.cacheWrite1h !== undefined
+    ) {
+      cacheWriteCost = tokens.cacheWrite5m * rates.cacheWrite5m +
+        tokens.cacheWrite1h * rates.cacheWrite1h;
+    } else if (rates.cacheWrite !== undefined) {
+      cacheWriteCost = tokens.cacheWrite * rates.cacheWrite;
+    } else if (
+      tokens.cacheWrite5m === undefined && tokens.cacheWrite1h === undefined &&
+      rates.cacheWrite5m !== undefined
+    ) {
+      // Sources with only a total cache-write count use the default 5-minute TTL.
+      cacheWriteCost = tokens.cacheWrite * rates.cacheWrite5m;
+    } else {
+      return undefined;
+    }
+  }
+  return (
+    tokens.uncachedInput * rates.input +
+    tokens.cacheRead * rates.cacheRead +
+    cacheWriteCost +
+    (tokens.output + tokens.reasoning) * rates.output
+  ) / 1_000_000;
+}


### PR DESCRIPTION
## Summary
- replace expandable session table rows with a routed agent-session transcript
- add collapsible turns, nested metric-colored navigation, relative path display, and expandable tool output
- add configurable counterfactual model and thinking-level cost estimates using shared pricing rates

## Verification
- `deno task check`
- `deno test src/server/pricing.test.ts src/server/cacheMissPricing.test.ts`
- `deno fmt --check src/client/main.tsx src/client/SessionsPage.tsx src/client/SessionDetailPage.tsx src/client/SessionDetailPage.css`