### PR TITLE
Refine estimated human work time

### DIFF
--- a/src/client/NewPage.tsx
+++ b/src/client/NewPage.tsx
@@ -23,40 +23,21 @@ export function NewPage() {
 
   useEffect(() => {
     let active = true;
-    let request = 0;
-
-    function load() {
-      const currentRequest = ++request;
-      setError(undefined);
-      getActivityOverview(search.range, search.harness).then((result) => {
-        if (active && currentRequest === request) {
-          setData(result);
-          setError(undefined);
-        }
-      }).catch((reason) => {
-        if (active && currentRequest === request) {
-          setError(
-            reason instanceof Error
-              ? reason.message
-              : "Unable to load overview",
-          );
-        }
-      });
-    }
-
-    function refreshVisibleOverview() {
-      if (document.visibilityState === "visible") load();
-    }
-
-    load();
-    const refreshInterval = window.setInterval(refreshVisibleOverview, 30_000);
-    window.addEventListener("focus", refreshVisibleOverview);
-    document.addEventListener("visibilitychange", refreshVisibleOverview);
+    setError(undefined);
+    getActivityOverview(search.range, search.harness).then((result) => {
+      if (active) {
+        setData(result);
+        setError(undefined);
+      }
+    }).catch((reason) => {
+      if (active) {
+        setError(
+          reason instanceof Error ? reason.message : "Unable to load overview",
+        );
+      }
+    });
     return () => {
       active = false;
-      window.clearInterval(refreshInterval);
-      window.removeEventListener("focus", refreshVisibleOverview);
-      document.removeEventListener("visibilitychange", refreshVisibleOverview);
     };
   }, [search.range, search.harness]);
 

--- a/src/client/new/WorkRhythm.css
+++ b/src/client/new/WorkRhythm.css
@@ -34,29 +34,10 @@
   align-items: flex-start;
 }
 
-.rhythm-title-line {
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.rhythm-title-line .mock-data-badge {
-  border: 1px solid #d8dfdc;
-  background: transparent;
-  color: #8c9793;
-  opacity: .72;
-}
-
 .work-rhythm-header h2 {
   margin: 0;
   font-size: 23px;
   letter-spacing: -.035em;
-}
-
-.work-rhythm-header p {
-  margin: 4px 0 0;
-  color: #5f6d68;
-  font: 10px/1.4 var(--mono);
 }
 
 .work-rhythm-header > strong {
@@ -66,13 +47,6 @@
   font-variant-numeric: tabular-nums;
   letter-spacing: -.04em;
   white-space: nowrap;
-}
-
-.work-rhythm-header > strong small {
-  color: var(--dashboard-muted);
-  font-size: 10px;
-  font-weight: 500;
-  letter-spacing: .02em;
 }
 
 .rhythm-charts {
@@ -101,12 +75,6 @@
   font: 650 10px var(--mono);
   letter-spacing: .09em;
   text-transform: uppercase;
-}
-
-.rhythm-subheading span {
-  color: #74817c;
-  font: 10px var(--mono);
-  text-align: right;
 }
 
 .weekday-chart {
@@ -536,8 +504,6 @@
 @media (max-width: 430px) {
   .work-rhythm-header { align-items: flex-start; }
   .work-rhythm-header > strong { font-size: 15px; }
-  .work-rhythm-header > strong small { display: block; margin-top: 3px; text-align: right; }
-  .rhythm-subheading span { max-width: 145px; }
   .day-explorer-header { align-items: flex-start; flex-direction: column; gap: 5px; }
   .rhythm-day-metrics { grid-template-columns: 1fr; }
 }

--- a/src/client/new/WorkRhythm.tsx
+++ b/src/client/new/WorkRhythm.tsx
@@ -50,8 +50,11 @@ function dateKey(date: Date) {
   ].join("-");
 }
 
-function formatDuration(minutes: number, decimalHours = false) {
-  if (decimalHours && minutes >= 60) return `${(minutes / 60).toFixed(1)}h`;
+function formatDuration(minutes: number, compactTotal = false) {
+  if (compactTotal && minutes > 24 * 60) {
+    return `${(minutes / (24 * 60)).toFixed(1)}d`;
+  }
+  if (compactTotal && minutes >= 60) return `${(minutes / 60).toFixed(1)}h`;
   const rounded = Math.round(minutes);
   if (rounded < 60) return `${rounded}m`;
   const hours = Math.floor(rounded / 60);
@@ -567,19 +570,9 @@ export function WorkRhythm({ data }: { data: WorkRhythmData }) {
     <section className="work-rhythm-module" aria-labelledby="work-rhythm-title">
       <div className="work-rhythm-overview">
         <header className="work-rhythm-header">
-          <div>
-            <div className="rhythm-title-line">
-              <h2 id="work-rhythm-title">Work</h2>
-            </div>
-            <p>
-              {data.methodology.initialMinutes} min initial/fallback · completion
-              gaps up to {data.methodology.completionGapTimeoutMinutes} min ·
-              overlaps counted once
-            </p>
-          </div>
-          <strong>
-            {formatDuration(data.estimatedActiveMinutes, true)}{" "}
-            <small>estimated</small>
+          <h2 id="work-rhythm-title">Estimated work</h2>
+          <strong title={formatDuration(data.estimatedActiveMinutes)}>
+            {formatDuration(data.estimatedActiveMinutes, true)}
           </strong>
         </header>
         <div className="rhythm-charts">
@@ -589,7 +582,6 @@ export function WorkRhythm({ data }: { data: WorkRhythmData }) {
           >
             <div className="rhythm-subheading">
               <h3 id="weekday-chart-title">By day</h3>
-              <span>Average per calendar occurrence</span>
             </div>
             <WeekdayChart data={data.weekdayActivity} />
           </section>
@@ -599,7 +591,6 @@ export function WorkRhythm({ data }: { data: WorkRhythmData }) {
           >
             <div className="rhythm-subheading">
               <h3 id="hourly-chart-title">By hour</h3>
-              <span>Distribution of estimated active time</span>
             </div>
             <HourlyChart data={data.hourlyActivity} />
             <div className="hourly-annotations">
@@ -608,7 +599,6 @@ export function WorkRhythm({ data }: { data: WorkRhythmData }) {
                   <i aria-hidden="true" />Peak: {hourRange(data.peakHour)}
                 </span>
               )}
-              <span>{Math.round(data.afterHoursShare * 100)}% after 8 PM</span>
             </div>
           </section>
         </div>

--- a/src/client/new/WorkRhythm.tsx
+++ b/src/client/new/WorkRhythm.tsx
@@ -572,8 +572,9 @@ export function WorkRhythm({ data }: { data: WorkRhythmData }) {
               <h2 id="work-rhythm-title">Work</h2>
             </div>
             <p>
-              {data.methodology.minutesBeforeTurn}{" "}
-              min before each user turn · overlapping time counted once
+              {data.methodology.initialMinutes} min initial/fallback · completion
+              gaps up to {data.methodology.completionGapTimeoutMinutes} min ·
+              overlaps counted once
             </p>
           </div>
           <strong>

--- a/src/client/new/workRhythmFixture.ts
+++ b/src/client/new/workRhythmFixture.ts
@@ -152,7 +152,12 @@ const totalMinutes = hourlyMinutes.reduce((total, minutes) => total + minutes, 0
 export const workRhythmFixture: WorkRhythmData = {
   range: { start: "2026-07-08", end: "2026-08-06" },
   estimatedActiveMinutes: totalMinutes,
-  methodology: { minutesBeforeTurn: 5, overlapsCountedOnce: true },
+  methodology: {
+    initialMinutes: 5,
+    completionGapTimeoutMinutes: 10,
+    fallbackMinutes: 5,
+    overlapsCountedOnce: true,
+  },
   weekdayActivity: [
     { weekday: 1, label: "Mon", averageMinutes: 163, totalMinutes: 652, occurrences: 4, activeOccurrences: 4 },
     { weekday: 2, label: "Tue", averageMinutes: 84, totalMinutes: 336, occurrences: 4, activeOccurrences: 3 },

--- a/src/server/conversationCompatibilityRepository.test.ts
+++ b/src/server/conversationCompatibilityRepository.test.ts
@@ -151,7 +151,11 @@ Deno.test("conversation compatibility repository preserves linear read contracts
     );
     strictEqual(compatibility.listToolCalls(0, 100, "pi").length, 1);
     strictEqual(compatibility.listCacheMisses(undefined, "pi").length, 1);
-    strictEqual(compatibility.listOverviewRollups(0, "pi").length, 1);
+    const legacyOverview = legacy.listOverviewRollups(0, "pi");
+    const compatibilityOverview = compatibility.listOverviewRollups(0, "pi");
+    strictEqual(compatibilityOverview.length, 1);
+    deepStrictEqual(legacyOverview[0].rootTurnStartedAts, [10, 20]);
+    deepStrictEqual(compatibilityOverview[0].rootTurnStartedAts, [10, 20]);
     strictEqual(compatibility.listUsageRollups(undefined, "pi").length, 1);
   } finally {
     db.close();

--- a/src/server/conversationCompatibilityRepository.test.ts
+++ b/src/server/conversationCompatibilityRepository.test.ts
@@ -154,8 +154,21 @@ Deno.test("conversation compatibility repository preserves linear read contracts
     const legacyOverview = legacy.listOverviewRollups(0, "pi");
     const compatibilityOverview = compatibility.listOverviewRollups(0, "pi");
     strictEqual(compatibilityOverview.length, 1);
-    deepStrictEqual(legacyOverview[0].rootTurnStartedAts, [10, 20]);
-    deepStrictEqual(compatibilityOverview[0].rootTurnStartedAts, [10, 20]);
+    const expectedRootIntervals = [{
+      startedAt: 10,
+      executionEndAt: 12,
+    }, {
+      startedAt: 20,
+      executionEndAt: 22,
+    }];
+    deepStrictEqual(
+      legacyOverview[0].rootExecutionIntervals,
+      expectedRootIntervals,
+    );
+    deepStrictEqual(
+      compatibilityOverview[0].rootExecutionIntervals,
+      expectedRootIntervals,
+    );
     strictEqual(compatibility.listUsageRollups(undefined, "pi").length, 1);
   } finally {
     db.close();

--- a/src/server/conversationCompatibilityRepository.ts
+++ b/src/server/conversationCompatibilityRepository.ts
@@ -678,19 +678,35 @@ export class ConversationCompatibilityRepository {
         ), 0) AS subagent_spend,
         COALESCE(c.public_id, c.external_id) AS session_public_id,
         COALESCE((
-          SELECT json_group_array(root_turn.started_at)
-          FROM conversation_turns root_turn
-          WHERE root_turn.conversation_id = c.id
-            AND EXISTS (
-              SELECT 1
-              FROM conversation_model_calls root_call
-              WHERE root_call.turn_id = root_turn.id
-                AND COALESCE(root_call.source_call_id, '')
-                  NOT LIKE 'context-operation:%'
-                AND COALESCE(root_call.source_call_id, '')
-                  NOT LIKE 'unmeasured:%'
-            )
-        ), '[]') AS root_turn_starts_json
+          SELECT json_group_array(json_object(
+            'startedAt', measured_turn.started_at,
+            'executionEndAt', measured_turn.execution_end_at
+          ))
+          FROM (
+            SELECT root_turn.started_at,
+              MAX(
+                root_turn.started_at,
+                MAX(COALESCE(
+                  root_tool.completed_at,
+                  root_tool.started_at,
+                  root_call.completed_at,
+                  root_call.started_at
+                ))
+              ) AS execution_end_at
+            FROM conversation_turns root_turn
+            JOIN conversation_model_calls root_call
+              ON root_call.turn_id = root_turn.id
+            LEFT JOIN conversation_tool_events root_tool
+              ON root_tool.model_call_id = root_call.id
+            WHERE root_turn.conversation_id = c.id
+              AND COALESCE(root_call.source_call_id, '')
+                NOT LIKE 'context-operation:%'
+              AND COALESCE(root_call.source_call_id, '')
+                NOT LIKE 'unmeasured:%'
+            GROUP BY root_turn.id
+            ORDER BY root_turn.started_at, root_turn.ordinal
+          ) measured_turn
+        ), '[]') AS root_execution_intervals_json
       FROM conversation_rollups cr
       JOIN conversations c ON c.id = cr.conversation_id
       JOIN sources so ON so.id = c.source_id
@@ -708,11 +724,11 @@ export class ConversationCompatibilityRepository {
       overview_json: string;
       subagent_spend: number;
       session_public_id: string;
-      root_turn_starts_json: string;
+      root_execution_intervals_json: string;
     }>;
     return rows.map((row) => ({
       rootSessionID: row.id,
-      rootTurnStartedAts: JSON.parse(row.root_turn_starts_json),
+      rootExecutionIntervals: JSON.parse(row.root_execution_intervals_json),
       sessionID: row.session_public_id,
       title: row.title,
       harness: row.harness,

--- a/src/server/conversationCompatibilityRepository.ts
+++ b/src/server/conversationCompatibilityRepository.ts
@@ -676,7 +676,21 @@ export class ConversationCompatibilityRepository {
           JOIN conversation_rollups child
             ON child.conversation_id = descendants.id
         ), 0) AS subagent_spend,
-        COALESCE(c.public_id, c.external_id) AS session_public_id
+        COALESCE(c.public_id, c.external_id) AS session_public_id,
+        COALESCE((
+          SELECT json_group_array(root_turn.started_at)
+          FROM conversation_turns root_turn
+          WHERE root_turn.conversation_id = c.id
+            AND EXISTS (
+              SELECT 1
+              FROM conversation_model_calls root_call
+              WHERE root_call.turn_id = root_turn.id
+                AND COALESCE(root_call.source_call_id, '')
+                  NOT LIKE 'context-operation:%'
+                AND COALESCE(root_call.source_call_id, '')
+                  NOT LIKE 'unmeasured:%'
+            )
+        ), '[]') AS root_turn_starts_json
       FROM conversation_rollups cr
       JOIN conversations c ON c.id = cr.conversation_id
       JOIN sources so ON so.id = c.source_id
@@ -694,9 +708,11 @@ export class ConversationCompatibilityRepository {
       overview_json: string;
       subagent_spend: number;
       session_public_id: string;
+      root_turn_starts_json: string;
     }>;
     return rows.map((row) => ({
       rootSessionID: row.id,
+      rootTurnStartedAts: JSON.parse(row.root_turn_starts_json),
       sessionID: row.session_public_id,
       title: row.title,
       harness: row.harness,

--- a/src/server/overviewAnalytics.ts
+++ b/src/server/overviewAnalytics.ts
@@ -7,8 +7,11 @@ import type { SessionOverviewRollup } from "./sessionRollups.ts";
 
 export type StoredOverviewRollup = {
   rootSessionID: number;
-  /** Starts of measured turns on the root session, excluding descendants. */
-  rootTurnStartedAts?: number[];
+  /** Measured turns on the root session, excluding descendants. */
+  rootExecutionIntervals?: Array<{
+    startedAt: number;
+    executionEndAt: number;
+  }>;
   /** Public/external ID accepted by /sessions/$harness/$sessionId. */
   sessionID?: string;
   title?: string;

--- a/src/server/overviewAnalytics.ts
+++ b/src/server/overviewAnalytics.ts
@@ -7,6 +7,8 @@ import type { SessionOverviewRollup } from "./sessionRollups.ts";
 
 export type StoredOverviewRollup = {
   rootSessionID: number;
+  /** Starts of measured turns on the root session, excluding descendants. */
+  rootTurnStartedAts?: number[];
   /** Public/external ID accepted by /sessions/$harness/$sessionId. */
   sessionID?: string;
   title?: string;

--- a/src/server/sessionRepository.test.ts
+++ b/src/server/sessionRepository.test.ts
@@ -536,6 +536,15 @@ Deno.test("atomically replaces trees with root-scoped public child IDs", () => {
       repository.listUsageRollups(undefined, "claude-code").length,
       2,
     );
+    const overviewRollups = repository.listOverviewRollups(
+      0,
+      "claude-code",
+    );
+    strictEqual(overviewRollups.length, 2);
+    for (const rollup of overviewRollups) {
+      deepStrictEqual(rollup.rootTurnStartedAts, [10]);
+      strictEqual(rollup.overview.executionIntervals.length, 2);
+    }
     deepStrictEqual(
       repository.listSubagentUsage(undefined, "claude-code").map((row) => ({
         input: row.input,

--- a/src/server/sessionRepository.test.ts
+++ b/src/server/sessionRepository.test.ts
@@ -542,7 +542,10 @@ Deno.test("atomically replaces trees with root-scoped public child IDs", () => {
     );
     strictEqual(overviewRollups.length, 2);
     for (const rollup of overviewRollups) {
-      deepStrictEqual(rollup.rootTurnStartedAts, [10]);
+      deepStrictEqual(rollup.rootExecutionIntervals, [{
+        startedAt: 10,
+        executionEndAt: 12,
+      }]);
       strictEqual(rollup.overview.executionIntervals.length, 2);
     }
     deepStrictEqual(

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -1210,7 +1210,21 @@ export class SessionRepository {
       SELECT sr.root_session_id, sr.overview_json, s.title, so.harness,
         COALESCE(sr.subagent_computed_cost, sr.subagent_reported_cost, 0)
           AS subagent_spend,
-        COALESCE(ss.public_id, ss.external_id) AS session_public_id
+        COALESCE(ss.public_id, ss.external_id) AS session_public_id,
+        COALESCE((
+          SELECT json_group_array(root_turn.started_at)
+          FROM turns root_turn
+          WHERE root_turn.session_id = sr.root_session_id
+            AND EXISTS (
+              SELECT 1
+              FROM model_calls root_call
+              WHERE root_call.turn_id = root_turn.id
+                AND COALESCE(root_call.source_call_id, '')
+                  NOT LIKE 'context-operation:%'
+                AND COALESCE(root_call.source_call_id, '')
+                  NOT LIKE 'unmeasured:%'
+            )
+        ), '[]') AS root_turn_starts_json
       FROM session_rollups sr
       JOIN sessions s ON s.source_session_id = sr.root_session_id
       JOIN source_sessions ss ON ss.id = sr.root_session_id
@@ -1225,9 +1239,11 @@ export class SessionRepository {
       harness: Harness;
       subagent_spend: number;
       session_public_id: string;
+      root_turn_starts_json: string;
     }>;
     return rows.map((row) => ({
       rootSessionID: row.root_session_id,
+      rootTurnStartedAts: JSON.parse(row.root_turn_starts_json),
       sessionID: row.session_public_id,
       title: row.title,
       harness: row.harness,

--- a/src/server/sessionRepository.ts
+++ b/src/server/sessionRepository.ts
@@ -1212,19 +1212,34 @@ export class SessionRepository {
           AS subagent_spend,
         COALESCE(ss.public_id, ss.external_id) AS session_public_id,
         COALESCE((
-          SELECT json_group_array(root_turn.started_at)
-          FROM turns root_turn
-          WHERE root_turn.session_id = sr.root_session_id
-            AND EXISTS (
-              SELECT 1
-              FROM model_calls root_call
-              WHERE root_call.turn_id = root_turn.id
-                AND COALESCE(root_call.source_call_id, '')
-                  NOT LIKE 'context-operation:%'
-                AND COALESCE(root_call.source_call_id, '')
-                  NOT LIKE 'unmeasured:%'
-            )
-        ), '[]') AS root_turn_starts_json
+          SELECT json_group_array(json_object(
+            'startedAt', measured_turn.started_at,
+            'executionEndAt', measured_turn.execution_end_at
+          ))
+          FROM (
+            SELECT root_turn.started_at,
+              MAX(
+                root_turn.started_at,
+                MAX(COALESCE(
+                  root_tool.completed_at,
+                  root_tool.started_at,
+                  root_call.completed_at,
+                  root_call.started_at
+                ))
+              ) AS execution_end_at
+            FROM turns root_turn
+            JOIN model_calls root_call ON root_call.turn_id = root_turn.id
+            LEFT JOIN tool_events root_tool
+              ON root_tool.model_call_id = root_call.id
+            WHERE root_turn.session_id = sr.root_session_id
+              AND COALESCE(root_call.source_call_id, '')
+                NOT LIKE 'context-operation:%'
+              AND COALESCE(root_call.source_call_id, '')
+                NOT LIKE 'unmeasured:%'
+            GROUP BY root_turn.id
+            ORDER BY root_turn.started_at, root_turn.ordinal
+          ) measured_turn
+        ), '[]') AS root_execution_intervals_json
       FROM session_rollups sr
       JOIN sessions s ON s.source_session_id = sr.root_session_id
       JOIN source_sessions ss ON ss.id = sr.root_session_id
@@ -1239,11 +1254,11 @@ export class SessionRepository {
       harness: Harness;
       subagent_spend: number;
       session_public_id: string;
-      root_turn_starts_json: string;
+      root_execution_intervals_json: string;
     }>;
     return rows.map((row) => ({
       rootSessionID: row.root_session_id,
-      rootTurnStartedAts: JSON.parse(row.root_turn_starts_json),
+      rootExecutionIntervals: JSON.parse(row.root_execution_intervals_json),
       sessionID: row.session_public_id,
       title: row.title,
       harness: row.harness,

--- a/src/server/workRhythm.test.ts
+++ b/src/server/workRhythm.test.ts
@@ -17,11 +17,13 @@ function root(
     title?: string;
     unpriced?: boolean;
     model?: string;
+    rootTurns?: number[];
   } = {},
 ): StoredOverviewRollup {
   const first = Math.min(...turns);
   return {
     rootSessionID: options.numericID ?? 1,
+    rootTurnStartedAts: options.rootTurns ?? turns,
     sessionID: id,
     harness: options.harness ?? "pi",
     title: options.title,
@@ -163,14 +165,19 @@ Deno.test("work rhythm ranges contain 30 or 90 local dates across DST", () => {
   }
 });
 
-Deno.test("work rhythm combines subagent and cross-harness overlap; filtered roots stay isolated", () => {
+Deno.test("work rhythm excludes subagent turns and unions root turns across harnesses", () => {
   const start = utc("2026-07-01T00:00:00");
   const end = utc("2026-07-01T23:59:59");
   const at = utc("2026-07-01T10:00:00");
-  // Repeated execution intervals in a root represent root and descendant turns.
-  const pi = root("pi-root", [at, at + 3 * minute], { harness: "pi" });
-  const codex = root("codex-root", [at + minute], { numericID: 2, harness: "codex" });
-  strictEqual(aggregateWorkRhythm([pi, codex], start, end, "UTC").estimatedActiveMinutes, 8);
-  strictEqual(aggregateWorkRhythm([pi], start, end, "UTC").estimatedActiveMinutes, 8);
+  const pi = root("pi-root", [at, at + 3 * minute], {
+    harness: "pi",
+    rootTurns: [at],
+  });
+  const codex = root("codex-root", [at + minute], {
+    numericID: 2,
+    harness: "codex",
+  });
+  strictEqual(aggregateWorkRhythm([pi, codex], start, end, "UTC").estimatedActiveMinutes, 6);
+  strictEqual(aggregateWorkRhythm([pi], start, end, "UTC").estimatedActiveMinutes, 5);
   strictEqual(aggregateWorkRhythm([codex], start, end, "UTC").estimatedActiveMinutes, 5);
 });

--- a/src/server/workRhythm.test.ts
+++ b/src/server/workRhythm.test.ts
@@ -17,13 +17,16 @@ function root(
     title?: string;
     unpriced?: boolean;
     model?: string;
-    rootTurns?: number[];
+    rootIntervals?: Array<{ startedAt: number; executionEndAt: number }>;
   } = {},
 ): StoredOverviewRollup {
   const first = Math.min(...turns);
   return {
     rootSessionID: options.numericID ?? 1,
-    rootTurnStartedAts: options.rootTurns ?? turns,
+    rootExecutionIntervals: options.rootIntervals ?? turns.map((startedAt) => ({
+      startedAt,
+      executionEndAt: startedAt,
+    })),
     sessionID: id,
     harness: options.harness ?? "pi",
     title: options.title,
@@ -81,6 +84,90 @@ Deno.test("work rhythm unions isolated, overlapping, duplicate, and touching tur
     33,
   );
   workRhythmDataSchema.parse(result);
+});
+
+Deno.test("work rhythm counts completion-to-follow-up gaps within the timeout", () => {
+  const start = utc("2026-07-01T00:00:00");
+  const end = utc("2026-07-01T23:59:59");
+  const first = utc("2026-07-01T10:00:00");
+
+  const shortReview = aggregateWorkRhythm([
+    root("short-review", [first, first + 15 * minute], {
+      rootIntervals: [{
+        startedAt: first,
+        executionEndAt: first + 12 * minute,
+      }, {
+        startedAt: first + 15 * minute,
+        executionEndAt: first + 15 * minute,
+      }],
+    }),
+  ], start, end, "UTC");
+  strictEqual(shortReview.estimatedActiveMinutes, 8);
+
+  const longerReview = aggregateWorkRhythm([
+    root("longer-review", [first, first + 21 * minute], {
+      rootIntervals: [{
+        startedAt: first,
+        executionEndAt: first + 12 * minute,
+      }, {
+        startedAt: first + 21 * minute,
+        executionEndAt: first + 21 * minute,
+      }],
+    }),
+  ], start, end, "UTC");
+  strictEqual(longerReview.estimatedActiveMinutes, 14);
+});
+
+Deno.test("work rhythm falls back to five minutes after the gap timeout", () => {
+  const start = utc("2026-07-01T00:00:00");
+  const end = utc("2026-07-01T23:59:59");
+  const first = utc("2026-07-01T10:00:00");
+  const followUp = first + 42 * minute;
+  const result = aggregateWorkRhythm([
+    root("returned-later", [first, followUp], {
+      rootIntervals: [{
+        startedAt: first,
+        executionEndAt: first + 12 * minute,
+      }, {
+        startedAt: followUp,
+        executionEndAt: followUp,
+      }],
+    }),
+  ], start, end, "UTC");
+
+  strictEqual(result.estimatedActiveMinutes, 10);
+});
+
+Deno.test("work rhythm gives mid-run turns a clamped fallback window", () => {
+  const start = utc("2026-07-01T00:00:00");
+  const end = utc("2026-07-01T23:59:59");
+  const first = utc("2026-07-01T10:00:00");
+
+  const midRun = aggregateWorkRhythm([
+    root("mid-run", [first, first + 8 * minute], {
+      rootIntervals: [{
+        startedAt: first,
+        executionEndAt: first + 12 * minute,
+      }, {
+        startedAt: first + 8 * minute,
+        executionEndAt: first + 8 * minute,
+      }],
+    }),
+  ], start, end, "UTC");
+  strictEqual(midRun.estimatedActiveMinutes, 10);
+
+  const immediate = aggregateWorkRhythm([
+    root("immediate-mid-run", [first, first + minute], {
+      rootIntervals: [{
+        startedAt: first,
+        executionEndAt: first + 12 * minute,
+      }, {
+        startedAt: first + minute,
+        executionEndAt: first + minute,
+      }],
+    }),
+  ], start, end, "UTC");
+  strictEqual(immediate.estimatedActiveMinutes, 6);
 });
 
 Deno.test("work rhythm clips boundaries and splits merged activity across midnight and hours", () => {
@@ -171,7 +258,7 @@ Deno.test("work rhythm excludes subagent turns and unions root turns across harn
   const at = utc("2026-07-01T10:00:00");
   const pi = root("pi-root", [at, at + 3 * minute], {
     harness: "pi",
-    rootTurns: [at],
+    rootIntervals: [{ startedAt: at, executionEndAt: at }],
   });
   const codex = root("codex-root", [at + minute], {
     numericID: 2,

--- a/src/server/workRhythm.ts
+++ b/src/server/workRhythm.ts
@@ -5,8 +5,12 @@ import type {
 } from "../shared/sessionSchemas.ts";
 import type { StoredOverviewRollup } from "./overviewAnalytics.ts";
 
-export const WORK_RHYTHM_MINUTES_BEFORE_TURN = 5;
-const TURN_WINDOW_MS = WORK_RHYTHM_MINUTES_BEFORE_TURN * 60_000;
+export const WORK_RHYTHM_INITIAL_MINUTES = 5;
+export const WORK_RHYTHM_GAP_TIMEOUT_MINUTES = 10;
+export const WORK_RHYTHM_FALLBACK_MINUTES = 5;
+const INITIAL_WINDOW_MS = WORK_RHYTHM_INITIAL_MINUTES * 60_000;
+const GAP_TIMEOUT_MS = WORK_RHYTHM_GAP_TIMEOUT_MINUTES * 60_000;
+const FALLBACK_WINDOW_MS = WORK_RHYTHM_FALLBACK_MINUTES * 60_000;
 const WEEKDAYS = [
   { weekday: 1 as const, label: "Mon" },
   { weekday: 2 as const, label: "Tue" },
@@ -52,6 +56,42 @@ function mergeIntervals(intervals: Interval[], start: number, end: number) {
     }
   }
   return merged;
+}
+
+function estimatedWorkIntervals(root: StoredOverviewRollup): Interval[] {
+  const turns = (root.rootExecutionIntervals ?? []).toSorted((a, b) =>
+    a.startedAt - b.startedAt || a.executionEndAt - b.executionEndAt
+  );
+  return turns.map((turn, index) => {
+    if (index === 0) {
+      return {
+        start: turn.startedAt - INITIAL_WINDOW_MS,
+        end: turn.startedAt,
+      };
+    }
+
+    const previous = turns[index - 1];
+    const previousEnd = Math.max(
+      previous.startedAt,
+      previous.executionEndAt,
+    );
+    if (turn.startedAt < previousEnd) {
+      return {
+        start: Math.max(
+          previous.startedAt,
+          turn.startedAt - FALLBACK_WINDOW_MS,
+        ),
+        end: turn.startedAt,
+      };
+    }
+    if (turn.startedAt - previousEnd <= GAP_TIMEOUT_MS) {
+      return { start: previousEnd, end: turn.startedAt };
+    }
+    return {
+      start: turn.startedAt - FALLBACK_WINDOW_MS,
+      end: turn.startedAt,
+    };
+  });
 }
 
 function overlapMs(intervals: Interval[], span: Interval) {
@@ -107,12 +147,7 @@ export function aggregateWorkRhythm(
     date = date.add({ days: 1 })
   ) dates.push(date);
 
-  const intervals = roots.flatMap((root) =>
-    (root.rootTurnStartedAts ?? []).map((startedAt) => ({
-      start: startedAt - TURN_WINDOW_MS,
-      end: startedAt,
-    }))
-  );
+  const intervals = roots.flatMap(estimatedWorkIntervals);
   const merged = mergeIntervals(intervals, start, end);
   const totalMs = merged.reduce(
     (sum, interval) => sum + interval.end - interval.start,
@@ -282,7 +317,12 @@ export function aggregateWorkRhythm(
   return {
     range: { start: startDate.toString(), end: endDate.toString() },
     estimatedActiveMinutes: totalMs / 60_000,
-    methodology: { minutesBeforeTurn: 5, overlapsCountedOnce: true },
+    methodology: {
+      initialMinutes: WORK_RHYTHM_INITIAL_MINUTES,
+      completionGapTimeoutMinutes: WORK_RHYTHM_GAP_TIMEOUT_MINUTES,
+      fallbackMinutes: WORK_RHYTHM_FALLBACK_MINUTES,
+      overlapsCountedOnce: true,
+    },
     weekdayActivity,
     hourlyActivity,
     afterHoursShare: totalMs === 0

--- a/src/server/workRhythm.ts
+++ b/src/server/workRhythm.ts
@@ -108,9 +108,9 @@ export function aggregateWorkRhythm(
   ) dates.push(date);
 
   const intervals = roots.flatMap((root) =>
-    root.overview.executionIntervals.map((turn) => ({
-      start: turn.startedAt - TURN_WINDOW_MS,
-      end: turn.startedAt,
+    (root.rootTurnStartedAts ?? []).map((startedAt) => ({
+      start: startedAt - TURN_WINDOW_MS,
+      end: startedAt,
     }))
   );
   const merged = mergeIntervals(intervals, start, end);

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -395,7 +395,9 @@ export const workRhythmDataSchema = z.object({
   range: z.object({ start: z.string(), end: z.string() }),
   estimatedActiveMinutes: z.number().nonnegative(),
   methodology: z.object({
-    minutesBeforeTurn: z.literal(5),
+    initialMinutes: z.literal(5),
+    completionGapTimeoutMinutes: z.literal(10),
+    fallbackMinutes: z.literal(5),
     overlapsCountedOnce: z.literal(true),
   }),
   weekdayActivity: z.array(z.object({


### PR DESCRIPTION
## Why
The fixed five-minute window before every turn can overcount quick follow-ups and agent execution while missing longer, active review periods.

## Logic
- Count five minutes before the first root turn.
- Count the actual completion-to-follow-up gap when it is at most ten minutes.
- Use a five-minute fallback after longer gaps and for mid-run follow-ups, clamped to the previous user turn.
- Exclude subagent turns and merge overlapping activity globally.

## Examples
- Agent finishes 3 minutes before a follow-up: 5m initial + 3m review = 8m.
- Agent finishes 9 minutes before a follow-up: 5m initial + 9m review = 14m.
- User returns 30 minutes after completion: 5m initial + 5m fallback = 10m.
- User follows up 9 minutes into an active run: 5m initial + 5m fallback = 10m.

## Verification
- 19 targeted tests passed.
- Server and client type checks passed.