### PR TITLE
Add overview copy and screenshot actions

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -7,6 +7,7 @@
     "hono": "npm:hono@4.12.29",
     "hono/cors": "npm:hono@4.12.29/cors",
     "hono/deno": "npm:hono@4.12.29/deno",
+    "html-to-image": "npm:html-to-image@1.11.13",
     "lucide-react": "npm:lucide-react@1.25.0",
     "pretty-ms": "npm:pretty-ms@9.3.0",
     "react": "npm:react@19.2.7",

--- a/deno.lock
+++ b/deno.lock
@@ -8,6 +8,7 @@
     "npm:concurrently@10.0.3": "10.0.3",
     "npm:dbmate@^2.28.0": "2.34.1",
     "npm:hono@4.12.29": "4.12.29",
+    "npm:html-to-image@1.11.13": "1.11.13",
     "npm:lucide-react@1.25.0": "1.25.0_react@19.2.7",
     "npm:pretty-ms@9.3.0": "9.3.0",
     "npm:react-dom@19.2.7": "19.2.7_react@19.2.7",
@@ -841,6 +842,9 @@
     "hono@4.12.29": {
       "integrity": "sha512-1hNiRjawYrLq/4m3DQQjPGFg0VZkk4RjQJDff/excI6Dm9BiL75qxGrd7/c6YOxPdq6AscP3LiXhQ6fKFC1Waw=="
     },
+    "html-to-image@1.11.13": {
+      "integrity": "sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg=="
+    },
     "immer@10.2.0": {
       "integrity": "sha512-d/+XTN3zfODyjr89gM3mPq1WNX2B8pYsu7eORitdwyA2sBubnTl3laYlBk4sXY5FUa5qTZGBDPJICVbvqzjlbw=="
     },
@@ -1294,6 +1298,7 @@
       "npm:@types/react@19.2.17",
       "npm:@vitejs/plugin-react@6.0.3",
       "npm:hono@4.12.29",
+      "npm:html-to-image@1.11.13",
       "npm:lucide-react@1.25.0",
       "npm:pretty-ms@9.3.0",
       "npm:react-dom@19.2.7",

--- a/src/client/NewPage.tsx
+++ b/src/client/NewPage.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useEffect, useState } from "react";
+import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { getRouteApi } from "@tanstack/react-router";
 import type {
   ActivityOverviewResponse,
@@ -7,11 +7,15 @@ import type {
 import { getActivityOverview, getHarnesses } from "./api.ts";
 import { SiteHeader } from "./SiteHeader.tsx";
 import "./NewPage.css";
-import { OverviewToolbar } from "./new/OverviewToolbar.tsx";
+import {
+  OverviewToolbar,
+  type ScreenshotState,
+} from "./new/OverviewToolbar.tsx";
 import { UsageOverview } from "./new/UsageOverview.tsx";
 import { SessionShape } from "./new/SessionShape.tsx";
 import { CacheOverview } from "./new/CacheOverview.tsx";
 import { RecentSessions } from "./new/RecentSessions.tsx";
+import { copyElementScreenshot } from "./copyScreenshot.ts";
 
 const route = getRouteApi("/");
 const WorkRhythm = lazy(() =>
@@ -47,6 +51,10 @@ export function NewPage() {
   }>();
   const [error, setError] = useState<string>();
   const [harnesses, setHarnesses] = useState<SessionSummary["harness"][]>([]);
+  const [screenshotState, setScreenshotState] = useState<ScreenshotState>(
+    "idle",
+  );
+  const overviewRef = useRef<HTMLElement>(null);
   const data = loadedOverview?.data;
 
   useEffect(() => {
@@ -93,6 +101,20 @@ export function NewPage() {
     });
   }
 
+  async function copyScreenshot() {
+    const element = overviewRef.current;
+    if (!element || screenshotState === "capturing") return;
+    setScreenshotState("capturing");
+    try {
+      await copyElementScreenshot(element);
+      setScreenshotState("copied");
+      globalThis.setTimeout(() => setScreenshotState("idle"), 2_000);
+    } catch {
+      setScreenshotState("error");
+      globalThis.setTimeout(() => setScreenshotState("idle"), 3_000);
+    }
+  }
+
   const selectedDate = data
     ? calendarDate(search.date, data.workRhythm.range)
     : undefined;
@@ -103,7 +125,7 @@ export function NewPage() {
   }, [search.date, selectedDate]);
 
   return (
-    <main className="new-page">
+    <main className="new-page" ref={overviewRef}>
       <SiteHeader
         active="overview"
         action={
@@ -113,6 +135,9 @@ export function NewPage() {
             harnesses={harnesses}
             onRangeChange={(range) => update({ range })}
             onHarnessChange={(harness) => update({ harness })}
+            screenshotState={screenshotState}
+            screenshotDisabled={!data || Boolean(error)}
+            onScreenshot={copyScreenshot}
           />
         }
       />

--- a/src/client/NewPage.tsx
+++ b/src/client/NewPage.tsx
@@ -2,12 +2,15 @@ import { lazy, Suspense, useEffect, useRef, useState } from "react";
 import { getRouteApi } from "@tanstack/react-router";
 import type {
   ActivityOverviewResponse,
+  SessionShapeResponse,
   SessionSummary,
+  TtlMissMetrics,
 } from "../shared/sessionSchemas.ts";
 import { getActivityOverview, getHarnesses } from "./api.ts";
 import { SiteHeader } from "./SiteHeader.tsx";
 import "./NewPage.css";
 import {
+  type CopyReportState,
   OverviewToolbar,
   type ScreenshotState,
 } from "./new/OverviewToolbar.tsx";
@@ -16,6 +19,7 @@ import { SessionShape } from "./new/SessionShape.tsx";
 import { CacheOverview } from "./new/CacheOverview.tsx";
 import { RecentSessions } from "./new/RecentSessions.tsx";
 import { copyElementScreenshot } from "./copyScreenshot.ts";
+import { buildOverviewReport } from "./overviewReport.ts";
 
 const route = getRouteApi("/");
 const WorkRhythm = lazy(() =>
@@ -33,6 +37,22 @@ const SessionDiagnostics = lazy(() =>
     default: SessionDiagnostics,
   }))
 );
+
+async function copyText(value: string) {
+  if (navigator.clipboard && globalThis.isSecureContext) {
+    await navigator.clipboard.writeText(value);
+    return;
+  }
+  const textarea = document.createElement("textarea");
+  textarea.value = value;
+  textarea.style.position = "fixed";
+  textarea.style.opacity = "0";
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand("copy");
+  textarea.remove();
+  if (!copied) throw new Error("Clipboard access is unavailable");
+}
 
 function calendarDate(
   date: string | undefined,
@@ -54,8 +74,31 @@ export function NewPage() {
   const [screenshotState, setScreenshotState] = useState<ScreenshotState>(
     "idle",
   );
-  const overviewRef = useRef<HTMLElement>(null);
-  const data = loadedOverview?.data;
+  const [copyReportState, setCopyReportState] = useState<CopyReportState>(
+    "idle",
+  );
+  const [loadedSessionShape, setLoadedSessionShape] = useState<{
+    range: 30 | 90;
+    harness: string;
+    data: SessionShapeResponse;
+  }>();
+  const [loadedCacheMisses, setLoadedCacheMisses] = useState<{
+    range: 30 | 90;
+    harness: string;
+    data: TtlMissMetrics;
+  }>();
+  const screenshotRef = useRef<HTMLDivElement>(null);
+  const data = loadedOverview?.range === search.range &&
+      loadedOverview.harness === search.harness
+    ? loadedOverview.data
+    : undefined;
+  const sessionShapeIsCurrent = loadedSessionShape?.range === search.range &&
+    loadedSessionShape.harness === search.harness;
+  const cacheMissesAreCurrent = loadedCacheMisses?.range === search.range &&
+    loadedCacheMisses.harness === search.harness;
+  const reportReady = Boolean(
+    data && sessionShapeIsCurrent && cacheMissesAreCurrent,
+  );
 
   useEffect(() => {
     let active = true;
@@ -101,8 +144,28 @@ export function NewPage() {
     });
   }
 
+  async function copyReport() {
+    if (
+      !data || !loadedSessionShape || !sessionShapeIsCurrent ||
+      !loadedCacheMisses || !cacheMissesAreCurrent
+    ) return;
+    try {
+      await copyText(buildOverviewReport({
+        overview: data,
+        sessionShape: loadedSessionShape.data,
+        cacheMisses: loadedCacheMisses.data,
+        harness: search.harness,
+      }));
+      setCopyReportState("copied");
+      globalThis.setTimeout(() => setCopyReportState("idle"), 2_000);
+    } catch {
+      setCopyReportState("error");
+      globalThis.setTimeout(() => setCopyReportState("idle"), 3_000);
+    }
+  }
+
   async function copyScreenshot() {
-    const element = overviewRef.current;
+    const element = screenshotRef.current;
     if (!element || screenshotState === "capturing") return;
     setScreenshotState("capturing");
     try {
@@ -125,7 +188,7 @@ export function NewPage() {
   }, [search.date, selectedDate]);
 
   return (
-    <main className="new-page" ref={overviewRef}>
+    <main className="new-page">
       <SiteHeader
         active="overview"
         action={
@@ -135,6 +198,9 @@ export function NewPage() {
             harnesses={harnesses}
             onRangeChange={(range) => update({ range })}
             onHarnessChange={(harness) => update({ harness })}
+            copyReportState={copyReportState}
+            copyReportDisabled={!reportReady || Boolean(error)}
+            onCopyReport={copyReport}
             screenshotState={screenshotState}
             screenshotDisabled={!data || Boolean(error)}
             onScreenshot={copyScreenshot}
@@ -142,50 +208,78 @@ export function NewPage() {
         }
       />
 
-      <section className="new-overview-panel">
-        {error && <div className="new-overview-error">{error}</div>}
+      <div className="new-overview-screenshot" ref={screenshotRef}>
+        <section className="new-overview-panel">
+          {error && <div className="new-overview-error">{error}</div>}
 
-        <div className="new-overview-grid">
-          <div className="new-overview-left">
-            <UsageOverview data={data} />
-            <SessionShape range={search.range} harness={search.harness} />
+          <div className="new-overview-grid">
+            <div className="new-overview-left">
+              <UsageOverview data={data} />
+              <SessionShape
+                range={search.range}
+                harness={search.harness}
+                onDataChange={(sessionShape) =>
+                  setLoadedSessionShape(
+                    sessionShape
+                      ? {
+                        range: search.range,
+                        harness: search.harness,
+                        data: sessionShape,
+                      }
+                      : undefined,
+                  )}
+              />
+            </div>
+            {data && (
+              <Suspense fallback={null}>
+                <WorkRhythm
+                  data={data.workRhythm}
+                  selectedDate={selectedDate!}
+                  onSelect={(date) => update({ date })}
+                />
+              </Suspense>
+            )}
           </div>
+
           {data && (
             <Suspense fallback={null}>
-              <WorkRhythm
-                data={data.workRhythm}
-                selectedDate={selectedDate!}
-                onSelect={(date) => update({ date })}
-              />
+              <SpendComposition data={data.spendComposition} />
             </Suspense>
           )}
-        </div>
 
-        {data && (
-          <Suspense fallback={null}>
-            <SpendComposition data={data.spendComposition} />
-          </Suspense>
-        )}
+          {data && (
+            <>
+              <div className="new-placeholder-grid">
+                <CacheOverview
+                  range={search.range}
+                  harness={search.harness}
+                  onDataChange={(cacheMisses) =>
+                    setLoadedCacheMisses(
+                      cacheMisses
+                        ? {
+                          range: search.range,
+                          harness: search.harness,
+                          data: cacheMisses,
+                        }
+                        : undefined,
+                    )}
+                />
+                <Suspense fallback={null}>
+                  <SessionDiagnostics data={data.sessionDiagnostics} />
+                </Suspense>
+              </div>
 
-        {data && (
-          <>
-            <div className="new-placeholder-grid">
-              <CacheOverview range={search.range} harness={search.harness} />
-              <Suspense fallback={null}>
-                <SessionDiagnostics data={data.sessionDiagnostics} />
-              </Suspense>
-            </div>
-
-            <RecentSessions
-              harness={search.harness}
-              harnesses={harnesses}
-              misses={search.misses}
-              onHarnessChange={(harness) => update({ harness })}
-              onMissesChange={(misses) => update({ misses })}
-            />
-          </>
-        )}
-      </section>
+              <RecentSessions
+                harness={search.harness}
+                harnesses={harnesses}
+                misses={search.misses}
+                onHarnessChange={(harness) => update({ harness })}
+                onMissesChange={(misses) => update({ misses })}
+              />
+            </>
+          )}
+        </section>
+      </div>
     </main>
   );
 }

--- a/src/client/SessionsPage.tsx
+++ b/src/client/SessionsPage.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from "react";
 import { getRouteApi } from "@tanstack/react-router";
-import { Check, Share } from "lucide-react";
+import { Check, Copy } from "lucide-react";
 import type {
   OverviewResponse,
   SessionDetail,
@@ -310,7 +310,7 @@ export function SessionsPage() {
           >
             {shareState === "copied"
               ? <Check size={16} aria-hidden="true" />
-              : <Share size={16} aria-hidden="true" />}
+              : <Copy size={16} aria-hidden="true" />}
           </button>
         }
       />

--- a/src/client/copyScreenshot.ts
+++ b/src/client/copyScreenshot.ts
@@ -1,0 +1,75 @@
+import { toBlob } from "html-to-image";
+
+const pageBackground = "#f4f0e8";
+const pageGrid =
+  "linear-gradient(rgba(49, 61, 47, .035) 1px, transparent 1px), " +
+  "linear-gradient(90deg, rgba(49, 61, 47, .035) 1px, transparent 1px)";
+
+function inheritedCustomProperties(element: HTMLElement) {
+  const properties: Record<string, string> = {};
+  const names = [
+    "--mono",
+    "--dashboard-bg",
+    "--dashboard-panel",
+    "--dashboard-ink",
+    "--dashboard-muted",
+    "--dashboard-rule",
+    "--dashboard-signal",
+    "--dashboard-spend",
+  ];
+  const sources = [document.documentElement, element];
+  for (const source of sources) {
+    const styles = getComputedStyle(source);
+    for (const name of names) {
+      const value = styles.getPropertyValue(name);
+      if (value) properties[name] = value;
+    }
+  }
+  return properties;
+}
+
+export async function copyElementScreenshot(element: HTMLElement) {
+  if (
+    !globalThis.isSecureContext ||
+    !navigator.clipboard?.write ||
+    !globalThis.ClipboardItem
+  ) {
+    throw new Error("Image clipboard access is unavailable");
+  }
+
+  const bounds = element.getBoundingClientRect();
+  // Keep the page's current layout width; scrollWidth can include an
+  // overflowing chart or table and make the cloned page unexpectedly wider.
+  const width = Math.ceil(bounds.width);
+  const excluded = element.querySelector<HTMLElement>(
+    "[data-screenshot-exclude]",
+  );
+  const height = excluded
+    ? Math.ceil(excluded.getBoundingClientRect().top - bounds.top)
+    : Math.ceil(Math.max(element.scrollHeight, bounds.height));
+  const blob = toBlob(element, {
+    backgroundColor: pageBackground,
+    cacheBust: true,
+    filter: (node) =>
+      !(node instanceof Element && (
+        node.hasAttribute("data-screenshot-control") ||
+        node.hasAttribute("data-screenshot-exclude")
+      )),
+    height,
+    pixelRatio: 2,
+    style: {
+      ...inheritedCustomProperties(element),
+      backgroundColor: pageBackground,
+      backgroundImage: pageGrid,
+      backgroundSize: "24px 24px",
+    } as Partial<CSSStyleDeclaration>,
+    width,
+  }).then((result) => {
+    if (!result) throw new Error("Screenshot rendering returned no image");
+    return result;
+  });
+
+  await navigator.clipboard.write([
+    new ClipboardItem({ "image/png": blob }),
+  ]);
+}

--- a/src/client/new/CacheOverview.tsx
+++ b/src/client/new/CacheOverview.tsx
@@ -7,6 +7,7 @@ import "./CacheOverview.css";
 type CacheOverviewProps = {
   range: 30 | 90;
   harness: string;
+  onDataChange?: (data: TtlMissMetrics | undefined) => void;
 };
 
 type CauseRow = {
@@ -260,7 +261,11 @@ function CacheMissTable({ metrics }: { metrics: TtlMissMetrics }) {
   );
 }
 
-export function CacheOverview({ range, harness }: CacheOverviewProps) {
+export function CacheOverview({
+  range,
+  harness,
+  onDataChange,
+}: CacheOverviewProps) {
   const [metrics, setMetrics] = useState<TtlMissMetrics>();
   const [error, setError] = useState<string>();
 
@@ -268,8 +273,12 @@ export function CacheOverview({ range, harness }: CacheOverviewProps) {
     let active = true;
     setMetrics(undefined);
     setError(undefined);
+    onDataChange?.(undefined);
     getCacheMissOverview(range, harness).then((result) => {
-      if (active) setMetrics(result);
+      if (active) {
+        setMetrics(result);
+        onDataChange?.(result);
+      }
     }).catch((reason) => {
       if (active) {
         setError(
@@ -277,6 +286,7 @@ export function CacheOverview({ range, harness }: CacheOverviewProps) {
             ? reason.message
             : "Unable to load cache metrics",
         );
+        onDataChange?.(undefined);
       }
     });
     return () => {

--- a/src/client/new/OverviewToolbar.css
+++ b/src/client/new/OverviewToolbar.css
@@ -34,6 +34,36 @@
   font: 10px var(--mono);
 }
 
+.overview-screenshot-button {
+  display: grid;
+  width: 34px;
+  height: 34px;
+  flex: 0 0 34px;
+  place-items: center;
+  padding: 0;
+  border: 1px solid #bdcac6;
+  border-radius: 5px;
+  background: transparent;
+  color: var(--dashboard-muted);
+  cursor: pointer;
+}
+
+.overview-screenshot-button:hover:not(:disabled),
+.overview-screenshot-button:focus-visible {
+  border-color: var(--dashboard-ink);
+  color: var(--dashboard-ink);
+}
+
+.overview-screenshot-button:disabled {
+  cursor: wait;
+  opacity: .5;
+}
+
+.overview-screenshot-button.error {
+  border-color: var(--danger);
+  color: var(--danger);
+}
+
 @media (max-width: 760px) {
   .new-page .site-header {
     padding-right: 0;

--- a/src/client/new/OverviewToolbar.css
+++ b/src/client/new/OverviewToolbar.css
@@ -34,7 +34,7 @@
   font: 10px var(--mono);
 }
 
-.overview-screenshot-button {
+.overview-action-button {
   display: grid;
   width: 34px;
   height: 34px;
@@ -48,18 +48,18 @@
   cursor: pointer;
 }
 
-.overview-screenshot-button:hover:not(:disabled),
-.overview-screenshot-button:focus-visible {
+.overview-action-button:hover:not(:disabled),
+.overview-action-button:focus-visible {
   border-color: var(--dashboard-ink);
   color: var(--dashboard-ink);
 }
 
-.overview-screenshot-button:disabled {
+.overview-action-button:disabled {
   cursor: wait;
   opacity: .5;
 }
 
-.overview-screenshot-button.error {
+.overview-action-button.error {
   border-color: var(--danger);
   color: var(--danger);
 }

--- a/src/client/new/OverviewToolbar.tsx
+++ b/src/client/new/OverviewToolbar.tsx
@@ -1,4 +1,4 @@
-import { Camera, Check } from "lucide-react";
+import { Camera, Check, Copy } from "lucide-react";
 import type { SessionSummary } from "../../shared/sessionSchemas.ts";
 import { HarnessOptions } from "../HarnessOptions.tsx";
 import "./OverviewToolbar.css";
@@ -12,6 +12,7 @@ export type OverviewHarness =
   | "codex"
   | "cursor";
 export type ScreenshotState = "idle" | "capturing" | "copied" | "error";
+export type CopyReportState = "idle" | "copied" | "error";
 
 type OverviewToolbarProps = {
   range: OverviewRange;
@@ -22,6 +23,9 @@ type OverviewToolbarProps = {
   screenshotState: ScreenshotState;
   screenshotDisabled?: boolean;
   onScreenshot: () => void;
+  copyReportState: CopyReportState;
+  copyReportDisabled?: boolean;
+  onCopyReport: () => void;
 };
 
 export function OverviewToolbar({
@@ -33,6 +37,9 @@ export function OverviewToolbar({
   screenshotState,
   screenshotDisabled = false,
   onScreenshot,
+  copyReportState,
+  copyReportDisabled = false,
+  onCopyReport,
 }: OverviewToolbarProps) {
   return (
     <div className="new-overview-controls">
@@ -45,9 +52,10 @@ export function OverviewToolbar({
             aria-pressed={range === option}
             onClick={() => onRangeChange(option)}
             onDoubleClick={option === 30
-              ? () => window.dispatchEvent(
-                new Event("frugal-tokens:toggle-secondary-pages"),
-              )
+              ? () =>
+                globalThis.dispatchEvent(
+                  new Event("frugal-tokens:toggle-secondary-pages"),
+                )
               : undefined}
           >
             {option}D
@@ -66,7 +74,27 @@ export function OverviewToolbar({
       </label>
       <button
         type="button"
-        className={`overview-screenshot-button${
+        className={`overview-action-button${
+          copyReportState === "error" ? " error" : ""
+        }`}
+        disabled={copyReportDisabled}
+        onClick={onCopyReport}
+        aria-label={copyReportState === "copied"
+          ? "Markdown report copied"
+          : "Copy Markdown report"}
+        title={copyReportState === "copied"
+          ? "Markdown report copied"
+          : copyReportState === "error"
+          ? "Unable to copy Markdown report"
+          : "Copy Markdown report"}
+      >
+        {copyReportState === "copied"
+          ? <Check size={16} aria-hidden="true" />
+          : <Copy size={16} aria-hidden="true" />}
+      </button>
+      <button
+        type="button"
+        className={`overview-action-button${
           screenshotState === "error" ? " error" : ""
         }`}
         data-screenshot-control

--- a/src/client/new/OverviewToolbar.tsx
+++ b/src/client/new/OverviewToolbar.tsx
@@ -1,3 +1,4 @@
+import { Camera, Check } from "lucide-react";
 import type { SessionSummary } from "../../shared/sessionSchemas.ts";
 import { HarnessOptions } from "../HarnessOptions.tsx";
 import "./OverviewToolbar.css";
@@ -10,6 +11,7 @@ export type OverviewHarness =
   | "pi"
   | "codex"
   | "cursor";
+export type ScreenshotState = "idle" | "capturing" | "copied" | "error";
 
 type OverviewToolbarProps = {
   range: OverviewRange;
@@ -17,6 +19,9 @@ type OverviewToolbarProps = {
   harnesses: SessionSummary["harness"][];
   onRangeChange: (range: OverviewRange) => void;
   onHarnessChange: (harness: OverviewHarness) => void;
+  screenshotState: ScreenshotState;
+  screenshotDisabled?: boolean;
+  onScreenshot: () => void;
 };
 
 export function OverviewToolbar({
@@ -25,6 +30,9 @@ export function OverviewToolbar({
   harnesses,
   onRangeChange,
   onHarnessChange,
+  screenshotState,
+  screenshotDisabled = false,
+  onScreenshot,
 }: OverviewToolbarProps) {
   return (
     <div className="new-overview-controls">
@@ -56,6 +64,27 @@ export function OverviewToolbar({
           <HarnessOptions harnesses={harnesses} />
         </select>
       </label>
+      <button
+        type="button"
+        className={`overview-screenshot-button${
+          screenshotState === "error" ? " error" : ""
+        }`}
+        data-screenshot-control
+        disabled={screenshotDisabled || screenshotState === "capturing"}
+        onClick={onScreenshot}
+        aria-label={screenshotState === "copied"
+          ? "Overview screenshot copied"
+          : "Copy overview screenshot"}
+        title={screenshotState === "copied"
+          ? "Overview screenshot copied"
+          : screenshotState === "error"
+          ? "Unable to copy overview screenshot"
+          : "Copy overview screenshot"}
+      >
+        {screenshotState === "copied"
+          ? <Check size={16} aria-hidden="true" />
+          : <Camera size={16} aria-hidden="true" />}
+      </button>
     </div>
   );
 }

--- a/src/client/new/RecentSessions.tsx
+++ b/src/client/new/RecentSessions.tsx
@@ -267,7 +267,10 @@ export function RecentSessions({
   }, [data, returnScrollY]);
 
   return (
-    <div className="new-recent-sessions">
+    <div
+      className="new-recent-sessions"
+      data-screenshot-exclude
+    >
       <SessionsPanel
         data={data}
         loadingSessions={loadingSessions}

--- a/src/client/new/SessionDiagnostics.tsx
+++ b/src/client/new/SessionDiagnostics.tsx
@@ -31,6 +31,7 @@ type SessionDotShapeProps = {
   payload?: ChartPoint;
 };
 
+const chartMono = '"SFMono-Regular", Consolas, monospace';
 const decimal = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
 const SCALE_PIVOT: Record<Metric, number> = {
   spend: 0.1,
@@ -150,9 +151,31 @@ function SessionDot({
         }
       }}
     >
-      <circle cx={cx} cy={cy} r={payload.highlighted ? 4.2 : 3.1} />
+      <circle
+        cx={cx}
+        cy={cy}
+        r={payload.highlighted ? 4.2 : 3.1}
+        fill={payload.highlighted ? "#235f59" : "#657a76"}
+        fillOpacity={payload.highlighted ? 0.88 : 0.34}
+        stroke={payload.highlighted ? "#235f59" : "#657a76"}
+        strokeOpacity={payload.highlighted ? 1 : 0.5}
+        strokeWidth={0.75}
+      />
       {payload.highestValueLabel && (
-        <text x={cx} y={cy - 9} textAnchor="middle">
+        <text
+          x={cx}
+          y={cy - 9}
+          fill="#29433f"
+          fontFamily={chartMono}
+          fontSize={9}
+          fontWeight={700}
+          paintOrder="stroke"
+          pointerEvents="none"
+          stroke="#fbfcfb"
+          strokeLinejoin="round"
+          strokeWidth={3}
+          textAnchor="middle"
+        >
           {payload.highestValueLabel}
         </text>
       )}
@@ -268,11 +291,17 @@ export function SessionDiagnostics({ data }: { data: SessionDiagnosticsData }) {
                   tickLine={false}
                   axisLine={false}
                   minTickGap={24}
+                  tick={{ fill: "#697572", fontFamily: chartMono, fontSize: 9 }}
                 >
                   <Label
                     value="Estimated active time"
                     position="insideBottom"
                     offset={-16}
+                    style={{
+                      fill: "#697572",
+                      fontFamily: chartMono,
+                      fontSize: 9,
+                    }}
                   />
                 </XAxis>
                 <YAxis
@@ -285,12 +314,18 @@ export function SessionDiagnostics({ data }: { data: SessionDiagnosticsData }) {
                   tickLine={false}
                   axisLine={false}
                   width={58}
+                  tick={{ fill: "#697572", fontFamily: chartMono, fontSize: 9 }}
                 >
                   <Label
                     value={`${metricLabel} · log scale`}
                     angle={-90}
                     position="insideLeft"
                     offset={4}
+                    style={{
+                      fill: "#697572",
+                      fontFamily: chartMono,
+                      fontSize: 9,
+                    }}
                   />
                 </YAxis>
                 <ReferenceLine
@@ -302,6 +337,7 @@ export function SessionDiagnostics({ data }: { data: SessionDiagnosticsData }) {
                     value: `Median active · ${duration(medianActive)}`,
                     position: "insideTopLeft",
                     fill: "#697572",
+                    fontFamily: chartMono,
                     fontSize: 9,
                   }}
                 />
@@ -316,6 +352,7 @@ export function SessionDiagnostics({ data }: { data: SessionDiagnosticsData }) {
                     } · ${formatMetric(metric, medianY)}`,
                     position: "insideTopRight",
                     fill: "#697572",
+                    fontFamily: chartMono,
                     fontSize: 9,
                   }}
                 />

--- a/src/client/new/SessionShape.tsx
+++ b/src/client/new/SessionShape.tsx
@@ -14,6 +14,7 @@ type MetricKey = DistributionMetric["key"];
 type SessionShapeProps = {
   range: 30 | 90;
   harness: string;
+  onDataChange?: (data: SessionShapeResponse | undefined) => void;
 };
 
 const metricLabels: Record<MetricKey, string> = {
@@ -202,7 +203,11 @@ function DistributionStrip({
   );
 }
 
-export function SessionShape({ range, harness }: SessionShapeProps) {
+export function SessionShape({
+  range,
+  harness,
+  onDataChange,
+}: SessionShapeProps) {
   const [data, setData] = useState<SessionShapeResponse>();
   const [error, setError] = useState<string>();
   const [initialInputUsage, setInitialInputUsage] = useState<UsageResponse>();
@@ -210,11 +215,16 @@ export function SessionShape({ range, harness }: SessionShapeProps) {
 
   useEffect(() => {
     let active = true;
+    setData(undefined);
     setError(undefined);
     setInitialInputError(undefined);
     setInitialInputUsage(undefined);
+    onDataChange?.(undefined);
     getSessionShape(range, harness).then((result) => {
-      if (active) setData(result);
+      if (active) {
+        setData(result);
+        onDataChange?.(result);
+      }
     }).catch((reason) => {
       if (active) {
         setError(
@@ -222,6 +232,7 @@ export function SessionShape({ range, harness }: SessionShapeProps) {
             ? reason.message
             : "Unable to load session shape",
         );
+        onDataChange?.(undefined);
       }
     });
     getUsage(range, harness).then((result) => {

--- a/src/client/new/SpendComposition.tsx
+++ b/src/client/new/SpendComposition.tsx
@@ -15,6 +15,8 @@ import { compact, currency } from "./formatters.ts";
 import { minorModelColor, modelColor, otherModelColor } from "./modelColors.ts";
 import "./SpendComposition.css";
 
+const chartMono = '"SFMono-Regular", Consolas, monospace';
+
 type Metric = "spend" | "tokens";
 type CompositionModel = SpendCompositionData["models"][number];
 type CompositionDay = SpendCompositionData["days"][number];
@@ -315,18 +317,17 @@ function CompositionChart(
             minTickGap={42}
             axisLine={false}
             tickLine={false}
-            tick={{ fill: "#73807c", fontSize: 9, fontFamily: "var(--mono)" }}
+            tick={{ fill: "#73807c", fontSize: 9, fontFamily: chartMono }}
           />
           <YAxis
             yAxisId="volume"
             width={48}
-            tickFormatter={(value) =>
-              metric === "spend"
-                ? `$${compact.format(Number(value))}`
-                : compact.format(Number(value))}
+            tickFormatter={(value) => metric === "spend"
+              ? `$${compact.format(Number(value))}`
+              : compact.format(Number(value))}
             axisLine={false}
             tickLine={false}
-            tick={{ fill: "#73807c", fontSize: 9, fontFamily: "var(--mono)" }}
+            tick={{ fill: "#73807c", fontSize: 9, fontFamily: chartMono }}
           />
           <YAxis
             yAxisId="rate"
@@ -339,7 +340,7 @@ function CompositionChart(
               ? {
                 fill: "#35433f",
                 fontSize: 9,
-                fontFamily: "var(--mono)",
+                fontFamily: chartMono,
               }
               : false}
           />
@@ -420,7 +421,11 @@ export function SpendComposition({ data }: { data: SpendCompositionData }) {
             <h2 id="spend-composition-title">Spend</h2>
           </header>
           {empty
-            ? <p className="composition-empty">No model usage in this period.</p>
+            ? (
+              <p className="composition-empty">
+                No model usage in this period.
+              </p>
+            )
             : <ModelTable data={data} />}
         </div>
         {!empty && (

--- a/src/client/new/WorkRhythm.tsx
+++ b/src/client/new/WorkRhythm.tsx
@@ -26,6 +26,7 @@ import { compact, currency, integer } from "./formatters.ts";
 import { saveOverviewReturnScroll } from "./overviewReturnScroll.ts";
 import "./WorkRhythm.css";
 
+const chartMono = '"SFMono-Regular", Consolas, monospace';
 const readableDate = new Intl.DateTimeFormat(undefined, {
   weekday: "long",
   month: "long",
@@ -153,7 +154,7 @@ function WeekdayChart({ data }: { data: WorkRhythmData["weekdayActivity"] }) {
             width={40}
             axisLine={false}
             tickLine={false}
-            tick={{ fill: "#52615d", fontSize: 11, fontFamily: "var(--mono)" }}
+            tick={{ fill: "#52615d", fontSize: 11, fontFamily: chartMono }}
           />
           <Tooltip
             cursor={{ fill: "rgba(15, 113, 105, .045)" }}
@@ -166,7 +167,7 @@ function WeekdayChart({ data }: { data: WorkRhythmData["weekdayActivity"] }) {
           />
           <Bar
             dataKey="averageMinutes"
-            fill="var(--dashboard-signal)"
+            fill="#0f7169"
             fillOpacity={0.76}
             barSize={12}
             radius={[0, 2, 2, 0]}
@@ -214,7 +215,7 @@ function HourlyChart({ data }: { data: WorkRhythmData["hourlyActivity"] }) {
             tickFormatter={formatHourTick}
             axisLine={false}
             tickLine={false}
-            tick={{ fill: "#6f7d78", fontSize: 11, fontFamily: "var(--mono)" }}
+            tick={{ fill: "#6f7d78", fontSize: 11, fontFamily: chartMono }}
           />
           <YAxis hide domain={[0, "dataMax"]} />
           <Tooltip
@@ -228,7 +229,7 @@ function HourlyChart({ data }: { data: WorkRhythmData["hourlyActivity"] }) {
           />
           <Bar
             dataKey="estimatedMinutes"
-            fill="var(--dashboard-signal)"
+            fill="#0f7169"
             fillOpacity={0.72}
             radius={[1.5, 1.5, 0, 0]}
             isAnimationActive={false}

--- a/src/client/overviewReport.ts
+++ b/src/client/overviewReport.ts
@@ -1,0 +1,318 @@
+import { displayModelName } from "../shared/modelNames.ts";
+import type {
+  ActivityOverviewResponse,
+  SessionShapeResponse,
+  TtlMissMetrics,
+} from "../shared/sessionSchemas.ts";
+
+const integer = new Intl.NumberFormat("en-US", { maximumFractionDigits: 0 });
+const decimal = new Intl.NumberFormat("en-US", { maximumFractionDigits: 1 });
+const money = new Intl.NumberFormat("en-US", {
+  style: "currency",
+  currency: "USD",
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function cell(value: string | number) {
+  return String(value).replaceAll("|", "\\|").replaceAll("\n", " ");
+}
+
+function table(headers: string[], rows: Array<Array<string | number>>) {
+  return [
+    `| ${headers.map(cell).join(" | ")} |`,
+    `| ${headers.map(() => "---").join(" | ")} |`,
+    ...rows.map((row) => `| ${row.map(cell).join(" | ")} |`),
+  ].join("\n");
+}
+
+function percent(value: number | undefined) {
+  return value === undefined ? "—" : `${decimal.format(value * 100)}%`;
+}
+
+function duration(minutes: number) {
+  if (minutes < 1) return `${integer.format(minutes * 60)} sec`;
+  if (minutes < 60) return `${decimal.format(minutes)} min`;
+  return `${decimal.format(minutes / 60)} hr`;
+}
+
+function harnessLabel(harness: string) {
+  const labels: Record<string, string> = {
+    all: "All harnesses",
+    "claude-code": "Claude Code",
+    codex: "Codex",
+    cursor: "Cursor",
+    opencode: "OpenCode",
+    pi: "Pi",
+  };
+  return labels[harness] ?? harness;
+}
+
+function hourLabel(hour: number) {
+  if (hour === 0) return "12am";
+  if (hour < 12) return `${hour}am`;
+  if (hour === 12) return "12pm";
+  return `${hour - 12}pm`;
+}
+
+const shapeLabels: Record<
+  SessionShapeResponse["metrics"][number]["key"],
+  string
+> = {
+  cost: "Cost",
+  observedSpan: "Duration",
+  peakContext: "Peak context",
+  processedInput: "Processed input",
+  startingContext: "Starting context",
+  tokenReuse: "Token reuse",
+  userTurns: "Turns",
+};
+
+function shapeValue(
+  key: SessionShapeResponse["metrics"][number]["key"],
+  value: number,
+) {
+  if (key === "cost") return money.format(value);
+  if (key === "observedSpan") return duration(value / 60_000);
+  if (key === "tokenReuse") return percent(value);
+  return integer.format(value);
+}
+
+type CacheCategory = {
+  affectedSessions: number;
+  attributedCost: number;
+  misses: number;
+};
+
+function cacheRows(metrics: TtlMissMetrics) {
+  const root = metrics.cacheMisses;
+  const categories: Array<[string, string, CacheCategory]> = [
+    ["Root", "TTL", {
+      affectedSessions: metrics.affectedSessions,
+      attributedCost: metrics.misses.attributedCost,
+      misses: metrics.misses.total,
+    }],
+    ["Root", "Thinking change", root.thinkingChange],
+    ["Root", "Compaction", root.compaction],
+    ["Root", "Model change", root.modelChange],
+    ["Root", "Unexpected full", root.unexpected.full],
+    ["Root", "Unexpected partial", root.unexpected.partial],
+    ["Subagent", "TTL", metrics.subagents.ttl],
+    ["Subagent", "Thinking change", metrics.subagents.thinkingChange],
+    ["Subagent", "Compaction", metrics.subagents.compaction],
+    ["Subagent", "Model change", metrics.subagents.modelChange],
+    ["Subagent", "Unexpected full", metrics.subagents.unexpected.full],
+    ["Subagent", "Unexpected partial", metrics.subagents.unexpected.partial],
+  ];
+  return categories.filter(([, , category]) => category.misses > 0).map(
+    ([scope, cause, category]) => [
+      scope,
+      cause,
+      integer.format(category.misses),
+      integer.format(category.affectedSessions),
+      money.format(category.attributedCost),
+    ],
+  );
+}
+
+export function buildOverviewReport({
+  overview,
+  sessionShape,
+  cacheMisses,
+  harness,
+}: {
+  overview: ActivityOverviewResponse;
+  sessionShape: SessionShapeResponse;
+  cacheMisses: TtlMissMetrics;
+  harness: string;
+}) {
+  const { summary, workRhythm, spendComposition } = overview;
+  const sections = [
+    '<!-- frugal-tokens-report version="1" -->',
+    "# Frugal Tokens Report",
+    table(["Period", "Harness", "Generated"], [[
+      `${overview.startDate} – ${overview.endDate}`,
+      harnessLabel(harness),
+      new Date().toISOString(),
+    ]]),
+  ];
+
+  const costPerMillion = summary.processedInput === 0
+    ? 0
+    : summary.spend / summary.processedInput * 1_000_000;
+  sections.push(
+    "## Usage\n\n" + table(
+      ["Sessions", "Spend", "Processed input", "Token reuse", "Cost / 1M"],
+      [[
+        integer.format(summary.sessions),
+        `${money.format(summary.spend)}${summary.hasUnpricedCost ? "+" : ""}`,
+        integer.format(summary.processedInput),
+        percent(summary.tokenReuse),
+        money.format(costPerMillion),
+      ]],
+    ),
+  );
+  sections.push(table(["Signal", "Value"], [
+    ["Spend at cache-miss calls", money.format(summary.spendAtMissCalls)],
+    ["Subagent spend", money.format(summary.subagentSpend)],
+    ["Spend from top 10% of sessions", percent(summary.topDecileSpendShare)],
+  ]));
+
+  sections.push(
+    `## Session shape\n\n${integer.format(sessionShape.sampleSize)} sessions; ${
+      integer.format(sessionShape.multiDaySessions)
+    } span multiple days (${percent(sessionShape.multiDaySessionRate)}); ${
+      integer.format(sessionShape.unpricedSessions)
+    } include unpriced usage.\n\n` + table(
+      ["Metric", "P10", "P25", "Median", "Mean", "P75", "P90"],
+      sessionShape.metrics.map((metric) => {
+        const distribution = metric.distribution;
+        return distribution
+          ? [
+            shapeLabels[metric.key],
+            shapeValue(metric.key, distribution.p10),
+            shapeValue(metric.key, distribution.p25),
+            shapeValue(metric.key, distribution.median),
+            shapeValue(metric.key, distribution.average),
+            shapeValue(metric.key, distribution.p75),
+            shapeValue(metric.key, distribution.p90),
+          ]
+          : [shapeLabels[metric.key], "—", "—", "—", "—", "—", "—"];
+      }),
+    ),
+  );
+
+  sections.push(
+    `## Estimated work\n\n**Total:** ${
+      duration(workRhythm.estimatedActiveMinutes)
+    } · **Peak hour:** ${
+      workRhythm.peakHour === undefined ? "—" : hourLabel(workRhythm.peakHour)
+    } · **After hours:** ${percent(workRhythm.afterHoursShare)}\n\n` +
+      "### By weekday\n\n" + table(
+        ["Day", "Average", "Active occurrences"],
+        workRhythm.weekdayActivity.map((day) => [
+          day.label,
+          duration(day.averageMinutes),
+          `${day.activeOccurrences}/${day.occurrences}`,
+        ]),
+      ) + "\n\n### By hour\n\n" + table(
+        ["Hour", "Estimated active"],
+        workRhythm.hourlyActivity.filter((hour) => hour.estimatedMinutes > 0)
+          .map((
+            hour,
+          ) => [hourLabel(hour.hour), duration(hour.estimatedMinutes)]),
+      ) + "\n\n" + table(["Work pattern", "Share"], [
+        [
+          "1 active session",
+          percent(workRhythm.parallelWork.activeTimeShare.oneSession),
+        ],
+        [
+          "2 active sessions",
+          percent(workRhythm.parallelWork.activeTimeShare.twoSessions),
+        ],
+        [
+          "3+ active sessions",
+          percent(
+            workRhythm.parallelWork.activeTimeShare.threeSessions +
+              workRhythm.parallelWork.activeTimeShare.fourPlusSessions,
+          ),
+        ],
+        [
+          "Overlapping activity",
+          percent(workRhythm.parallelWork.overlappingShare),
+        ],
+        ["Work blocks", integer.format(workRhythm.workBlocks.count)],
+        [
+          "Work blocks / active day",
+          decimal.format(workRhythm.workBlocks.blocksPerActiveDay),
+        ],
+        [
+          "Work blocks under 15 min",
+          percent(workRhythm.workBlocks.durationShare.underFifteenMinutes),
+        ],
+        [
+          "Work blocks 15–60 min",
+          percent(workRhythm.workBlocks.durationShare.fifteenToSixtyMinutes),
+        ],
+        [
+          "Work blocks 1+ hr",
+          percent(workRhythm.workBlocks.durationShare.oneHourPlus),
+        ],
+      ]),
+  );
+
+  const modelRows: Array<Array<string | number>> = spendComposition.models.map(
+    (model) => [
+      displayModelName(model.model),
+      `${money.format(model.spend)}${model.hasUnpricedCost ? "+" : ""}`,
+      integer.format(model.processedInput),
+    ],
+  );
+  if (spendComposition.other) {
+    modelRows.push([
+      "Other",
+      `${money.format(spendComposition.other.spend)}${
+        spendComposition.other.hasUnpricedCost ? "+" : ""
+      }`,
+      integer.format(spendComposition.other.processedInput),
+    ]);
+  }
+  sections.push(
+    "## Spend and input by model\n\n" + table(
+      ["Model", "Spend", "Processed input"],
+      modelRows,
+    ),
+  );
+
+  sections.push(
+    `## Cache misses\n\n${
+      integer.format(cacheMisses.combined.misses)
+    } misses across ${
+      integer.format(cacheMisses.combined.affectedSessions)
+    } of ${integer.format(cacheMisses.sessions)} sessions; ${
+      money.format(cacheMisses.combined.attributedCost)
+    } attributed cost and ${
+      integer.format(cacheMisses.combined.missedTokens)
+    } missed tokens.\n\n` + table(
+      ["Scope", "Cause", "Misses", "Sessions", "Attributed cost"],
+      cacheRows(cacheMisses),
+    ) + "\n\n### Root TTL timing\n\n" + table(
+      ["Gap", "Misses", "Sessions", "Attributed cost"],
+      [
+        [
+          "Under 30 min",
+          cacheMisses.misses.underThirtyMinutes,
+          cacheMisses.misses.underThirtyMinutesSessions,
+          cacheMisses.misses.underThirtyMinutesCost,
+        ],
+        [
+          "30 min–2 hr",
+          cacheMisses.misses.thirtyMinutesToTwoHours,
+          cacheMisses.misses.thirtyMinutesToTwoHoursSessions,
+          cacheMisses.misses.thirtyMinutesToTwoHoursCost,
+        ],
+        [
+          "2–8 hr",
+          cacheMisses.misses.twoToEightHours,
+          cacheMisses.misses.twoToEightHoursSessions,
+          cacheMisses.misses.twoToEightHoursCost,
+        ],
+        [
+          "8+ hr",
+          cacheMisses.misses.eightHoursOrMore,
+          cacheMisses.misses.eightHoursOrMoreSessions,
+          cacheMisses.misses.eightHoursOrMoreCost,
+        ],
+      ].filter((row) => Number(row[1]) > 0).map((
+        [gap, misses, sessions, cost],
+      ) => [
+        gap,
+        integer.format(Number(misses)),
+        integer.format(Number(sessions)),
+        money.format(Number(cost)),
+      ]),
+    ),
+  );
+
+  return `${sections.join("\n\n")}\n`;
+}


### PR DESCRIPTION
## Summary

- Add a toolbar action that copies the overview dashboard as an image.
- Preserve chart colors, typography, and scatter-point detail in copied screenshots.
- Add a compact, versioned Markdown report containing aggregate usage, session shape, work patterns, model composition, and cache misses.
- Use copy-oriented labels and icons for clipboard actions.