### PR TITLE
Split estimated work loading

### DIFF
--- a/src/client/NewPage.css
+++ b/src/client/NewPage.css
@@ -41,6 +41,38 @@
   min-width: 0;
 }
 
+.work-rhythm-loading {
+  display: grid;
+  min-width: 0;
+  min-height: 560px;
+  place-items: center;
+  align-self: stretch;
+  border: 1px solid var(--dashboard-rule);
+  border-radius: 8px;
+  background: var(--dashboard-panel);
+}
+
+.work-rhythm-loading span {
+  width: 24px;
+  height: 24px;
+  border: 2px solid var(--dashboard-rule);
+  border-top-color: var(--dashboard-signal);
+  border-radius: 50%;
+  animation: work-rhythm-loading-spin .8s linear infinite;
+}
+
+@keyframes work-rhythm-loading-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .work-rhythm-loading span {
+    animation-duration: 1.8s;
+  }
+}
+
 .signal-summary,
 .session-shape {
   min-width: 0;
@@ -125,21 +157,33 @@
   outline-offset: 2px;
 }
 
-
 @media (max-width: 1120px) {
-  .new-placeholder-grid { grid-template-columns: 1fr; }
+  .new-placeholder-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 1050px) {
-  .new-overview-grid { grid-template-columns: 1fr; }
+  .new-overview-grid {
+    grid-template-columns: 1fr;
+  }
 }
 
 @media (max-width: 760px) {
-  .new-page .page-tabs { gap: 20px; }
-  .signal-summary, .session-shape { padding: 14px; }
+  .new-page .page-tabs {
+    gap: 20px;
+  }
+  .signal-summary,
+  .session-shape {
+    padding: 14px;
+  }
 }
 
 @media (max-width: 480px) {
-  .new-page .page-tabs { gap: 12px; }
-  .new-page .page-tabs a { font-size: 10px; }
+  .new-page .page-tabs {
+    gap: 12px;
+  }
+  .new-page .page-tabs a {
+    font-size: 10px;
+  }
 }

--- a/src/client/NewPage.tsx
+++ b/src/client/NewPage.tsx
@@ -3,8 +3,9 @@ import { getRouteApi } from "@tanstack/react-router";
 import type {
   ActivityOverviewResponse,
   SessionSummary,
+  WorkRhythmOverviewResponse,
 } from "../shared/sessionSchemas.ts";
-import { getActivityOverview, getHarnesses } from "./api.ts";
+import { getActivityOverview, getHarnesses, getWorkRhythm } from "./api.ts";
 import { SiteHeader } from "./SiteHeader.tsx";
 import "./NewPage.css";
 import { OverviewToolbar } from "./new/OverviewToolbar.tsx";
@@ -45,9 +46,16 @@ export function NewPage() {
     harness: string;
     data: ActivityOverviewResponse;
   }>();
+  const [loadedWorkRhythm, setLoadedWorkRhythm] = useState<{
+    range: 30 | 90;
+    harness: string;
+    data: WorkRhythmOverviewResponse;
+  }>();
   const [error, setError] = useState<string>();
+  const [workRhythmError, setWorkRhythmError] = useState<string>();
   const [harnesses, setHarnesses] = useState<SessionSummary["harness"][]>([]);
   const data = loadedOverview?.data;
+  const workRhythmData = loadedWorkRhythm?.data;
 
   useEffect(() => {
     let active = true;
@@ -64,15 +72,32 @@ export function NewPage() {
   useEffect(() => {
     let active = true;
     setError(undefined);
+    setWorkRhythmError(undefined);
+    setLoadedWorkRhythm(undefined);
     getActivityOverview(search.range, search.harness).then((result) => {
-      if (active) {
-        setLoadedOverview({
+      if (!active) return;
+      setLoadedOverview({
+        range: search.range,
+        harness: search.harness,
+        data: result,
+      });
+      setError(undefined);
+      return getWorkRhythm(search.range, search.harness).then((workRhythm) => {
+        if (!active) return;
+        setLoadedWorkRhythm({
           range: search.range,
           harness: search.harness,
-          data: result,
+          data: workRhythm,
         });
-        setError(undefined);
-      }
+      }).catch((reason) => {
+        if (active) {
+          setWorkRhythmError(
+            reason instanceof Error
+              ? reason.message
+              : "Unable to load estimated work",
+          );
+        }
+      });
     }).catch((reason) => {
       if (active) {
         setError(
@@ -93,8 +118,8 @@ export function NewPage() {
     });
   }
 
-  const selectedDate = data
-    ? calendarDate(search.date, data.workRhythm.range)
+  const selectedDate = workRhythmData
+    ? calendarDate(search.date, workRhythmData.workRhythm.range)
     : undefined;
 
   useEffect(() => {
@@ -119,16 +144,19 @@ export function NewPage() {
 
       <section className="new-overview-panel">
         {error && <div className="new-overview-error">{error}</div>}
+        {workRhythmError && (
+          <div className="new-overview-error">{workRhythmError}</div>
+        )}
 
         <div className="new-overview-grid">
           <div className="new-overview-left">
             <UsageOverview data={data} />
             <SessionShape range={search.range} harness={search.harness} />
           </div>
-          {data && (
+          {workRhythmData && (
             <Suspense fallback={null}>
               <WorkRhythm
-                data={data.workRhythm}
+                data={workRhythmData.workRhythm}
                 selectedDate={selectedDate!}
                 onSelect={(date) => update({ date })}
               />
@@ -146,9 +174,13 @@ export function NewPage() {
           <>
             <div className="new-placeholder-grid">
               <CacheOverview range={search.range} harness={search.harness} />
-              <Suspense fallback={null}>
-                <SessionDiagnostics data={data.sessionDiagnostics} />
-              </Suspense>
+              {workRhythmData && (
+                <Suspense fallback={null}>
+                  <SessionDiagnostics
+                    data={workRhythmData.sessionDiagnostics}
+                  />
+                </Suspense>
+              )}
             </div>
 
             <RecentSessions

--- a/src/client/NewPage.tsx
+++ b/src/client/NewPage.tsx
@@ -38,6 +38,18 @@ function calendarDate(
   return date && date >= range.start && date <= range.end ? date : range.end;
 }
 
+function WorkRhythmLoading() {
+  return (
+    <div
+      className="work-rhythm-loading"
+      role="status"
+      aria-label="Loading estimated work"
+    >
+      <span aria-hidden="true" />
+    </div>
+  );
+}
+
 export function NewPage() {
   const search = route.useSearch();
   const navigate = route.useNavigate();
@@ -153,15 +165,17 @@ export function NewPage() {
             <UsageOverview data={data} />
             <SessionShape range={search.range} harness={search.harness} />
           </div>
-          {workRhythmData && (
-            <Suspense fallback={null}>
-              <WorkRhythm
-                data={workRhythmData.workRhythm}
-                selectedDate={selectedDate!}
-                onSelect={(date) => update({ date })}
-              />
-            </Suspense>
-          )}
+          {workRhythmData
+            ? (
+              <Suspense fallback={<WorkRhythmLoading />}>
+                <WorkRhythm
+                  data={workRhythmData.workRhythm}
+                  selectedDate={selectedDate!}
+                  onSelect={(date) => update({ date })}
+                />
+              </Suspense>
+            )
+            : data && !workRhythmError && <WorkRhythmLoading />}
         </div>
 
         {data && (

--- a/src/client/api.ts
+++ b/src/client/api.ts
@@ -10,6 +10,7 @@ import {
   toolCallsResponseSchema,
   ttlMissMetricsSchema,
   usageResponseSchema,
+  workRhythmOverviewResponseSchema,
 } from "../shared/sessionSchemas.ts";
 
 const apiBaseUrl = (import.meta as ImportMeta & {
@@ -34,7 +35,8 @@ export async function syncSessions() {
 }
 
 export async function getHarnesses() {
-  return harnessesResponseSchema.parse(await getJson("/api/harnesses")).harnesses;
+  return harnessesResponseSchema.parse(await getJson("/api/harnesses"))
+    .harnesses;
 }
 
 export async function getTitleGenerationSetting() {
@@ -73,6 +75,20 @@ export async function getActivityOverview(
   });
   return activityOverviewResponseSchema.parse(
     await getJson(`/api/activity-overview?${query}`),
+  );
+}
+
+export async function getWorkRhythm(
+  range: 30 | 90,
+  harness: string,
+) {
+  const query = new URLSearchParams({
+    range: String(range),
+    harness,
+    timeZone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+  });
+  return workRhythmOverviewResponseSchema.parse(
+    await getJson(`/api/work-rhythm?${query}`),
   );
 }
 

--- a/src/client/new/SessionDiagnostics.tsx
+++ b/src/client/new/SessionDiagnostics.tsx
@@ -11,13 +11,13 @@ import {
   XAxis,
   YAxis,
 } from "recharts";
-import type { ActivityOverviewResponse } from "../../shared/sessionSchemas.ts";
+import type { WorkRhythmOverviewResponse } from "../../shared/sessionSchemas.ts";
 import { harnessName } from "../harness.ts";
 import { compact, currency } from "./formatters.ts";
 import { saveOverviewReturnScroll } from "./overviewReturnScroll.ts";
 import "./SessionDiagnostics.css";
 
-type SessionDiagnosticsData = ActivityOverviewResponse["sessionDiagnostics"];
+type SessionDiagnosticsData = WorkRhythmOverviewResponse["sessionDiagnostics"];
 type SessionPoint = SessionDiagnosticsData["sessions"][number];
 type Metric = "spend" | "input";
 type ChartPoint = SessionPoint & {

--- a/src/server/activityOverview.test.ts
+++ b/src/server/activityOverview.test.ts
@@ -1,7 +1,13 @@
 import { deepStrictEqual, strictEqual } from "node:assert";
-import { activityOverviewResponseSchema } from "../shared/sessionSchemas.ts";
+import {
+  activityOverviewResponseSchema,
+  workRhythmOverviewResponseSchema,
+} from "../shared/sessionSchemas.ts";
 import type { StoredOverviewRollup } from "./overviewAnalytics.ts";
-import { aggregateActivityOverview } from "./activityOverview.ts";
+import {
+  aggregateActivityOverview,
+  aggregateWorkRhythmOverview,
+} from "./activityOverview.ts";
 import type { OverviewDayRollup } from "./sessionRollups.ts";
 
 function day(
@@ -57,11 +63,17 @@ Deno.test("activity overview returns period totals and daily drill-down data", (
     roots,
     new Date(2026, 6, 1).getTime(),
     new Date(2026, 6, 2, 23, 59).getTime(),
-    undefined,
     1.5,
   );
 
   activityOverviewResponseSchema.parse(result);
+  const workRhythm = aggregateWorkRhythmOverview(
+    roots,
+    new Date(2026, 6, 1).getTime(),
+    new Date(2026, 6, 2, 23, 59).getTime(),
+    Intl.DateTimeFormat().resolvedOptions().timeZone,
+  );
+  workRhythmOverviewResponseSchema.parse(workRhythm);
   strictEqual(result.summary.sessions, 2);
   strictEqual(result.summary.processedInput, 6_000_000);
   strictEqual(result.summary.tokenReuse, 4_300_000 / 6_000_000);
@@ -70,7 +82,7 @@ Deno.test("activity overview returns period totals and daily drill-down data", (
   strictEqual(result.summary.spendAtMissCalls, 1.5);
   strictEqual(result.summary.subagentSpend, 2);
   strictEqual(result.summary.topDecileSpendShare, 5 / 9);
-  deepStrictEqual(result.sessionDiagnostics.sessions, [{
+  deepStrictEqual(workRhythm.sessionDiagnostics.sessions, [{
     id: "2",
     title: "Session 2",
     primaryModel: null,

--- a/src/server/activityOverview.ts
+++ b/src/server/activityOverview.ts
@@ -1,4 +1,7 @@
-import type { ActivityOverviewResponse } from "../shared/sessionSchemas.ts";
+import type {
+  ActivityOverviewResponse,
+  WorkRhythmOverviewResponse,
+} from "../shared/sessionSchemas.ts";
 import type { StoredOverviewRollup } from "./overviewAnalytics.ts";
 import { aggregateWorkRhythm } from "./workRhythm.ts";
 import { modelMetadata } from "../shared/modelMetadata.ts";
@@ -191,7 +194,7 @@ function sessionDiagnostics(
   roots: StoredOverviewRollup[],
   start: number,
   end: number,
-): ActivityOverviewResponse["sessionDiagnostics"] {
+): WorkRhythmOverviewResponse["sessionDiagnostics"] {
   const sessions = roots.flatMap((root) => {
     const days = root.overview.days.filter((day) =>
       day.firstTurnAt >= start && day.firstTurnAt <= end
@@ -258,7 +261,6 @@ export function aggregateActivityOverview(
   roots: StoredOverviewRollup[],
   start: number,
   end: number,
-  timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone,
   spendAtMissCalls = 0,
   recordTiming?: (name: string, duration: number) => void,
 ): ActivityOverviewResponse {
@@ -371,14 +373,6 @@ export function aggregateActivityOverview(
     "activity-buckets",
     performance.now() - aggregationStartedAt,
   );
-  const diagnostics = measured(
-    "session-diagnostics",
-    () => sessionDiagnostics(roots, start, end),
-  );
-  const workRhythm = measured(
-    "work-rhythm",
-    () => aggregateWorkRhythm(roots, start, end, timeZone),
-  );
   const composition = measured(
     "spend-composition",
     () => spendComposition(days, start, end),
@@ -422,9 +416,32 @@ export function aggregateActivityOverview(
         ? 0
         : topDecileSpend / pricedSessionSpend,
     },
-    sessionDiagnostics: diagnostics,
-    workRhythm,
     spendComposition: composition,
     days: responseDays,
+  };
+}
+
+export function aggregateWorkRhythmOverview(
+  roots: StoredOverviewRollup[],
+  start: number,
+  end: number,
+  timeZone: string,
+  recordTiming?: (name: string, duration: number) => void,
+): WorkRhythmOverviewResponse {
+  const measured = <T>(name: string, operation: () => T): T => {
+    const startedAt = performance.now();
+    const result = operation();
+    recordTiming?.(name, performance.now() - startedAt);
+    return result;
+  };
+  return {
+    workRhythm: measured(
+      "work-rhythm",
+      () => aggregateWorkRhythm(roots, start, end, timeZone),
+    ),
+    sessionDiagnostics: measured(
+      "session-diagnostics",
+      () => sessionDiagnostics(roots, start, end),
+    ),
   };
 }

--- a/src/server/activityOverview.ts
+++ b/src/server/activityOverview.ts
@@ -260,7 +260,15 @@ export function aggregateActivityOverview(
   end: number,
   timeZone = Intl.DateTimeFormat().resolvedOptions().timeZone,
   spendAtMissCalls = 0,
+  recordTiming?: (name: string, duration: number) => void,
 ): ActivityOverviewResponse {
+  const aggregationStartedAt = performance.now();
+  const measured = <T>(name: string, operation: () => T): T => {
+    const startedAt = performance.now();
+    const result = operation();
+    recordTiming?.(name, performance.now() - startedAt);
+    return result;
+  };
   const days = new Map<string, DayBucket>();
   const activityIntervals: Interval[] = [];
   const inactivityBuffer = ACTIVITY_INACTIVITY_MINUTES * 60_000;
@@ -359,6 +367,45 @@ export function aggregateActivityOverview(
   const topDecileSpend = rootSessionSpend.toSorted((a, b) => b - a)
     .slice(0, topSessionCount)
     .reduce((sum, spend) => sum + spend, 0);
+  recordTiming?.(
+    "activity-buckets",
+    performance.now() - aggregationStartedAt,
+  );
+  const diagnostics = measured(
+    "session-diagnostics",
+    () => sessionDiagnostics(roots, start, end),
+  );
+  const workRhythm = measured(
+    "work-rhythm",
+    () => aggregateWorkRhythm(roots, start, end, timeZone),
+  );
+  const composition = measured(
+    "spend-composition",
+    () => spendComposition(days, start, end),
+  );
+  const responseDays = measured(
+    "daily-response",
+    () =>
+      [...days.entries()].sort(([a], [b]) => a.localeCompare(b)).map(
+        ([date, day]) => ({
+          date,
+          processedInput: day.processedInput,
+          spend: day.spend,
+          hasUnpricedCost: day.hasUnpricedCost,
+          sessions: day.sessions,
+          turns: day.turns,
+          estimatedActiveMs: estimatedActiveMs(date, activityIntervals),
+          models: [...day.models.values()].toSorted((a, b) =>
+            b.spend - a.spend || b.input - a.input ||
+            a.model.localeCompare(b.model)
+          ).slice(0, 3).map(({ hasUnpricedCost: _, ...model }) => model),
+          topSessions: day.topSessions.toSorted((a, b) =>
+            b.spend - a.spend || b.processedInput - a.processedInput ||
+            a.id - b.id
+          ).slice(0, 3),
+        }),
+      ),
+  );
 
   return {
     startDate: dateKey(start),
@@ -375,27 +422,9 @@ export function aggregateActivityOverview(
         ? 0
         : topDecileSpend / pricedSessionSpend,
     },
-    sessionDiagnostics: sessionDiagnostics(roots, start, end),
-    workRhythm: aggregateWorkRhythm(roots, start, end, timeZone),
-    spendComposition: spendComposition(days, start, end),
-    days: [...days.entries()].sort(([a], [b]) => a.localeCompare(b)).map(
-      ([date, day]) => ({
-        date,
-        processedInput: day.processedInput,
-        spend: day.spend,
-        hasUnpricedCost: day.hasUnpricedCost,
-        sessions: day.sessions,
-        turns: day.turns,
-        estimatedActiveMs: estimatedActiveMs(date, activityIntervals),
-        models: [...day.models.values()].toSorted((a, b) =>
-          b.spend - a.spend || b.input - a.input ||
-          a.model.localeCompare(b.model)
-        ).slice(0, 3).map(({ hasUnpricedCost: _, ...model }) => model),
-        topSessions: day.topSessions.toSorted((a, b) =>
-          b.spend - a.spend || b.processedInput - a.processedInput ||
-          a.id - b.id
-        ).slice(0, 3),
-      }),
-    ),
+    sessionDiagnostics: diagnostics,
+    workRhythm,
+    spendComposition: composition,
+    days: responseDays,
   };
 }

--- a/src/server/conversationRepository.test.ts
+++ b/src/server/conversationRepository.test.ts
@@ -104,6 +104,39 @@ function linearSession(sourceID: number): LinearConversationImport {
   };
 }
 
+Deno.test("overview rollups return ordered root execution intervals", () => {
+  const db = openArchiveDatabase(":memory:");
+  migrateTestDatabase(db);
+  const sources = new SourceArtifactRepository(db);
+  const projection = new ConversationWriteRepository(db);
+  const conversations = new ConversationRepository(db);
+  try {
+    const sourceID = sources.ensureSource(
+      "pi",
+      "directory",
+      "Pi",
+      "/sessions",
+    );
+    const imported = linearSession(sourceID);
+    sources.recordUnchangedArtifact(
+      sourceID,
+      imported.externalID,
+      "project/linear.jsonl",
+      imported.observedAt,
+    );
+    projection.replaceLinearConversationTree([imported]);
+
+    const rollups = conversations.listOverviewRollups(0, "pi");
+    strictEqual(rollups.length, 1);
+    deepStrictEqual(rollups[0].rootExecutionIntervals, [
+      { startedAt: 10, executionEndAt: 12 },
+      { startedAt: 20, executionEndAt: 22 },
+    ]);
+  } finally {
+    db.close();
+  }
+});
+
 Deno.test("conversation repository linearizes Codex branches without duplicating usage", async () => {
   const db = openArchiveDatabase(":memory:");
   migrateTestDatabase(db);

--- a/src/server/conversationRepository.ts
+++ b/src/server/conversationRepository.ts
@@ -876,10 +876,42 @@ export class ConversationRepository {
   listOverviewRollups(
     startedAt: number,
     harness?: Harness,
+    recordTiming?: (name: string, duration: number) => void,
   ): StoredOverviewRollup[] {
-    const rows = this.db.prepare(`
-      SELECT c.id, ${effectiveConversationTitle} AS title, so.harness,
-        c.started_at, c.ended_at, cr.overview_json, COALESCE((
+    const measured = <T>(name: string, operation: () => T): T => {
+      const started = performance.now();
+      const result = operation();
+      recordTiming?.(name, performance.now() - started);
+      return result;
+    };
+    const parameters = [startedAt, harness ?? null, harness ?? null] as const;
+    const rows = measured("root-rollups", () =>
+      this.db.prepare(`
+        SELECT c.id, ${effectiveConversationTitle} AS title, so.harness,
+          c.started_at, c.ended_at, cr.overview_json,
+          COALESCE(c.public_id, c.external_id) AS session_public_id
+        FROM conversation_rollups cr
+        JOIN conversations c ON c.id = cr.conversation_id
+        JOIN sources so ON so.id = c.source_id
+        WHERE cr.last_activity_at >= ? AND cr.overview_json IS NOT NULL
+          AND (? IS NULL OR so.harness = ?)
+          AND NOT EXISTS (
+            SELECT 1 FROM conversation_subagent_launches launch
+            WHERE launch.child_conversation_id = c.id
+          )
+        ORDER BY c.id
+      `).all(...parameters) as Array<{
+        id: number;
+        title: string;
+        harness: Harness;
+        started_at: number | null;
+        ended_at: number | null;
+        overview_json: string;
+        session_public_id: string;
+      }>);
+    const spendRows = measured("descendant-spend", () =>
+      this.db.prepare(`
+        SELECT c.id, COALESCE((
           WITH RECURSIVE descendants(id) AS (
             SELECT launch.child_conversation_id
             FROM conversation_subagent_launches launch
@@ -894,15 +926,45 @@ export class ConversationRepository {
           FROM descendants
           JOIN conversation_rollups child
             ON child.conversation_id = descendants.id
-        ), 0) AS subagent_spend,
-        COALESCE(c.public_id, c.external_id) AS session_public_id,
-        COALESCE((
-          SELECT json_group_array(json_object(
-            'startedAt', measured_turn.started_at,
-            'executionEndAt', measured_turn.execution_end_at
-          ))
+        ), 0) AS subagent_spend
+        FROM conversation_rollups cr
+        JOIN conversations c ON c.id = cr.conversation_id
+        JOIN sources so ON so.id = c.source_id
+        WHERE cr.last_activity_at >= ? AND cr.overview_json IS NOT NULL
+          AND (? IS NULL OR so.harness = ?)
+          AND NOT EXISTS (
+            SELECT 1 FROM conversation_subagent_launches launch
+            WHERE launch.child_conversation_id = c.id
+          )
+        ORDER BY c.id
+      `).all(...parameters) as Array<{
+        id: number;
+        subagent_spend: number;
+      }>);
+    const intervalRows = measured(
+      "root-execution-intervals",
+      () =>
+        this.db.prepare(`
+          WITH selected_roots(id) AS MATERIALIZED (
+            SELECT c.id
+            FROM conversation_rollups cr
+            JOIN conversations c ON c.id = cr.conversation_id
+            JOIN sources so ON so.id = c.source_id
+            WHERE cr.last_activity_at >= ? AND cr.overview_json IS NOT NULL
+              AND (? IS NULL OR so.harness = ?)
+              AND NOT EXISTS (
+                SELECT 1 FROM conversation_subagent_launches launch
+                WHERE launch.child_conversation_id = c.id
+              )
+          )
+          SELECT measured_turn.root_id AS id,
+            json_group_array(json_object(
+              'startedAt', measured_turn.started_at,
+              'executionEndAt', measured_turn.execution_end_at
+            )) AS root_execution_intervals_json
           FROM (
-            SELECT root_turn.started_at,
+            SELECT root_turn.conversation_id AS root_id,
+              root_turn.id AS turn_id, root_turn.started_at, root_turn.ordinal,
               MAX(
                 root_turn.started_at,
                 MAX(COALESCE(
@@ -912,52 +974,50 @@ export class ConversationRepository {
                   root_call.started_at
                 ))
               ) AS execution_end_at
-            FROM conversation_turns root_turn
-            JOIN conversation_model_calls root_call
+            FROM selected_roots root
+            CROSS JOIN conversation_turns root_turn
+              ON root_turn.conversation_id = root.id
+            CROSS JOIN conversation_model_calls root_call
               ON root_call.turn_id = root_turn.id
             LEFT JOIN conversation_tool_events root_tool
               ON root_tool.model_call_id = root_call.id
-            WHERE root_turn.conversation_id = c.id
-              AND COALESCE(root_call.source_call_id, '')
+            WHERE COALESCE(root_call.source_call_id, '')
                 NOT LIKE 'context-operation:%'
               AND COALESCE(root_call.source_call_id, '')
                 NOT LIKE 'unmeasured:%'
-            GROUP BY root_turn.id
-            ORDER BY root_turn.started_at, root_turn.ordinal
+            GROUP BY root_turn.conversation_id, root_turn.id
+            ORDER BY root_turn.conversation_id, root_turn.started_at,
+              root_turn.ordinal
           ) measured_turn
-        ), '[]') AS root_execution_intervals_json
-      FROM conversation_rollups cr
-      JOIN conversations c ON c.id = cr.conversation_id
-      JOIN sources so ON so.id = c.source_id
-      WHERE cr.last_activity_at >= ? AND cr.overview_json IS NOT NULL
-        AND (? IS NULL OR so.harness = ?)
-        AND NOT EXISTS (
-          SELECT 1 FROM conversation_subagent_launches launch
-          WHERE launch.child_conversation_id = c.id
-        )
-      ORDER BY c.id
-    `).all(startedAt, harness ?? null, harness ?? null) as Array<{
-      id: number;
-      title: string;
-      harness: Harness;
-      started_at: number | null;
-      ended_at: number | null;
-      overview_json: string;
-      subagent_spend: number;
-      session_public_id: string;
-      root_execution_intervals_json: string;
-    }>;
-    return rows.map((row) => ({
-      rootSessionID: row.id,
-      rootExecutionIntervals: JSON.parse(row.root_execution_intervals_json),
-      sessionID: row.session_public_id,
-      ...(row.started_at === null ? {} : { startedAt: row.started_at }),
-      ...(row.ended_at === null ? {} : { endedAt: row.ended_at }),
-      title: row.title,
-      harness: row.harness,
-      subagentSpend: row.subagent_spend,
-      overview: JSON.parse(row.overview_json),
-    }));
+          GROUP BY measured_turn.root_id
+          ORDER BY measured_turn.root_id
+        `).all(...parameters) as Array<{
+          id: number;
+          root_execution_intervals_json: string;
+        }>,
+    );
+    return measured("hydrate-rollups", () => {
+      const spendByRoot = new Map(
+        spendRows.map((row) => [row.id, row.subagent_spend]),
+      );
+      const intervalsByRoot = new Map(
+        intervalRows.map((row) => [
+          row.id,
+          row.root_execution_intervals_json,
+        ]),
+      );
+      return rows.map((row) => ({
+        rootSessionID: row.id,
+        rootExecutionIntervals: JSON.parse(intervalsByRoot.get(row.id) ?? "[]"),
+        sessionID: row.session_public_id,
+        ...(row.started_at === null ? {} : { startedAt: row.started_at }),
+        ...(row.ended_at === null ? {} : { endedAt: row.ended_at }),
+        title: row.title,
+        harness: row.harness,
+        subagentSpend: spendByRoot.get(row.id) ?? 0,
+        overview: JSON.parse(row.overview_json),
+      }));
+    });
   }
 
   listSessionShapeRollups(

--- a/src/server/conversationRepository.ts
+++ b/src/server/conversationRepository.ts
@@ -876,8 +876,17 @@ export class ConversationRepository {
   listOverviewRollups(
     startedAt: number,
     harness?: Harness,
-    recordTiming?: (name: string, duration: number) => void,
+    options: {
+      includeSubagentSpend?: boolean;
+      includeRootExecutionIntervals?: boolean;
+      recordTiming?: (name: string, duration: number) => void;
+    } = {},
   ): StoredOverviewRollup[] {
+    const {
+      includeSubagentSpend = true,
+      includeRootExecutionIntervals = true,
+      recordTiming,
+    } = options;
     const measured = <T>(name: string, operation: () => T): T => {
       const started = performance.now();
       const result = operation();
@@ -909,8 +918,9 @@ export class ConversationRepository {
         overview_json: string;
         session_public_id: string;
       }>);
-    const spendRows = measured("descendant-spend", () =>
-      this.db.prepare(`
+    const spendRows = includeSubagentSpend
+      ? measured("descendant-spend", () =>
+        this.db.prepare(`
         SELECT c.id, COALESCE((
           WITH RECURSIVE descendants(id) AS (
             SELECT launch.child_conversation_id
@@ -937,14 +947,16 @@ export class ConversationRepository {
             WHERE launch.child_conversation_id = c.id
           )
         ORDER BY c.id
-      `).all(...parameters) as Array<{
-        id: number;
-        subagent_spend: number;
-      }>);
-    const intervalRows = measured(
-      "root-execution-intervals",
-      () =>
-        this.db.prepare(`
+        `).all(...parameters) as Array<{
+          id: number;
+          subagent_spend: number;
+        }>)
+      : [];
+    const intervalRows = includeRootExecutionIntervals
+      ? measured(
+        "root-execution-intervals",
+        () =>
+          this.db.prepare(`
           WITH selected_roots(id) AS MATERIALIZED (
             SELECT c.id
             FROM conversation_rollups cr
@@ -991,11 +1003,12 @@ export class ConversationRepository {
           ) measured_turn
           GROUP BY measured_turn.root_id
           ORDER BY measured_turn.root_id
-        `).all(...parameters) as Array<{
-          id: number;
-          root_execution_intervals_json: string;
-        }>,
-    );
+          `).all(...parameters) as Array<{
+            id: number;
+            root_execution_intervals_json: string;
+          }>,
+      )
+      : [];
     return measured("hydrate-rollups", () => {
       const spendByRoot = new Map(
         spendRows.map((row) => [row.id, row.subagent_spend]),
@@ -1008,13 +1021,21 @@ export class ConversationRepository {
       );
       return rows.map((row) => ({
         rootSessionID: row.id,
-        rootExecutionIntervals: JSON.parse(intervalsByRoot.get(row.id) ?? "[]"),
+        ...(includeRootExecutionIntervals
+          ? {
+            rootExecutionIntervals: JSON.parse(
+              intervalsByRoot.get(row.id) ?? "[]",
+            ),
+          }
+          : {}),
         sessionID: row.session_public_id,
         ...(row.started_at === null ? {} : { startedAt: row.started_at }),
         ...(row.ended_at === null ? {} : { endedAt: row.ended_at }),
         title: row.title,
         harness: row.harness,
-        subagentSpend: spendByRoot.get(row.id) ?? 0,
+        ...(includeSubagentSpend
+          ? { subagentSpend: spendByRoot.get(row.id) ?? 0 }
+          : {}),
         overview: JSON.parse(row.overview_json),
       }));
     });

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -25,7 +25,10 @@ import {
   aggregateOverviewRollups,
   ROTATION_INACTIVITY_MINUTES,
 } from "./overviewAnalytics.ts";
-import { aggregateActivityOverview } from "./activityOverview.ts";
+import {
+  aggregateActivityOverview,
+  aggregateWorkRhythmOverview,
+} from "./activityOverview.ts";
 import { workRhythmRange } from "./workRhythm.ts";
 import { aggregateSessionShape } from "./sessionShapeAnalytics.ts";
 import { expandHomePath, openArchiveDatabase, sqlitePath } from "./database.ts";
@@ -562,7 +565,10 @@ app.get("/api/activity-overview", (context) => {
   const loaded = readRepository.listOverviewRollups(
     start - 5 * 60_000,
     selectedHarness,
-    (name, duration) => databaseTimings.set(name, duration),
+    {
+      includeRootExecutionIntervals: false,
+      recordTiming: (name, duration) => databaseTimings.set(name, duration),
+    },
   );
   const loadDuration = performance.now() - loadStartedAt;
   const cacheMissStartedAt = performance.now();
@@ -577,7 +583,6 @@ app.get("/api/activity-overview", (context) => {
     loaded,
     start,
     end,
-    timeZone,
     spendAtMissCalls,
     (name, duration) => aggregationTimings.set(name, duration),
   );
@@ -614,6 +619,77 @@ app.get("/api/activity-overview", (context) => {
   return context.json(overview);
 });
 
+app.get("/api/work-rhythm", (context) => {
+  const requestStartedAt = performance.now();
+  const harness = context.req.query("harness") ?? "all";
+  if (!isHarnessFilter(harness)) {
+    return context.json({ error: "Invalid harness" }, 400);
+  }
+  const rangeParam = context.req.query("range") ?? "30";
+  if (rangeParam !== "30" && rangeParam !== "90") {
+    return context.json({ error: "Invalid range; expected 30 or 90" }, 400);
+  }
+  const range = Number(rangeParam) as 30 | 90;
+  const timeZone = context.req.query("timeZone") ??
+    Intl.DateTimeFormat().resolvedOptions().timeZone;
+  let boundaries: { start: number; end: number };
+  try {
+    boundaries = workRhythmRange(range, timeZone);
+  } catch {
+    return context.json({ error: "Invalid IANA timezone" }, 400);
+  }
+  const { start, end } = boundaries;
+  const selectedHarness = harness === "all"
+    ? undefined
+    : harness as SessionSummary["harness"];
+  const databaseTimings = new Map<string, number>();
+  const databaseStartedAt = performance.now();
+  const loaded = readRepository.listOverviewRollups(
+    start - 5 * 60_000,
+    selectedHarness,
+    {
+      includeSubagentSpend: false,
+      recordTiming: (name, duration) => databaseTimings.set(name, duration),
+    },
+  );
+  const databaseDuration = performance.now() - databaseStartedAt;
+  const aggregationTimings = new Map<string, number>();
+  const aggregationStartedAt = performance.now();
+  const overview = aggregateWorkRhythmOverview(
+    loaded,
+    start,
+    end,
+    timeZone,
+    (name, duration) => aggregationTimings.set(name, duration),
+  );
+  const aggregationDuration = performance.now() - aggregationStartedAt;
+  const totalDuration = performance.now() - requestStartedAt;
+  const detailTimingHeader = [
+    ...databaseTimings.entries(),
+    ...aggregationTimings.entries(),
+  ].map(([name, duration]) => `${name};dur=${duration.toFixed(1)}`).join(", ");
+  const detailTimingLog = [
+    ...databaseTimings.entries(),
+    ...aggregationTimings.entries(),
+  ].map(([name, duration]) => `${name}=${formatTiming(duration)}`).join(" ");
+  context.header(
+    "Server-Timing",
+    `database;dur=${
+      databaseDuration.toFixed(1)
+    }, ${detailTimingHeader}, aggregate;dur=${
+      aggregationDuration.toFixed(1)
+    }, total;dur=${totalDuration.toFixed(1)}`,
+  );
+  console.info(
+    `[work-rhythm] harness=${harness} range=${range} roots=${loaded.length} days=${
+      Object.keys(overview.workRhythm.days).length
+    } database=${formatTiming(databaseDuration)} ${detailTimingLog} aggregate=${
+      formatTiming(aggregationDuration)
+    } total=${formatTiming(totalDuration)}`,
+  );
+  return context.json(overview);
+});
+
 app.get("/api/overview", (context) => {
   const requestStartedAt = performance.now();
   const harness = context.req.query("harness") ?? "all";
@@ -643,6 +719,10 @@ app.get("/api/overview", (context) => {
   const loaded = readRepository.listOverviewRollups(
     start - ROTATION_INACTIVITY_MINUTES * 60_000,
     harness === "all" ? undefined : harness as SessionSummary["harness"],
+    {
+      includeSubagentSpend: false,
+      includeRootExecutionIntervals: false,
+    },
   );
   const loadDuration = performance.now() - loadStartedAt;
   const aggregationStartedAt = performance.now();

--- a/src/server/main.ts
+++ b/src/server/main.ts
@@ -557,35 +557,57 @@ app.get("/api/activity-overview", (context) => {
   const selectedHarness = harness === "all"
     ? undefined
     : harness as SessionSummary["harness"];
+  const databaseTimings = new Map<string, number>();
   const loadStartedAt = performance.now();
   const loaded = readRepository.listOverviewRollups(
     start - 5 * 60_000,
     selectedHarness,
+    (name, duration) => databaseTimings.set(name, duration),
   );
   const loadDuration = performance.now() - loadStartedAt;
-  const aggregationStartedAt = performance.now();
+  const cacheMissStartedAt = performance.now();
   const spendAtMissCalls = sumCacheMissCost(
     readRepository.summarizeCacheMisses(start, selectedHarness),
   );
+  const cacheMissDuration = performance.now() - cacheMissStartedAt;
+  databaseTimings.set("cache-misses", cacheMissDuration);
+  const aggregationTimings = new Map<string, number>();
+  const aggregationStartedAt = performance.now();
   const overview = aggregateActivityOverview(
     loaded,
     start,
     end,
     timeZone,
     spendAtMissCalls,
+    (name, duration) => aggregationTimings.set(name, duration),
   );
   const aggregationDuration = performance.now() - aggregationStartedAt;
+  const databaseDuration = loadDuration + cacheMissDuration;
   const totalDuration = performance.now() - requestStartedAt;
+  const detailTimingHeader = [
+    ...databaseTimings.entries(),
+    ...aggregationTimings.entries(),
+  ].map(
+    ([name, duration]) => `${name};dur=${duration.toFixed(1)}`,
+  ).join(", ");
+  const detailTimingLog = [
+    ...databaseTimings.entries(),
+    ...aggregationTimings.entries(),
+  ].map(
+    ([name, duration]) => `${name}=${formatTiming(duration)}`,
+  ).join(" ");
   context.header(
     "Server-Timing",
-    `sources;dur=${loadDuration.toFixed(1)}, aggregate;dur=${
+    `database;dur=${
+      databaseDuration.toFixed(1)
+    }, ${detailTimingHeader}, aggregate;dur=${
       aggregationDuration.toFixed(1)
     }, total;dur=${totalDuration.toFixed(1)}`,
   );
   console.info(
-    `[activity-overview] harness=${harness} range=${range} roots=${loaded.length} days=${overview.days.length} load=${
-      formatTiming(loadDuration)
-    } aggregate=${formatTiming(aggregationDuration)} total=${
+    `[activity-overview] harness=${harness} range=${range} roots=${loaded.length} days=${overview.days.length} database=${
+      formatTiming(databaseDuration)
+    } ${detailTimingLog} aggregate=${formatTiming(aggregationDuration)} total=${
       formatTiming(totalDuration)
     }`,
   );

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -535,6 +535,27 @@ export const spendCompositionSchema = z.object({
   })),
 });
 
+export const sessionDiagnosticsSchema = z.object({
+  sessions: z.array(z.object({
+    id: z.string(),
+    title: z.string(),
+    harness: harnessSchema.optional(),
+    primaryModel: z.string().nullable(),
+    estimatedActiveMinutes: z.number().nonnegative(),
+    observedSessionMinutes: z.number().nonnegative(),
+    spend: z.number().nonnegative(),
+    hasUnpricedSpend: z.boolean(),
+    processedInput: z.number().int().nonnegative(),
+    tokenReuse: z.number().min(0).max(1).optional(),
+    userTurns: z.number().int().nonnegative(),
+  })),
+});
+
+export const workRhythmOverviewResponseSchema = z.object({
+  workRhythm: workRhythmDataSchema,
+  sessionDiagnostics: sessionDiagnosticsSchema,
+});
+
 export const activityOverviewResponseSchema = z.object({
   startDate: z.string(),
   endDate: z.string(),
@@ -548,22 +569,6 @@ export const activityOverviewResponseSchema = z.object({
     subagentSpend: z.number().nonnegative(),
     topDecileSpendShare: z.number().min(0).max(1),
   }),
-  sessionDiagnostics: z.object({
-    sessions: z.array(z.object({
-      id: z.string(),
-      title: z.string(),
-      harness: harnessSchema.optional(),
-      primaryModel: z.string().nullable(),
-      estimatedActiveMinutes: z.number().nonnegative(),
-      observedSessionMinutes: z.number().nonnegative(),
-      spend: z.number().nonnegative(),
-      hasUnpricedSpend: z.boolean(),
-      processedInput: z.number().int().nonnegative(),
-      tokenReuse: z.number().min(0).max(1).optional(),
-      userTurns: z.number().int().nonnegative(),
-    })),
-  }),
-  workRhythm: workRhythmDataSchema,
   spendComposition: spendCompositionSchema,
   days: z.array(z.object({
     date: z.string(),
@@ -970,6 +975,9 @@ export type WorkRhythmDay = z.infer<typeof workRhythmDaySchema>;
 export type WorkRhythmData = z.infer<typeof workRhythmDataSchema>;
 export type ActivityOverviewResponse = z.infer<
   typeof activityOverviewResponseSchema
+>;
+export type WorkRhythmOverviewResponse = z.infer<
+  typeof workRhythmOverviewResponseSchema
 >;
 export type SpendCompositionData = z.infer<typeof spendCompositionSchema>;
 export type OverviewResponse = z.infer<typeof overviewResponseSchema>;


### PR DESCRIPTION
## Summary
- instrument activity overview database and aggregation phases
- rewrite root execution interval loading as a set-based query
- move Work Rhythm and Session Diagnostics to a dedicated endpoint
- let Usage and Spend Composition render without waiting for execution intervals
- show an accessible loading spinner while Estimated Work loads

## Measured outcome
Fresh uncached local requests on the current archive:

| Endpoint | Database | Total | Payload |
| --- | ---: | ---: | ---: |
| `/api/activity-overview` | 22.2 ms | 27.4 ms | 41 KB |
| `/api/work-rhythm` | 252.5 ms | 265.9 ms | 340 KB |

The previous combined activity endpoint took roughly 258–329 ms. Reconstructing the old response from the two new responses produced deeply equal data.

## Verification
- `deno task check`
- `deno task test` — 162 passed, 0 failed
- pre-commit formatting, linting, and type checking
- live requests to both endpoints returned 200
