### PR TITLE
Parse user prompts from older Claude Code versions

### DIFF
--- a/src/server/claudeCodeImporter.ts
+++ b/src/server/claudeCodeImporter.ts
@@ -13,7 +13,7 @@ import {
 import type { LinearConversationImport } from "./conversationImportTypes.ts";
 import { ConversationWriteRepository } from "./conversationWriteRepository.ts";
 
-const parserVersion = "claude-code-conversation-family-1";
+const parserVersion = "claude-code-conversation-family-2";
 const projectionName = "conversation";
 const sourceIdentityNamespace = "session";
 const forkRelationship = "fork";

--- a/src/server/claudeCodeRepository.ts
+++ b/src/server/claudeCodeRepository.ts
@@ -61,6 +61,8 @@ const recordSchema = z.object({
   compactMetadata: z.unknown().optional(),
   content: z.unknown().optional(),
   promptSource: z.string().optional(),
+  promptId: z.string().nullable().optional(),
+  userType: z.string().optional(),
   cwd: z.string().optional(),
   origin: z.object({ kind: z.string().optional() }).passthrough().optional(),
   message: z.object({
@@ -268,7 +270,8 @@ function startsTurn(record: Record, hasTurns: boolean) {
   if (!text) return false;
   return record.origin?.kind === "human" ||
     record.promptSource === "typed" || record.promptSource === "sdk" ||
-    text.startsWith("❯ ") || (record.isSidechain === true && !hasTurns);
+    text.startsWith("❯ ") || (record.isSidechain === true && !hasTurns) ||
+    (record.userType === "external" && record.promptId != null);
 }
 
 function claudeCheckpointItem(


### PR DESCRIPTION
## Summary

The parser skipped Claude Code sessions from older CLI versions because it did not recognize their user prompt format. I don't know at what version the cutoff is.

  - Add `promptId` and `userType` to the Claude Code transcript schema.
  - Detect the start of a user turn when `promptId` is set and `userType` is `external`.
  - Bump the Claude Code parser version so existing sessions parse again on the next sync.

## Verification
  - Local sync now imports 42 Claude sessions (previously 0).