### PR TITLE
Import compact Codex fork history

### DIFF
--- a/src/server/codexFamilyImporter.test.ts
+++ b/src/server/codexFamilyImporter.test.ts
@@ -828,6 +828,139 @@ Deno.test("Codex does not deduplicate copied-looking calls without stable identi
   }
 });
 
+Deno.test("Codex imports compact fork history carried by agent messages", async () => {
+  const directory = Deno.makeTempDirSync();
+  const source = `${directory}/sessions`;
+  Deno.mkdirSync(source);
+  const timestamp = "2026-08-20T12:00:00.000Z";
+  const tokenCount = (output: number) => ({
+    timestamp,
+    type: "event_msg",
+    payload: {
+      type: "token_count",
+      info: {
+        last_token_usage: {
+          input_tokens: 10,
+          cached_input_tokens: 0,
+          output_tokens: output,
+          reasoning_output_tokens: 0,
+        },
+      },
+    },
+  });
+  const agentMessage = (message: string) => ({
+    timestamp,
+    type: "event_msg",
+    payload: { type: "agent_message", message },
+  });
+  const response = (id: string, text: string) => ({
+    timestamp,
+    type: "response_item",
+    payload: {
+      type: "message",
+      id,
+      role: "assistant",
+      content: [{ type: "output_text", text }],
+    },
+  });
+  const toolCall = {
+    timestamp,
+    type: "response_item",
+    payload: {
+      type: "custom_tool_call",
+      id: "first-tool",
+      call_id: "first-tool-call",
+      name: "exec",
+      input: "echo first",
+    },
+  };
+  const toolOutput = {
+    timestamp,
+    type: "response_item",
+    payload: {
+      type: "custom_tool_call_output",
+      call_id: "first-tool-call",
+      output: "Tool result",
+    },
+  };
+  const task = (turnID: string) => ({
+    timestamp,
+    type: "event_msg",
+    payload: { type: "task_started", turn_id: turnID },
+  });
+  const user = (text: string) => ({
+    timestamp,
+    type: "response_item",
+    payload: {
+      type: "message",
+      role: "user",
+      content: [{ type: "input_text", text }],
+    },
+  });
+  const sharedPrefix = [task("shared-turn"), user("Inspect this")];
+  writeJsonl(`${source}/rollout-root.jsonl`, [
+    { type: "session_meta", payload: { id: "root" } },
+    ...sharedPrefix,
+    agentMessage("First result"),
+    response("first-response", "First result"),
+    toolCall,
+    toolOutput,
+    tokenCount(1),
+    agentMessage("Final result"),
+    response("final-response", "Final result"),
+    tokenCount(2),
+    user("Queued prompt"),
+    agentMessage("Queued result"),
+    response("queued-response", "Queued result"),
+    tokenCount(3),
+    task("later-shared-turn"),
+    user("Continue"),
+    agentMessage("Continued result"),
+    response("continued-response", "Continued result"),
+    tokenCount(4),
+  ]);
+  writeJsonl(`${source}/rollout-fork.jsonl`, [
+    {
+      type: "session_meta",
+      payload: { id: "fork", forked_from_id: "root" },
+    },
+    ...sharedPrefix,
+    agentMessage("First result"),
+    tokenCount(1),
+    agentMessage("Final result"),
+    response("final-response", "Final result"),
+    tokenCount(2),
+    user("Queued prompt"),
+    agentMessage("Queued result"),
+    tokenCount(3),
+    task("later-shared-turn"),
+    user("Continue"),
+    agentMessage("Continued result"),
+    response("continued-response", "Continued result"),
+    tokenCount(4),
+  ]);
+
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  migrateTestDatabase(db);
+  try {
+    const result = await syncCodexSessions(
+      source,
+      new SourceArtifactRepository(db),
+      new ConversationWriteRepository(db),
+    );
+
+    strictEqual(result.imported, 2);
+    strictEqual(result.failed, 0);
+    strictEqual(count(db, "conversations"), 1);
+    strictEqual(count(db, "conversation_branches"), 2);
+    strictEqual(count(db, "conversation_entries"), 8);
+    strictEqual(count(db, "artifact_entry_occurrences"), 15);
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});
+
 Deno.test("Codex projects a source artifact without provider session identity", async () => {
   const directory = Deno.makeTempDirSync();
   const source = `${directory}/sessions`;

--- a/src/server/codexRepository.ts
+++ b/src/server/codexRepository.ts
@@ -669,6 +669,10 @@ function decodeRecords(records: Record[]) {
   let pendingHasText = false;
   let pendingTools: ConversationToolImport[] = [];
   let pendingContent: ConversationContentImport[] = [];
+  // Codex forks can retain agent_message events while omitting their matching
+  // structured response_item records. Keep those messages as content unless a
+  // structured assistant response supersedes the same text.
+  const pendingAgentMessageContent = new Set<ConversationContentImport>();
   let pendingCallSourceIDs: string[] = [];
   const callTimings = inferCodexCallTimings(records);
   type PendingContextEvent = ConversationContextEventImport & {
@@ -772,6 +776,7 @@ function decodeRecords(records: Record[]) {
       pendingHasText = false;
       pendingTools = [];
       pendingContent = [];
+      pendingAgentMessageContent.clear();
       pendingCallSourceIDs = [];
       continue;
     }
@@ -866,6 +871,22 @@ function decodeRecords(records: Record[]) {
     }
 
     if (
+      record.type === "event_msg" && payload?.type === "agent_message"
+    ) {
+      const message = stringValue(payload.message);
+      if (message !== undefined) {
+        const content = {
+          ...preview(message),
+          sourceOrder: recordIndex + 1,
+        };
+        pendingContent.push(content);
+        pendingAgentMessageContent.add(content);
+        pendingHasText = true;
+      }
+      continue;
+    }
+
+    if (
       record.type === "response_item" &&
       (payload?.type === "custom_tool_call_output" ||
         payload?.type === "function_call_output")
@@ -884,7 +905,23 @@ function decodeRecords(records: Record[]) {
 
     if (record.type === "response_item" && hasText(record)) {
       pendingHasText = true;
-      pendingContent.push(...messageContent(record, recordIndex + 1));
+      const content = messageContent(record, recordIndex + 1);
+      // Full Codex logs store an agent_message immediately before the matching
+      // structured assistant response. Prefer the latter's stable source ID.
+      if (payload?.role === "assistant" && content.length === 1) {
+        for (let index = pendingContent.length - 1; index >= 0; index--) {
+          const fallback = pendingContent[index];
+          if (
+            !pendingAgentMessageContent.has(fallback) ||
+            fallback.preview !== content[0].preview ||
+            fallback.originalLength !== content[0].originalLength
+          ) continue;
+          pendingContent.splice(index, 1);
+          pendingAgentMessageContent.delete(fallback);
+          break;
+        }
+      }
+      pendingContent.push(...content);
       if (record.payload?.id !== undefined) {
         pendingCallSourceIDs.push(record.payload.id);
       }
@@ -976,6 +1013,7 @@ function decodeRecords(records: Record[]) {
     pendingHasText = false;
     pendingTools = [];
     pendingContent = [];
+    pendingAgentMessageContent.clear();
     pendingCallSourceIDs = [];
   }
 

--- a/src/server/conversationWriteRepository.ts
+++ b/src/server/conversationWriteRepository.ts
@@ -74,6 +74,28 @@ export type SourceArtifactFamilyImport = {
 
 type IdentityBasis = "stable-id" | "explicit-lineage" | "unresolved";
 
+type CanonicalEntrySource = {
+  sourceID?: string;
+  sourceOrder?: number;
+  signature: string;
+};
+
+function entrySignature(
+  kind: string,
+  role: string | undefined,
+  content: ConversationContentImport,
+) {
+  return JSON.stringify([
+    kind,
+    role ?? null,
+    content.kind,
+    content.preview ?? null,
+    content.originalLength ?? null,
+    content.truncated ?? false,
+    content.mimeType ?? null,
+  ]);
+}
+
 function confirmedIdentity(basis: IdentityBasis | undefined) {
   return basis === "stable-id" || basis === "explicit-lineage";
 }
@@ -616,6 +638,7 @@ export class ConversationWriteRepository {
         id: number;
         parentID: number | null;
         entryIDs: number[];
+        entrySources: CanonicalEntrySource[];
         callIDs: number[];
         lastEntryID: number | null;
       }>();
@@ -746,6 +769,8 @@ export class ConversationWriteRepository {
         const callKeys = new Set<string>();
         const turnKeys = new Set<string>();
         const entryKeys = new Set<string>();
+        let previousTurnKey: string | undefined;
+        const unresolvedTurnAppearances = new Map<string, number>();
         const contexts = [...(artifact.value.session.contextEvents ?? [])]
           .sort((a, b) => a.sourceOrder - b.sourceOrder);
         const contextAppearances = new Map<string, number>();
@@ -803,19 +828,34 @@ export class ConversationWriteRepository {
             turn.sourceOrderStart ?? Number.MAX_SAFE_INTEGER,
           );
           const turnBasis: IdentityBasis = turn.identityBasis ?? "unresolved";
+          const unresolvedTurnKey = previousTurnKey === undefined ||
+              turn.inputs === undefined || turn.inputs.length === 0
+            ? undefined
+            : `${previousTurnKey}:unresolved:${turn.inputs.map((input) =>
+              entrySignature("message", "user", input)
+            ).join("|")}`;
+          const unresolvedAppearance = unresolvedTurnKey === undefined
+            ? undefined
+            : (unresolvedTurnAppearances.get(unresolvedTurnKey) ?? 0) + 1;
+          if (unresolvedAppearance !== undefined) {
+            unresolvedTurnAppearances.set(
+              unresolvedTurnKey!,
+              unresolvedAppearance,
+            );
+          }
           const turnKey =
             confirmedIdentity(turnBasis) && turn.sourceID !== undefined
               ? `${turnBasis}:${turn.sourceID}`
-              : `${artifact.externalID}:turn:${turnIndex + 1}`;
+              : unresolvedTurnKey === undefined
+              ? `${artifact.externalID}:turn:${turnIndex + 1}`
+              : `${unresolvedTurnKey}:${unresolvedAppearance}`;
           let canonicalTurn = canonicalTurns.get(turnKey);
-          const currentEntrySources: Array<{
-            sourceID?: string;
-            sourceOrder?: number;
-          }> = [];
+          const currentEntrySources: CanonicalEntrySource[] = [];
           for (const input of turn.inputs ?? []) {
             currentEntrySources.push({
               sourceID: input.sourceID,
               sourceOrder: input.sourceOrder,
+              signature: entrySignature("message", "user", input),
             });
           }
           for (const call of turn.calls) {
@@ -823,19 +863,36 @@ export class ConversationWriteRepository {
               currentEntrySources.push({
                 sourceID: content.sourceID,
                 sourceOrder: content.sourceOrder,
+                signature: entrySignature(
+                  "message",
+                  content.kind === "reasoning" ? "reasoning" : "assistant",
+                  content,
+                ),
               });
             }
             for (const tool of call.activity.tools) {
               if (
                 tool.output !== undefined || tool.outputPreview !== undefined
               ) {
+                const content: ConversationContentImport = {
+                  kind: "text",
+                  preview: tool.output?.preview ?? tool.outputPreview,
+                  originalLength: tool.output?.originalLength ??
+                    tool.outputPreview?.length,
+                  truncated: tool.output?.truncated,
+                };
                 currentEntrySources.push({
                   sourceID: tool.outputSourceEntryID,
                   sourceOrder: tool.sourceOrderEnd,
+                  signature: entrySignature("tool-result", "tool", content),
                 });
               }
             }
           }
+          let entryMatches: Array<{
+            canonicalIndex: number;
+            source: CanonicalEntrySource;
+          }>;
 
           if (canonicalTurn === undefined) {
             turnOrdinal++;
@@ -1005,26 +1062,53 @@ export class ConversationWriteRepository {
               id: turnID,
               parentID: previousTurnID,
               entryIDs,
+              entrySources: currentEntrySources,
               callIDs,
               lastEntryID: previousEntryID,
             };
             canonicalTurns.set(turnKey, canonicalTurn);
+            entryMatches = currentEntrySources.map((source, canonicalIndex) => ({
+              canonicalIndex,
+              source,
+            }));
           } else {
-            if (canonicalTurn.parentID !== previousTurnID) {
+            const currentCanonicalTurn = canonicalTurn;
+            if (currentCanonicalTurn.parentID !== previousTurnID) {
               throw new Error(
                 `Conflicting canonical turn lineage: ${
                   turn.sourceID ?? turnKey
                 }`,
               );
             }
-            if (canonicalTurn.entryIDs.length !== currentEntrySources.length) {
-              throw new Error(
-                `Conflicting canonical entry shape: ${
-                  turn.sourceID ?? turnKey
-                }`,
+            const unmatchedCanonicalEntries = new Set(
+              currentCanonicalTurn.entrySources.map((_, index) => index),
+            );
+            entryMatches = currentEntrySources.map((source) => {
+              const canonicalIndex = currentCanonicalTurn.entrySources.findIndex(
+                (candidate, index) =>
+                  unmatchedCanonicalEntries.has(index) &&
+                  source.sourceID !== undefined &&
+                  source.sourceID === candidate.sourceID,
               );
-            }
-            previousEntryID = canonicalTurn.lastEntryID;
+              const fallbackIndex = canonicalIndex === -1
+                ? currentCanonicalTurn.entrySources.findIndex((candidate, index) =>
+                  unmatchedCanonicalEntries.has(index) &&
+                  source.signature === candidate.signature
+                )
+                : canonicalIndex;
+              if (fallbackIndex === -1) {
+                throw new Error(
+                  `Conflicting canonical entry shape: ${
+                    turn.sourceID ?? turnKey
+                  }`,
+                );
+              }
+              unmatchedCanonicalEntries.delete(fallbackIndex);
+              return { canonicalIndex: fallbackIndex, source };
+            });
+            previousEntryID = entryMatches.at(-1) === undefined
+              ? currentCanonicalTurn.lastEntryID
+              : currentCanonicalTurn.entryIDs[entryMatches.at(-1)!.canonicalIndex];
           }
 
           const turnKind = occurrenceKind(
@@ -1033,20 +1117,20 @@ export class ConversationWriteRepository {
             artifactTurnKeys,
             turnBasis,
           );
-          for (const [index, entryID] of canonicalTurn.entryIDs.entries()) {
-            const source = currentEntrySources[index];
-            const entryKey = source?.sourceID === undefined
-              ? `${turnKey}:entry:${index + 1}`
+          for (const { canonicalIndex, source } of entryMatches) {
+            const entryID = canonicalTurn.entryIDs[canonicalIndex];
+            const entryKey = source.sourceID === undefined
+              ? `${turnKey}:entry:${canonicalIndex + 1}`
               : `stable:${source.sourceID}`;
             insertEntryOccurrence({
               artifact,
               branchID,
               entryID,
-              sourceEntryID: source?.sourceID,
-              sourceOrderStart: source?.sourceOrder ?? turn.sourceOrderStart,
-              sourceOrderEnd: source?.sourceOrder ?? turn.sourceOrderEnd,
+              sourceEntryID: source.sourceID,
+              sourceOrderStart: source.sourceOrder ?? turn.sourceOrderStart,
+              sourceOrderEnd: source.sourceOrder ?? turn.sourceOrderEnd,
               kind: turnKind,
-              basis: source?.sourceID === undefined ? turnBasis : "stable-id",
+              basis: source.sourceID === undefined ? turnBasis : "stable-id",
             });
             pathEntryIDs.push(entryID);
             entryKeys.add(entryKey);
@@ -1107,6 +1191,7 @@ export class ConversationWriteRepository {
             callKeys.add(callKey);
           }
           previousTurnID = canonicalTurn.id;
+          previousTurnKey = turnKey;
           turnKeys.add(turnKey);
         }
         insertContextsBefore(Number.MAX_SAFE_INTEGER);


### PR DESCRIPTION
## Summary
- preserve compact `agent_message` records when detailed response items are absent
- reconcile fork branches that omit tool-result entries and carry queued prompts without native IDs
- cover compact copied history with a Codex family importer regression test

## Verification
- `deno test --config deno.json --allow-read --allow-write --allow-env src/server/codexFamilyImporter.test.ts`
- `deno test --config deno.json --allow-read --allow-write src/server/conversationWriteRepository.test.ts`
- `deno test --config deno.json --allow-read --allow-write src/server/codexRepository.test.ts`
- in-memory sync of the configured Codex source: 39 discovered, 39 imported, 0 failed
