### PR TITLE
Handle Claude background turn handoffs

### DIFF
--- a/src/server/claudeCodeImporter.test.ts
+++ b/src/server/claudeCodeImporter.test.ts
@@ -359,6 +359,82 @@ ${
   }
 });
 
+Deno.test("extends a copied Claude turn continued by a descendant", async () => {
+  const directory = Deno.makeTempDirSync();
+  const sessions = `${directory}/projects`;
+  const project = `${sessions}/project`;
+  const parent = "00000000-0000-4000-8000-000000000011";
+  const child = "00000000-0000-4000-8000-000000000012";
+  const sharedUser =
+    `{"type":"user","uuid":"shared-user","sessionId":"${parent}","timestamp":"2026-08-01T10:00:00Z","promptSource":"typed","origin":{"kind":"human"},"message":{"content":"Continue this turn"}}`;
+  const sharedCall =
+    `{"type":"assistant","uuid":"shared-assistant","sessionId":"${parent}","session_id":"${parent}","timestamp":"2026-08-01T10:00:01Z","message":{"id":"shared-call","model":"claude-sonnet","content":[{"type":"text","text":"First response"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}`;
+  write(
+    `${project}/${parent}.jsonl`,
+    `
+{"type":"ai-title","sessionId":"${parent}","aiTitle":"Background handoff"}
+${sharedUser}
+${sharedCall}
+    `,
+  );
+  write(
+    `${project}/${child}.jsonl`,
+    `
+{"type":"ai-title","sessionId":"${child}","aiTitle":"Background handoff"}
+${sharedUser.replaceAll(`"${parent}"`, `"${child}"`)}
+${sharedCall.replace(`"sessionId":"${parent}"`, `"sessionId":"${child}"`)}
+{"type":"assistant","uuid":"continued-assistant","sessionId":"${child}","session_id":"${child}","timestamp":"2026-08-01T10:00:02Z","message":{"id":"continued-call","model":"claude-sonnet","content":[{"type":"text","text":"Continued in background"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}
+    `,
+  );
+
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  migrateTestDatabase(db);
+  const repository = new SourceArtifactRepository(db);
+  const conversations = new ConversationWriteRepository(db);
+  try {
+    const result = await syncClaudeCodeSessions(
+      sessions,
+      repository,
+      conversations,
+    );
+    strictEqual(result.imported, 2);
+    strictEqual(
+      db.prepare("SELECT COUNT(*) AS count FROM conversation_turns").get()!
+        .count,
+      1,
+    );
+    strictEqual(
+      db.prepare("SELECT COUNT(*) AS count FROM conversation_model_calls")
+        .get()!.count,
+      2,
+    );
+    strictEqual(
+      db.prepare("SELECT COUNT(*) AS count FROM conversation_entries").get()!
+        .count,
+      3,
+    );
+    strictEqual(
+      db.prepare("SELECT model_calls FROM conversation_rollups").get()!
+        .model_calls,
+      2,
+    );
+    deepStrictEqual(
+      db.prepare(`
+        SELECT occurrence_kind, COUNT(*) AS count
+        FROM artifact_model_call_occurrences
+        GROUP BY occurrence_kind ORDER BY occurrence_kind
+      `).all().map((row) => ({ ...row })),
+      [
+        { occurrence_kind: "copied", count: 1 },
+        { occurrence_kind: "executed", count: 2 },
+      ],
+    );
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});
+
 Deno.test("Claude lineage changes rebuild both the prior and new families", async () => {
   const directory = Deno.makeTempDirSync();
   const sessions = `${directory}/projects`;

--- a/src/server/claudeCodeImporter.test.ts
+++ b/src/server/claudeCodeImporter.test.ts
@@ -420,15 +420,70 @@ ${sharedCall.replace(`"sessionId":"${parent}"`, `"sessionId":"${child}"`)}
     );
     deepStrictEqual(
       db.prepare(`
-        SELECT occurrence_kind, COUNT(*) AS count
-        FROM artifact_model_call_occurrences
-        GROUP BY occurrence_kind ORDER BY occurrence_kind
+        SELECT call.source_call_id, occurrence.occurrence_kind, COUNT(*) AS count
+        FROM artifact_model_call_occurrences occurrence
+        JOIN conversation_model_calls call ON call.id = occurrence.model_call_id
+        GROUP BY call.source_call_id, occurrence.occurrence_kind
+        ORDER BY call.source_call_id, occurrence.occurrence_kind
       `).all().map((row) => ({ ...row })),
       [
-        { occurrence_kind: "copied", count: 1 },
-        { occurrence_kind: "executed", count: 2 },
+        {
+          source_call_id: "continued-call",
+          occurrence_kind: "executed",
+          count: 1,
+        },
+        { source_call_id: "shared-call", occurrence_kind: "copied", count: 1 },
+        {
+          source_call_id: "shared-call",
+          occurrence_kind: "executed",
+          count: 1,
+        },
       ],
     );
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});
+
+Deno.test("rejects a divergent Claude continuation of a copied turn", async () => {
+  const directory = Deno.makeTempDirSync();
+  const sessions = `${directory}/projects`;
+  const project = `${sessions}/project`;
+  const parent = "00000000-0000-4000-8000-000000000013";
+  const child = "00000000-0000-4000-8000-000000000014";
+  const sharedUser =
+    `{"type":"user","uuid":"shared-user","sessionId":"${parent}","timestamp":"2026-08-01T10:00:00Z","promptSource":"typed","origin":{"kind":"human"},"message":{"content":"Continue this turn"}}`;
+  write(
+    `${project}/${parent}.jsonl`,
+    `
+{"type":"ai-title","sessionId":"${parent}","aiTitle":"Divergent handoff"}
+${sharedUser}
+{"type":"assistant","uuid":"shared-assistant","sessionId":"${parent}","session_id":"${parent}","timestamp":"2026-08-01T10:00:01Z","message":{"id":"shared-call","model":"claude-sonnet","content":[{"type":"text","text":"First response"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}
+    `,
+  );
+  write(
+    `${project}/${child}.jsonl`,
+    `
+{"type":"ai-title","sessionId":"${child}","aiTitle":"Divergent handoff"}
+${sharedUser.replaceAll(`"${parent}"`, `"${child}"`)}
+{"type":"assistant","uuid":"other-assistant","sessionId":"${child}","session_id":"${parent}","timestamp":"2026-08-01T10:00:01Z","message":{"id":"other-call","model":"claude-sonnet","content":[{"type":"text","text":"Different first response"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}
+{"type":"assistant","uuid":"continued-assistant","sessionId":"${child}","session_id":"${child}","timestamp":"2026-08-01T10:00:02Z","message":{"id":"continued-call","model":"claude-sonnet","content":[{"type":"text","text":"Continued in background"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}
+    `,
+  );
+
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  migrateTestDatabase(db);
+  const repository = new SourceArtifactRepository(db);
+  const conversations = new ConversationWriteRepository(db);
+  try {
+    const result = await syncClaudeCodeSessions(
+      sessions,
+      repository,
+      conversations,
+    );
+    strictEqual(result.imported, 0);
+    strictEqual(result.failed, 2);
   } finally {
     db.close();
     Deno.removeSync(directory, { recursive: true });

--- a/src/server/claudeCodeImporter.test.ts
+++ b/src/server/claudeCodeImporter.test.ts
@@ -440,13 +440,91 @@ ${sharedCall.replace(`"sessionId":"${parent}"`, `"sessionId":"${child}"`)}
         },
       ],
     );
+    deepStrictEqual(
+      db.prepare(`
+        SELECT session.external_id AS artifact, entry.content_preview AS head
+        FROM conversation_branches branch
+        JOIN source_sessions session ON session.id = branch.source_session_id
+        JOIN conversation_entries entry ON entry.id = branch.head_entry_id
+        ORDER BY session.external_id
+      `).all().map((row) => ({ ...row })),
+      [
+        { artifact: `project/${parent}`, head: "First response" },
+        {
+          artifact: `project/${child}`,
+          head: "Continued in background",
+        },
+      ],
+    );
+    deepStrictEqual(
+      db.prepare(`
+        SELECT session.external_id AS artifact, occurrence.occurrence_kind
+        FROM artifact_entry_occurrences occurrence
+        JOIN conversation_entries entry ON entry.id = occurrence.entry_id
+        JOIN source_sessions session ON session.id = occurrence.source_session_id
+        WHERE entry.content_preview = 'Continued in background'
+        ORDER BY session.external_id
+      `).all().map((row) => ({ ...row })),
+      [
+        {
+          artifact: `project/${child}`,
+          occurrence_kind: "executed",
+        },
+      ],
+    );
   } finally {
     db.close();
     Deno.removeSync(directory, { recursive: true });
   }
 });
 
-Deno.test("rejects a divergent Claude continuation of a copied turn", async () => {
+Deno.test("rejects extra content on a copied Claude call", async () => {
+  const directory = Deno.makeTempDirSync();
+  const sessions = `${directory}/projects`;
+  const project = `${sessions}/project`;
+  const parent = "00000000-0000-4000-8000-000000000015";
+  const child = "00000000-0000-4000-8000-000000000016";
+  const sharedUser =
+    `{"type":"user","uuid":"shared-user","sessionId":"${parent}","timestamp":"2026-08-01T10:00:00Z","promptSource":"typed","origin":{"kind":"human"},"message":{"content":"Continue this turn"}}`;
+  const sharedCall =
+    `{"type":"assistant","uuid":"shared-assistant","sessionId":"${parent}","session_id":"${parent}","timestamp":"2026-08-01T10:00:01Z","message":{"id":"shared-call","model":"claude-sonnet","content":[{"type":"text","text":"First response"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}`;
+  write(
+    `${project}/${parent}.jsonl`,
+    `
+{"type":"ai-title","sessionId":"${parent}","aiTitle":"Same-call growth"}
+${sharedUser}
+${sharedCall}
+    `,
+  );
+  write(
+    `${project}/${child}.jsonl`,
+    `
+{"type":"ai-title","sessionId":"${child}","aiTitle":"Same-call growth"}
+${sharedUser.replaceAll(`"${parent}"`, `"${child}"`)}
+${sharedCall.replace(`"sessionId":"${parent}"`, `"sessionId":"${child}"`)}
+{"type":"assistant","uuid":"continued-assistant","sessionId":"${child}","session_id":"${child}","timestamp":"2026-08-01T10:00:02Z","message":{"id":"shared-call","model":"claude-sonnet","content":[{"type":"text","text":"More on the same call"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}
+    `,
+  );
+
+  const db = openArchiveDatabase(`${directory}/archive.sqlite`);
+  migrateTestDatabase(db);
+  const repository = new SourceArtifactRepository(db);
+  const conversations = new ConversationWriteRepository(db);
+  try {
+    const result = await syncClaudeCodeSessions(
+      sessions,
+      repository,
+      conversations,
+    );
+    strictEqual(result.imported, 0);
+    strictEqual(result.failed, 2);
+  } finally {
+    db.close();
+    Deno.removeSync(directory, { recursive: true });
+  }
+});
+
+Deno.test("rejects a copied Claude call whose content changed under the same IDs", async () => {
   const directory = Deno.makeTempDirSync();
   const sessions = `${directory}/projects`;
   const project = `${sessions}/project`;
@@ -454,12 +532,14 @@ Deno.test("rejects a divergent Claude continuation of a copied turn", async () =
   const child = "00000000-0000-4000-8000-000000000014";
   const sharedUser =
     `{"type":"user","uuid":"shared-user","sessionId":"${parent}","timestamp":"2026-08-01T10:00:00Z","promptSource":"typed","origin":{"kind":"human"},"message":{"content":"Continue this turn"}}`;
+  const sharedCall =
+    `{"type":"assistant","uuid":"shared-assistant","sessionId":"${parent}","session_id":"${parent}","timestamp":"2026-08-01T10:00:01Z","message":{"id":"shared-call","model":"claude-sonnet","content":[{"type":"text","text":"First response"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}`;
   write(
     `${project}/${parent}.jsonl`,
     `
 {"type":"ai-title","sessionId":"${parent}","aiTitle":"Divergent handoff"}
 ${sharedUser}
-{"type":"assistant","uuid":"shared-assistant","sessionId":"${parent}","session_id":"${parent}","timestamp":"2026-08-01T10:00:01Z","message":{"id":"shared-call","model":"claude-sonnet","content":[{"type":"text","text":"First response"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}
+${sharedCall}
     `,
   );
   write(
@@ -467,7 +547,10 @@ ${sharedUser}
     `
 {"type":"ai-title","sessionId":"${child}","aiTitle":"Divergent handoff"}
 ${sharedUser.replaceAll(`"${parent}"`, `"${child}"`)}
-{"type":"assistant","uuid":"other-assistant","sessionId":"${child}","session_id":"${parent}","timestamp":"2026-08-01T10:00:01Z","message":{"id":"other-call","model":"claude-sonnet","content":[{"type":"text","text":"Different first response"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}
+${
+      sharedCall.replace(`"sessionId":"${parent}"`, `"sessionId":"${child}"`)
+        .replace("First response", "Changed first response")
+    }
 {"type":"assistant","uuid":"continued-assistant","sessionId":"${child}","session_id":"${child}","timestamp":"2026-08-01T10:00:02Z","message":{"id":"continued-call","model":"claude-sonnet","content":[{"type":"text","text":"Continued in background"}],"usage":{"input_tokens":1,"cache_read_input_tokens":2,"cache_creation_input_tokens":3,"output_tokens":4}}}
     `,
   );

--- a/src/server/conversationWriteRepository.ts
+++ b/src/server/conversationWriteRepository.ts
@@ -96,6 +96,7 @@ function entrySignature(
     content.originalLength ?? null,
     content.truncated ?? false,
     content.mimeType ?? null,
+    content.contentHash ?? null,
   ]);
 }
 
@@ -143,67 +144,92 @@ function turnEntrySources(
   return sources;
 }
 
-type TurnRelation =
-  | "equal"
-  | "current-is-prefix"
-  | "current-is-extension"
-  | "conflict";
-
 function sameEntrySources(
   left: CanonicalEntrySource[],
   right: CanonicalEntrySource[],
 ) {
   return left.length === right.length &&
-    left.every((source, index) =>
-      source.sourceID === right[index].sourceID &&
-      source.signature === right[index].signature
-    );
+    left.every((source, index) => {
+      const candidate = right[index];
+      return candidate !== undefined &&
+        source.sourceID === candidate.sourceID &&
+        source.signature === candidate.signature;
+    });
 }
 
-function overlappingCallIdentitiesAlign(
-  left: ConversationTurnImport,
-  right: ConversationTurnImport,
-) {
-  const overlap = Math.min(left.calls.length, right.calls.length);
-  return left.calls.slice(0, overlap).every((call, index) => {
-    const candidate = right.calls[index];
-    return candidate !== undefined && call.id === candidate.id &&
-      call.sourceID === candidate.sourceID;
-  });
+function persistedCallState(call: ConversationCallImport) {
+  return JSON.stringify([
+    call.id,
+    call.sourceID ?? null,
+    call.identityBasis ?? null,
+    call.callWithinTurn,
+    call.provider,
+    call.model,
+    call.startedAt,
+    call.completedAt ?? null,
+    call.reportedCost ?? null,
+    call.tokens.uncachedInput,
+    call.tokens.cacheRead,
+    call.tokens.cacheWrite ?? null,
+    call.tokens.cacheWrite5m ?? null,
+    call.tokens.cacheWrite1h ?? null,
+    call.tokens.freshPrompt,
+    call.tokens.output,
+    call.tokens.reasoning,
+    call.tokens.processed,
+    call.activity.finishReason ?? null,
+    call.activity.images ?? null,
+    Number(call.activity.hasText),
+    Number(call.activity.hasReasoning),
+    call.reasoningSetting ?? null,
+    (call.content ?? []).map((content) => [
+      content.sourceID ?? null,
+      entrySignature(
+        "message",
+        content.kind === "reasoning" ? "reasoning" : "assistant",
+        content,
+      ),
+    ]),
+    call.activity.tools.map((tool) => [
+      tool.sourceID ?? null,
+      tool.name,
+      tool.status,
+      tool.startedAt ?? null,
+      tool.completedAt ?? null,
+      tool.childExternalID ?? null,
+      tool.input?.preview ?? tool.inputPreview ?? null,
+      tool.input?.originalLength ?? null,
+      Number(tool.input?.truncated ?? false),
+      tool.output?.preview ?? tool.outputPreview ?? null,
+      tool.output?.originalLength ?? tool.outputPreview?.length ?? null,
+      Number(tool.output?.truncated ?? false),
+      tool.outputSourceEntryID ?? null,
+    ]),
+  ]);
 }
 
 function turnCallPrefix(turn: ConversationTurnImport, callCount: number) {
   return { ...turn, calls: turn.calls.slice(0, callCount) };
 }
 
-// Same-call content/tool growth is conflict until nested row updates exist.
-// current-is-extension is whole new calls on a descendant, overlapping calls unchanged.
-function compareTurnObservation(
+// Whole new descendant calls only. Extra content or tool results on an
+// existing call stay conflicts; those need nested row updates.
+function isWholeCallExtension(
   canonical: ConversationTurnImport,
   observed: ConversationTurnImport,
-): TurnRelation {
-  if (!overlappingCallIdentitiesAlign(canonical, observed)) return "conflict";
-  const canonicalEntries = turnEntrySources(canonical);
-  const observedEntries = turnEntrySources(observed);
+) {
+  if (observed.calls.length <= canonical.calls.length) return false;
   if (
-    canonical.calls.length === observed.calls.length &&
-    sameEntrySources(canonicalEntries, observedEntries)
-  ) return "equal";
-  if (
-    observed.calls.length < canonical.calls.length &&
-    sameEntrySources(
-      observedEntries,
-      turnEntrySources(turnCallPrefix(canonical, observed.calls.length)),
-    )
-  ) return "current-is-prefix";
-  if (
-    observed.calls.length > canonical.calls.length &&
-    sameEntrySources(
-      canonicalEntries,
-      turnEntrySources(turnCallPrefix(observed, canonical.calls.length)),
-    )
-  ) return "current-is-extension";
-  return "conflict";
+    !canonical.calls.every((call, index) => {
+      const candidate = observed.calls[index];
+      return candidate !== undefined &&
+        persistedCallState(call) === persistedCallState(candidate);
+    })
+  ) return false;
+  return sameEntrySources(
+    turnEntrySources(canonical),
+    turnEntrySources(turnCallPrefix(observed, canonical.calls.length)),
+  );
 }
 
 function isSourceDescendant(
@@ -788,7 +814,6 @@ export class ConversationWriteRepository {
         string,
         Array<{ modelCallID: number; toolEventID: number }>
       >();
-      const artifactTurnKeys = new Map<string, Set<string>>();
       const artifactCallKeys = new Map<string, Set<string>>();
       const artifactEntryKeys = new Map<string, Set<string>>();
       const artifactPaths = new Map<string, number[]>();
@@ -1043,7 +1068,6 @@ export class ConversationWriteRepository {
           : artifactCallPaths.get(parentArtifact.externalID);
         let implicitParentCallPrefix: number[] = [];
         const callKeys = new Set<string>();
-        const turnKeys = new Set<string>();
         const entryKeys = new Set<string>();
         let previousTurnKey: string | undefined;
         const unresolvedTurnAppearances = new Map<string, number>();
@@ -1213,15 +1237,16 @@ export class ConversationWriteRepository {
               );
             }
             if (
-              compareTurnObservation(currentCanonicalTurn.payload, turn) ===
-                "current-is-extension" &&
+              isWholeCallExtension(currentCanonicalTurn.payload, turn) &&
               isSourceDescendant(
                 artifact,
                 currentCanonicalTurn.owner,
                 byIdentity,
               )
             ) {
-              // Append descendant-only calls; do not rewrite overlapping calls.
+              const extraCalls = turn.calls.slice(
+                currentCanonicalTurn.payload.calls.length,
+              );
               const cursor: { entryID: number | null } = {
                 entryID: currentCanonicalTurn.lastEntryID,
               };
@@ -1229,17 +1254,25 @@ export class ConversationWriteRepository {
                 artifact,
                 turnKey,
                 currentCanonicalTurn.id,
-                turn.calls.slice(currentCanonicalTurn.payload.calls.length),
+                extraCalls,
                 currentCanonicalTurn.entryIDs,
                 currentCanonicalTurn.callIDs,
                 cursor,
               );
               currentCanonicalTurn.lastEntryID = cursor.entryID;
-              currentCanonicalTurn.payload = turn;
+              currentCanonicalTurn.payload = {
+                ...currentCanonicalTurn.payload,
+                calls: [
+                  ...currentCanonicalTurn.payload.calls,
+                  ...extraCalls,
+                ],
+              };
               currentCanonicalTurn.owner = artifact;
-              currentCanonicalTurn.entrySources = turnEntrySources(turn);
+              currentCanonicalTurn.entrySources = turnEntrySources(
+                currentCanonicalTurn.payload,
+              );
               canonicalTurnValues[currentCanonicalTurn.valueIndex] = {
-                ...turn,
+                ...currentCanonicalTurn.payload,
                 number:
                   canonicalTurnValues[currentCanonicalTurn.valueIndex].number,
               };
@@ -1248,22 +1281,31 @@ export class ConversationWriteRepository {
               currentCanonicalTurn.entrySources.map((_, index) => index),
             );
             entryMatches = currentEntrySources.map((source) => {
-              const canonicalIndex = currentCanonicalTurn.entrySources
+              if (source.sourceID !== undefined) {
+                const byID = currentCanonicalTurn.entrySources.findIndex(
+                  (candidate, index) =>
+                    unmatchedCanonicalEntries.has(index) &&
+                    candidate.sourceID === source.sourceID,
+                );
+                if (byID !== -1) {
+                  const matched = currentCanonicalTurn.entrySources[byID];
+                  if (matched.signature !== source.signature) {
+                    throw new Error(
+                      `Conflicting canonical entry shape: ${
+                        turn.sourceID ?? turnKey
+                      }`,
+                    );
+                  }
+                  unmatchedCanonicalEntries.delete(byID);
+                  return { canonicalIndex: byID, source };
+                }
+              }
+              const fallbackIndex = currentCanonicalTurn.entrySources
                 .findIndex(
                   (candidate, index) =>
                     unmatchedCanonicalEntries.has(index) &&
-                    source.sourceID !== undefined &&
-                    source.sourceID === candidate.sourceID,
+                    source.signature === candidate.signature,
                 );
-              const fallbackIndex = canonicalIndex === -1
-                ? currentCanonicalTurn.entrySources.findIndex((
-                  candidate,
-                  index,
-                ) =>
-                  unmatchedCanonicalEntries.has(index) &&
-                  source.signature === candidate.signature
-                )
-                : canonicalIndex;
               if (fallbackIndex === -1) {
                 throw new Error(
                   `Conflicting canonical entry shape: ${
@@ -1280,17 +1322,14 @@ export class ConversationWriteRepository {
                 .entryIDs[entryMatches.at(-1)!.canonicalIndex];
           }
 
-          const turnKind = occurrenceKind(
-            artifact,
-            turnKey,
-            artifactTurnKeys,
-            turnBasis,
-          );
           for (const { canonicalIndex, source } of entryMatches) {
             const entryID = canonicalTurn.entryIDs[canonicalIndex];
             const entryKey = source.sourceID === undefined
               ? `${turnKey}:entry:${canonicalIndex + 1}`
               : `stable:${source.sourceID}`;
+            const entryBasis: IdentityBasis = source.sourceID === undefined
+              ? turnBasis
+              : "stable-id";
             insertEntryOccurrence({
               artifact,
               branchID,
@@ -1298,8 +1337,13 @@ export class ConversationWriteRepository {
               sourceEntryID: source.sourceID,
               sourceOrderStart: source.sourceOrder ?? turn.sourceOrderStart,
               sourceOrderEnd: source.sourceOrder ?? turn.sourceOrderEnd,
-              kind: turnKind,
-              basis: source.sourceID === undefined ? turnBasis : "stable-id",
+              kind: occurrenceKind(
+                artifact,
+                entryKey,
+                artifactEntryKeys,
+                entryBasis,
+              ),
+              basis: entryBasis,
             });
             pathEntryIDs.push(entryID);
             entryKeys.add(entryKey);
@@ -1368,7 +1412,6 @@ export class ConversationWriteRepository {
           }
           previousTurnID = canonicalTurn.id;
           previousTurnKey = turnKey;
-          turnKeys.add(turnKey);
         }
         insertContextsBefore(Number.MAX_SAFE_INTEGER);
 
@@ -1406,7 +1449,6 @@ export class ConversationWriteRepository {
           forkPointProvenance,
           branchID,
         );
-        artifactTurnKeys.set(artifact.externalID, turnKeys);
         artifactCallKeys.set(artifact.externalID, callKeys);
         artifactEntryKeys.set(artifact.externalID, entryKeys);
         artifactPaths.set(artifact.externalID, pathEntryIDs);

--- a/src/server/conversationWriteRepository.ts
+++ b/src/server/conversationWriteRepository.ts
@@ -2,6 +2,7 @@ import type { DatabaseSync } from "node:sqlite";
 import type { JsonObject } from "../shared/json.ts";
 import type {
   ConversationContentImport,
+  ConversationTurnImport,
   LinearConversationImport,
   ReasoningSettingImport,
 } from "./conversationImportTypes.ts";
@@ -95,6 +96,71 @@ function entrySignature(
     content.truncated ?? false,
     content.mimeType ?? null,
   ]);
+}
+
+function turnEntrySources(turn: ConversationTurnImport): CanonicalEntrySource[] {
+  const sources: CanonicalEntrySource[] = [];
+  for (const input of turn.inputs ?? []) {
+    sources.push({
+      sourceID: input.sourceID,
+      sourceOrder: input.sourceOrder,
+      signature: entrySignature("message", "user", input),
+    });
+  }
+  for (const call of turn.calls) {
+    for (const content of call.content ?? []) {
+      sources.push({
+        sourceID: content.sourceID,
+        sourceOrder: content.sourceOrder,
+        signature: entrySignature(
+          "message",
+          content.kind === "reasoning" ? "reasoning" : "assistant",
+          content,
+        ),
+      });
+    }
+    for (const tool of call.activity.tools) {
+      if (tool.output === undefined && tool.outputPreview === undefined) {
+        continue;
+      }
+      const content: ConversationContentImport = {
+        kind: "text",
+        preview: tool.output?.preview ?? tool.outputPreview,
+        originalLength: tool.output?.originalLength ??
+          tool.outputPreview?.length,
+        truncated: tool.output?.truncated,
+      };
+      sources.push({
+        sourceID: tool.outputSourceEntryID,
+        sourceOrder: tool.sourceOrderEnd,
+        signature: entrySignature("tool-result", "tool", content),
+      });
+    }
+  }
+  return sources;
+}
+
+function isStrictTurnPrefix(
+  prefix: ConversationTurnImport,
+  extension: ConversationTurnImport,
+) {
+  if (
+    prefix.calls.length > extension.calls.length ||
+    (prefix.calls.length === extension.calls.length &&
+      turnEntrySources(prefix).length >= turnEntrySources(extension).length)
+  ) return false;
+  if (!prefix.calls.every((call, index) => {
+    const candidate = extension.calls[index];
+    return candidate !== undefined && call.id === candidate.id &&
+      call.sourceID === candidate.sourceID;
+  })) return false;
+  const prefixEntries = turnEntrySources(prefix);
+  const extensionEntries = turnEntrySources(extension);
+  return prefixEntries.every((source, index) => {
+    const candidate = extensionEntries[index];
+    return candidate !== undefined && source.sourceID === candidate.sourceID &&
+      source.signature === candidate.signature;
+  });
 }
 
 function confirmedIdentity(basis: IdentityBasis | undefined) {
@@ -422,6 +488,41 @@ export class ConversationWriteRepository {
       )[0];
     if (root === undefined) {
       throw new Error("A source artifact family has no root");
+    }
+
+    // Claude can copy an in-progress stable turn into a descendant and finish
+    // it there. Preselect that strict extension before materializing its parent.
+    const canonicalTurnImports = new Map<string, {
+      artifact: SourceArtifactFamilyMemberImport;
+      turn: ConversationTurnImport;
+    }>();
+    const isDescendant = (
+      artifact: SourceArtifactFamilyMemberImport,
+      ancestor: SourceArtifactFamilyMemberImport,
+    ) => {
+      let current = artifact;
+      while (current.parentSourceIdentity !== undefined) {
+        const parent = byIdentity.get(current.parentSourceIdentity);
+        if (parent === undefined) return false;
+        if (parent.externalID === ancestor.externalID) return true;
+        current = parent;
+      }
+      return false;
+    };
+    for (const artifact of ordered) {
+      for (const turn of artifact.value.session.turns) {
+        const basis: IdentityBasis = turn.identityBasis ?? "unresolved";
+        if (!confirmedIdentity(basis) || turn.sourceID === undefined) continue;
+        const key = `${basis}:${turn.sourceID}`;
+        const canonical = canonicalTurnImports.get(key);
+        if (
+          canonical === undefined ||
+          (isDescendant(artifact, canonical.artifact) &&
+            isStrictTurnPrefix(canonical.turn, turn))
+        ) {
+          canonicalTurnImports.set(key, { artifact, turn });
+        }
+      }
     }
 
     const allCalls = ordered.flatMap((artifact) =>
@@ -864,45 +965,9 @@ export class ConversationWriteRepository {
               ? `${artifact.externalID}:turn:${turnIndex + 1}`
               : `${unresolvedTurnKey}:${unresolvedAppearance}`;
           let canonicalTurn = canonicalTurns.get(turnKey);
-          const currentEntrySources: CanonicalEntrySource[] = [];
-          for (const input of turn.inputs ?? []) {
-            currentEntrySources.push({
-              sourceID: input.sourceID,
-              sourceOrder: input.sourceOrder,
-              signature: entrySignature("message", "user", input),
-            });
-          }
-          for (const call of turn.calls) {
-            for (const content of call.content ?? []) {
-              currentEntrySources.push({
-                sourceID: content.sourceID,
-                sourceOrder: content.sourceOrder,
-                signature: entrySignature(
-                  "message",
-                  content.kind === "reasoning" ? "reasoning" : "assistant",
-                  content,
-                ),
-              });
-            }
-            for (const tool of call.activity.tools) {
-              if (
-                tool.output !== undefined || tool.outputPreview !== undefined
-              ) {
-                const content: ConversationContentImport = {
-                  kind: "text",
-                  preview: tool.output?.preview ?? tool.outputPreview,
-                  originalLength: tool.output?.originalLength ??
-                    tool.outputPreview?.length,
-                  truncated: tool.output?.truncated,
-                };
-                currentEntrySources.push({
-                  sourceID: tool.outputSourceEntryID,
-                  sourceOrder: tool.sourceOrderEnd,
-                  signature: entrySignature("tool-result", "tool", content),
-                });
-              }
-            }
-          }
+          const currentEntrySources = turnEntrySources(turn);
+          const canonicalTurnImport = canonicalTurnImports.get(turnKey)?.turn ??
+            turn;
           let entryMatches: Array<{
             canonicalIndex: number;
             source: CanonicalEntrySource;
@@ -910,7 +975,10 @@ export class ConversationWriteRepository {
 
           if (canonicalTurn === undefined) {
             turnOrdinal++;
-            canonicalTurnValues.push({ ...turn, number: turnOrdinal });
+            canonicalTurnValues.push({
+              ...canonicalTurnImport,
+              number: turnOrdinal,
+            });
             const turnID: number = Number(
               // SAFETY: The static SQL projection and migrated schema define this row contract.
               (this.#prepare(`
@@ -924,28 +992,28 @@ export class ConversationWriteRepository {
             `).get(
                   conversationID,
                   previousTurnID,
-                  turn.sourceID ?? null,
+                  canonicalTurnImport.sourceID ?? null,
                   turnOrdinal,
-                  turn.startedAt,
-                  ...reasoningValues(turn.reasoningSetting),
+                  canonicalTurnImport.startedAt,
+                  ...reasoningValues(canonicalTurnImport.reasoningSetting),
                 ) as { id: number }).id,
             );
             const entryIDs: number[] = [];
-            for (const input of turn.inputs ?? []) {
+            for (const input of canonicalTurnImport.inputs ?? []) {
               const entryID = insertEntry({
                 parentEntryID: previousEntryID,
                 turnID,
                 stableSourceID: input.sourceID,
                 kind: "message",
                 role: "user",
-                occurredAt: turn.startedAt,
+                occurredAt: canonicalTurnImport.startedAt,
                 content: input,
               });
               previousEntryID = entryID;
               entryIDs.push(entryID);
             }
             const callIDs: number[] = [];
-            for (const call of turn.calls) {
+            for (const call of canonicalTurnImport.calls) {
               const callBasis: IdentityBasis = call.identityBasis ??
                 "unresolved";
               const callKey =
@@ -999,7 +1067,6 @@ export class ConversationWriteRepository {
                 canonicalCallValues.set(callID, call);
               }
               callIDs.push(callID);
-              callKeys.add(callKey);
 
               (call.content ?? []).forEach((content, index) => {
                 const entryID = insertEntry({
@@ -1079,7 +1146,7 @@ export class ConversationWriteRepository {
               id: turnID,
               parentID: previousTurnID,
               entryIDs,
-              entrySources: currentEntrySources,
+              entrySources: turnEntrySources(canonicalTurnImport),
               callIDs,
               lastEntryID: previousEntryID,
             };
@@ -1091,6 +1158,9 @@ export class ConversationWriteRepository {
               canonicalIndex,
               source,
             }));
+            previousEntryID = entryMatches.at(-1) === undefined
+              ? canonicalTurn.lastEntryID
+              : canonicalTurn.entryIDs[entryMatches.at(-1)!.canonicalIndex];
           } else {
             const currentCanonicalTurn = canonicalTurn;
             if (currentCanonicalTurn.parentID !== previousTurnID) {

--- a/src/server/conversationWriteRepository.ts
+++ b/src/server/conversationWriteRepository.ts
@@ -1,6 +1,7 @@
 import type { DatabaseSync } from "node:sqlite";
 import type { JsonObject } from "../shared/json.ts";
 import type {
+  ConversationCallImport,
   ConversationContentImport,
   ConversationTurnImport,
   LinearConversationImport,
@@ -98,7 +99,9 @@ function entrySignature(
   ]);
 }
 
-function turnEntrySources(turn: ConversationTurnImport): CanonicalEntrySource[] {
+function turnEntrySources(
+  turn: ConversationTurnImport,
+): CanonicalEntrySource[] {
   const sources: CanonicalEntrySource[] = [];
   for (const input of turn.inputs ?? []) {
     sources.push({
@@ -140,27 +143,82 @@ function turnEntrySources(turn: ConversationTurnImport): CanonicalEntrySource[] 
   return sources;
 }
 
-function isStrictTurnPrefix(
-  prefix: ConversationTurnImport,
-  extension: ConversationTurnImport,
+type TurnRelation =
+  | "equal"
+  | "current-is-prefix"
+  | "current-is-extension"
+  | "conflict";
+
+function sameEntrySources(
+  left: CanonicalEntrySource[],
+  right: CanonicalEntrySource[],
 ) {
-  if (
-    prefix.calls.length > extension.calls.length ||
-    (prefix.calls.length === extension.calls.length &&
-      turnEntrySources(prefix).length >= turnEntrySources(extension).length)
-  ) return false;
-  if (!prefix.calls.every((call, index) => {
-    const candidate = extension.calls[index];
+  return left.length === right.length &&
+    left.every((source, index) =>
+      source.sourceID === right[index].sourceID &&
+      source.signature === right[index].signature
+    );
+}
+
+function overlappingCallIdentitiesAlign(
+  left: ConversationTurnImport,
+  right: ConversationTurnImport,
+) {
+  const overlap = Math.min(left.calls.length, right.calls.length);
+  return left.calls.slice(0, overlap).every((call, index) => {
+    const candidate = right.calls[index];
     return candidate !== undefined && call.id === candidate.id &&
       call.sourceID === candidate.sourceID;
-  })) return false;
-  const prefixEntries = turnEntrySources(prefix);
-  const extensionEntries = turnEntrySources(extension);
-  return prefixEntries.every((source, index) => {
-    const candidate = extensionEntries[index];
-    return candidate !== undefined && source.sourceID === candidate.sourceID &&
-      source.signature === candidate.signature;
   });
+}
+
+function turnCallPrefix(turn: ConversationTurnImport, callCount: number) {
+  return { ...turn, calls: turn.calls.slice(0, callCount) };
+}
+
+// Same-call content/tool growth is conflict until nested row updates exist.
+// current-is-extension is whole new calls on a descendant, overlapping calls unchanged.
+function compareTurnObservation(
+  canonical: ConversationTurnImport,
+  observed: ConversationTurnImport,
+): TurnRelation {
+  if (!overlappingCallIdentitiesAlign(canonical, observed)) return "conflict";
+  const canonicalEntries = turnEntrySources(canonical);
+  const observedEntries = turnEntrySources(observed);
+  if (
+    canonical.calls.length === observed.calls.length &&
+    sameEntrySources(canonicalEntries, observedEntries)
+  ) return "equal";
+  if (
+    observed.calls.length < canonical.calls.length &&
+    sameEntrySources(
+      observedEntries,
+      turnEntrySources(turnCallPrefix(canonical, observed.calls.length)),
+    )
+  ) return "current-is-prefix";
+  if (
+    observed.calls.length > canonical.calls.length &&
+    sameEntrySources(
+      canonicalEntries,
+      turnEntrySources(turnCallPrefix(observed, canonical.calls.length)),
+    )
+  ) return "current-is-extension";
+  return "conflict";
+}
+
+function isSourceDescendant(
+  artifact: SourceArtifactFamilyMemberImport,
+  ancestor: SourceArtifactFamilyMemberImport,
+  byIdentity: Map<string, SourceArtifactFamilyMemberImport>,
+) {
+  let current = artifact;
+  while (current.parentSourceIdentity !== undefined) {
+    const parent = byIdentity.get(current.parentSourceIdentity);
+    if (parent === undefined) return false;
+    if (parent.externalID === ancestor.externalID) return true;
+    current = parent;
+  }
+  return false;
 }
 
 function confirmedIdentity(basis: IdentityBasis | undefined) {
@@ -490,41 +548,6 @@ export class ConversationWriteRepository {
       throw new Error("A source artifact family has no root");
     }
 
-    // Claude can copy an in-progress stable turn into a descendant and finish
-    // it there. Preselect that strict extension before materializing its parent.
-    const canonicalTurnImports = new Map<string, {
-      artifact: SourceArtifactFamilyMemberImport;
-      turn: ConversationTurnImport;
-    }>();
-    const isDescendant = (
-      artifact: SourceArtifactFamilyMemberImport,
-      ancestor: SourceArtifactFamilyMemberImport,
-    ) => {
-      let current = artifact;
-      while (current.parentSourceIdentity !== undefined) {
-        const parent = byIdentity.get(current.parentSourceIdentity);
-        if (parent === undefined) return false;
-        if (parent.externalID === ancestor.externalID) return true;
-        current = parent;
-      }
-      return false;
-    };
-    for (const artifact of ordered) {
-      for (const turn of artifact.value.session.turns) {
-        const basis: IdentityBasis = turn.identityBasis ?? "unresolved";
-        if (!confirmedIdentity(basis) || turn.sourceID === undefined) continue;
-        const key = `${basis}:${turn.sourceID}`;
-        const canonical = canonicalTurnImports.get(key);
-        if (
-          canonical === undefined ||
-          (isDescendant(artifact, canonical.artifact) &&
-            isStrictTurnPrefix(canonical.turn, turn))
-        ) {
-          canonicalTurnImports.set(key, { artifact, turn });
-        }
-      }
-    }
-
     const allCalls = ordered.flatMap((artifact) =>
       artifact.value.session.turns.flatMap((turn) => turn.calls)
     );
@@ -748,6 +771,9 @@ export class ConversationWriteRepository {
       const canonicalTurns = new Map<string, {
         id: number;
         parentID: number | null;
+        owner: SourceArtifactFamilyMemberImport;
+        payload: ConversationTurnImport;
+        valueIndex: number;
         entryIDs: number[];
         entrySources: CanonicalEntrySource[];
         callIDs: number[];
@@ -866,6 +892,143 @@ export class ConversationWriteRepository {
             evidence(options.artifact),
           );
 
+      const appendTurnCalls = (
+        artifact: SourceArtifactFamilyMemberImport,
+        turnKey: string,
+        turnID: number,
+        calls: ConversationCallImport[],
+        entryIDs: number[],
+        callIDs: number[],
+        cursor: { entryID: number | null },
+      ) => {
+        for (const call of calls) {
+          const callBasis: IdentityBasis = call.identityBasis ?? "unresolved";
+          const callKey =
+            confirmedIdentity(callBasis) && call.sourceID !== undefined
+              ? `${callBasis}:${call.sourceID}`
+              : `${artifact.externalID}:${turnKey}:call:${call.callWithinTurn}`;
+          let callID = canonicalCalls.get(callKey);
+          if (callID === undefined) {
+            callOrdinal++;
+            callID = Number(
+              // SAFETY: The static SQL projection and migrated schema define this row contract.
+              (this.#prepare(`
+                  INSERT INTO conversation_model_calls (
+                    conversation_id, turn_id, source_call_id, ordinal,
+                    call_within_turn, provider, model, started_at, completed_at,
+                    reported_cost, computed_cost, uncached_input_tokens,
+                    cache_read_tokens, cache_write_tokens, cache_write_5m_tokens,
+                    cache_write_1h_tokens, fresh_prompt_tokens, output_tokens,
+                    reasoning_tokens, processed_tokens, finish_reason, images,
+                    has_text, has_reasoning, reasoning_setting_name,
+                    reasoning_setting_value, reasoning_source_field_path,
+                    reasoning_source_order, reasoning_observed_at,
+                    reasoning_provenance
+                  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                  RETURNING id
+                `).get(
+                conversationID,
+                turnID,
+                call.sourceID ?? call.id,
+                callOrdinal,
+                call.callWithinTurn,
+                call.provider,
+                call.model,
+                call.startedAt,
+                call.completedAt ?? null,
+                call.reportedCost ?? null,
+                computeModelCallCost(
+                  call.tokens,
+                  call.model,
+                  call.startedAt,
+                ) ?? null,
+                ...tokenValues(call.tokens),
+                call.activity.finishReason ?? null,
+                call.activity.images ?? null,
+                Number(call.activity.hasText),
+                Number(call.activity.hasReasoning),
+                ...reasoningValues(call.reasoningSetting),
+              ) as { id: number }).id,
+            );
+            canonicalCalls.set(callKey, callID);
+            canonicalCallValues.set(callID, call);
+          }
+          callIDs.push(callID);
+
+          (call.content ?? []).forEach((content, index) => {
+            const entryID = insertEntry({
+              parentEntryID: cursor.entryID,
+              turnID,
+              stableSourceID: content.sourceID,
+              kind: "message",
+              role: content.kind === "reasoning" ? "reasoning" : "assistant",
+              occurredAt: call.completedAt ?? call.startedAt,
+              content,
+              producerModelCallID: callID,
+              outputOrdinal: index + 1,
+            });
+            cursor.entryID = entryID;
+            entryIDs.push(entryID);
+          });
+          call.activity.tools.forEach((tool, index) => {
+            const toolEventID = Number(
+              // SAFETY: The static SQL projection and migrated schema define this row contract.
+              (this.#prepare(`
+                  INSERT INTO conversation_tool_events (
+                    model_call_id, source_tool_id, ordinal, name, status,
+                    started_at, completed_at, input_preview,
+                    input_original_length, input_truncated, output_preview,
+                    output_original_length, output_truncated
+                  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                  RETURNING id
+                `).get(
+                callID,
+                tool.sourceID ?? null,
+                index + 1,
+                tool.name,
+                tool.status,
+                tool.startedAt ?? null,
+                tool.completedAt ?? null,
+                tool.input?.preview ?? tool.inputPreview ?? null,
+                tool.input?.originalLength ?? null,
+                Number(tool.input?.truncated ?? false),
+                tool.output?.preview ?? tool.outputPreview ?? null,
+                tool.output?.originalLength ?? null,
+                Number(tool.output?.truncated ?? false),
+              ) as { id: number }).id,
+            );
+            if (tool.childExternalID !== undefined) {
+              const launches = launchTools.get(tool.childExternalID) ?? [];
+              launches.push({ modelCallID: callID, toolEventID });
+              launchTools.set(tool.childExternalID, launches);
+            }
+            if (
+              tool.output !== undefined || tool.outputPreview !== undefined
+            ) {
+              const entryID = insertEntry({
+                parentEntryID: cursor.entryID,
+                turnID,
+                stableSourceID: tool.outputSourceEntryID,
+                kind: "tool-result",
+                role: "tool",
+                occurredAt: tool.completedAt,
+                content: {
+                  kind: "text",
+                  preview: tool.output?.preview ?? tool.outputPreview,
+                  originalLength: tool.output?.originalLength ??
+                    tool.outputPreview?.length,
+                  truncated: tool.output?.truncated,
+                },
+                producerToolEventID: toolEventID,
+                outputOrdinal: 1,
+              });
+              cursor.entryID = entryID;
+              entryIDs.push(entryID);
+            }
+          });
+        }
+      };
+
       for (const artifact of ordered) {
         const branchID = branchIDs.get(artifact.externalID)!;
         const parentArtifact = artifact.parentSourceIdentity === undefined
@@ -966,8 +1129,6 @@ export class ConversationWriteRepository {
               : `${unresolvedTurnKey}:${unresolvedAppearance}`;
           let canonicalTurn = canonicalTurns.get(turnKey);
           const currentEntrySources = turnEntrySources(turn);
-          const canonicalTurnImport = canonicalTurnImports.get(turnKey)?.turn ??
-            turn;
           let entryMatches: Array<{
             canonicalIndex: number;
             source: CanonicalEntrySource;
@@ -975,10 +1136,7 @@ export class ConversationWriteRepository {
 
           if (canonicalTurn === undefined) {
             turnOrdinal++;
-            canonicalTurnValues.push({
-              ...canonicalTurnImport,
-              number: turnOrdinal,
-            });
+            canonicalTurnValues.push({ ...turn, number: turnOrdinal });
             const turnID: number = Number(
               // SAFETY: The static SQL projection and migrated schema define this row contract.
               (this.#prepare(`
@@ -992,161 +1150,48 @@ export class ConversationWriteRepository {
             `).get(
                   conversationID,
                   previousTurnID,
-                  canonicalTurnImport.sourceID ?? null,
+                  turn.sourceID ?? null,
                   turnOrdinal,
-                  canonicalTurnImport.startedAt,
-                  ...reasoningValues(canonicalTurnImport.reasoningSetting),
+                  turn.startedAt,
+                  ...reasoningValues(turn.reasoningSetting),
                 ) as { id: number }).id,
             );
             const entryIDs: number[] = [];
-            for (const input of canonicalTurnImport.inputs ?? []) {
+            for (const input of turn.inputs ?? []) {
               const entryID = insertEntry({
                 parentEntryID: previousEntryID,
                 turnID,
                 stableSourceID: input.sourceID,
                 kind: "message",
                 role: "user",
-                occurredAt: canonicalTurnImport.startedAt,
+                occurredAt: turn.startedAt,
                 content: input,
               });
               previousEntryID = entryID;
               entryIDs.push(entryID);
             }
             const callIDs: number[] = [];
-            for (const call of canonicalTurnImport.calls) {
-              const callBasis: IdentityBasis = call.identityBasis ??
-                "unresolved";
-              const callKey =
-                confirmedIdentity(callBasis) && call.sourceID !== undefined
-                  ? `${callBasis}:${call.sourceID}`
-                  : `${artifact.externalID}:${turnKey}:call:${call.callWithinTurn}`;
-              let callID = canonicalCalls.get(callKey);
-              if (callID === undefined) {
-                callOrdinal++;
-                callID = Number(
-                  // SAFETY: The static SQL projection and migrated schema define this row contract.
-                  (this.#prepare(`
-                  INSERT INTO conversation_model_calls (
-                    conversation_id, turn_id, source_call_id, ordinal,
-                    call_within_turn, provider, model, started_at, completed_at,
-                    reported_cost, computed_cost, uncached_input_tokens,
-                    cache_read_tokens, cache_write_tokens, cache_write_5m_tokens,
-                    cache_write_1h_tokens, fresh_prompt_tokens, output_tokens,
-                    reasoning_tokens, processed_tokens, finish_reason, images,
-                    has_text, has_reasoning, reasoning_setting_name,
-                    reasoning_setting_value, reasoning_source_field_path,
-                    reasoning_source_order, reasoning_observed_at,
-                    reasoning_provenance
-                  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                  RETURNING id
-                `).get(
-                      conversationID,
-                      turnID,
-                      call.sourceID ?? call.id,
-                      callOrdinal,
-                      call.callWithinTurn,
-                      call.provider,
-                      call.model,
-                      call.startedAt,
-                      call.completedAt ?? null,
-                      call.reportedCost ?? null,
-                      computeModelCallCost(
-                        call.tokens,
-                        call.model,
-                        call.startedAt,
-                      ) ?? null,
-                      ...tokenValues(call.tokens),
-                      call.activity.finishReason ?? null,
-                      call.activity.images ?? null,
-                      Number(call.activity.hasText),
-                      Number(call.activity.hasReasoning),
-                      ...reasoningValues(call.reasoningSetting),
-                    ) as { id: number }).id,
-                );
-                canonicalCalls.set(callKey, callID);
-                canonicalCallValues.set(callID, call);
-              }
-              callIDs.push(callID);
-
-              (call.content ?? []).forEach((content, index) => {
-                const entryID = insertEntry({
-                  parentEntryID: previousEntryID,
-                  turnID,
-                  stableSourceID: content.sourceID,
-                  kind: "message",
-                  role: content.kind === "reasoning"
-                    ? "reasoning"
-                    : "assistant",
-                  occurredAt: call.completedAt ?? call.startedAt,
-                  content,
-                  producerModelCallID: callID,
-                  outputOrdinal: index + 1,
-                });
-                previousEntryID = entryID;
-                entryIDs.push(entryID);
-              });
-              call.activity.tools.forEach((tool, index) => {
-                const toolEventID = Number(
-                  // SAFETY: The static SQL projection and migrated schema define this row contract.
-                  (this.#prepare(`
-                  INSERT INTO conversation_tool_events (
-                    model_call_id, source_tool_id, ordinal, name, status,
-                    started_at, completed_at, input_preview,
-                    input_original_length, input_truncated, output_preview,
-                    output_original_length, output_truncated
-                  ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-                  RETURNING id
-                `).get(
-                      callID,
-                      tool.sourceID ?? null,
-                      index + 1,
-                      tool.name,
-                      tool.status,
-                      tool.startedAt ?? null,
-                      tool.completedAt ?? null,
-                      tool.input?.preview ?? tool.inputPreview ?? null,
-                      tool.input?.originalLength ?? null,
-                      Number(tool.input?.truncated ?? false),
-                      tool.output?.preview ?? tool.outputPreview ?? null,
-                      tool.output?.originalLength ?? null,
-                      Number(tool.output?.truncated ?? false),
-                    ) as { id: number }).id,
-                );
-                if (tool.childExternalID !== undefined) {
-                  const launches = launchTools.get(tool.childExternalID) ?? [];
-                  launches.push({ modelCallID: callID, toolEventID });
-                  launchTools.set(tool.childExternalID, launches);
-                }
-                if (
-                  tool.output !== undefined || tool.outputPreview !== undefined
-                ) {
-                  const entryID = insertEntry({
-                    parentEntryID: previousEntryID,
-                    turnID,
-                    stableSourceID: tool.outputSourceEntryID,
-                    kind: "tool-result",
-                    role: "tool",
-                    occurredAt: tool.completedAt,
-                    content: {
-                      kind: "text",
-                      preview: tool.output?.preview ?? tool.outputPreview,
-                      originalLength: tool.output?.originalLength ??
-                        tool.outputPreview?.length,
-                      truncated: tool.output?.truncated,
-                    },
-                    producerToolEventID: toolEventID,
-                    outputOrdinal: 1,
-                  });
-                  previousEntryID = entryID;
-                  entryIDs.push(entryID);
-                }
-              });
-            }
+            const cursor: { entryID: number | null } = {
+              entryID: previousEntryID,
+            };
+            appendTurnCalls(
+              artifact,
+              turnKey,
+              turnID,
+              turn.calls,
+              entryIDs,
+              callIDs,
+              cursor,
+            );
+            previousEntryID = cursor.entryID;
             canonicalTurn = {
               id: turnID,
               parentID: previousTurnID,
+              owner: artifact,
+              payload: turn,
+              valueIndex: canonicalTurnValues.length - 1,
               entryIDs,
-              entrySources: turnEntrySources(canonicalTurnImport),
+              entrySources: currentEntrySources,
               callIDs,
               lastEntryID: previousEntryID,
             };
@@ -1158,9 +1203,6 @@ export class ConversationWriteRepository {
               canonicalIndex,
               source,
             }));
-            previousEntryID = entryMatches.at(-1) === undefined
-              ? canonicalTurn.lastEntryID
-              : canonicalTurn.entryIDs[entryMatches.at(-1)!.canonicalIndex];
           } else {
             const currentCanonicalTurn = canonicalTurn;
             if (currentCanonicalTurn.parentID !== previousTurnID) {
@@ -1169,6 +1211,38 @@ export class ConversationWriteRepository {
                   turn.sourceID ?? turnKey
                 }`,
               );
+            }
+            if (
+              compareTurnObservation(currentCanonicalTurn.payload, turn) ===
+                "current-is-extension" &&
+              isSourceDescendant(
+                artifact,
+                currentCanonicalTurn.owner,
+                byIdentity,
+              )
+            ) {
+              // Append descendant-only calls; do not rewrite overlapping calls.
+              const cursor: { entryID: number | null } = {
+                entryID: currentCanonicalTurn.lastEntryID,
+              };
+              appendTurnCalls(
+                artifact,
+                turnKey,
+                currentCanonicalTurn.id,
+                turn.calls.slice(currentCanonicalTurn.payload.calls.length),
+                currentCanonicalTurn.entryIDs,
+                currentCanonicalTurn.callIDs,
+                cursor,
+              );
+              currentCanonicalTurn.lastEntryID = cursor.entryID;
+              currentCanonicalTurn.payload = turn;
+              currentCanonicalTurn.owner = artifact;
+              currentCanonicalTurn.entrySources = turnEntrySources(turn);
+              canonicalTurnValues[currentCanonicalTurn.valueIndex] = {
+                ...turn,
+                number:
+                  canonicalTurnValues[currentCanonicalTurn.valueIndex].number,
+              };
             }
             const unmatchedCanonicalEntries = new Set(
               currentCanonicalTurn.entrySources.map((_, index) => index),


### PR DESCRIPTION
## What broke

When Claude backgrounds an active conversation mid-turn, it creates a new transcript with a copied history and then continues that same turn. The copied turn keeps its stable UUID.

Frugal Tokens treated the shorter parent copy as the final version of that turn. When it reached the child-only continuation, it rejected the conversation family as a conflicting entry shape.

## Fix

If a descendant adds whole new model calls to a copied in-progress turn, append those calls while walking the descendant. Overlapping calls must match persisted metadata and stored entries; the ancestor's overlapping call rows stay canonical. Extra content or tool results on an existing call still conflict. Copied entries that keep a stable ID must also keep the same content signature. Each artifact keeps its own branch head, and continuation entries are attributed on the descendant that observed them.

## Impact

Backgrounded mid-turn Claude sessions that continue with additional model calls import successfully. Same-call growth is still rejected. Normal resumes and forks between completed turns are unchanged. Rewriting copied content under the same IDs still fails rather than silently merging.

## Test plan

- Copied turn continued with a new descendant call imports as one turn, with parent/child branch heads and continuation entry attribution.
- Extra content on a copied call is rejected.
- Same call and entry IDs with changed content are rejected.