### PR TITLE
Highlight spend dates from session scatter

### DIFF
--- a/src/client/NewPage.tsx
+++ b/src/client/NewPage.tsx
@@ -137,6 +137,7 @@ export function NewPage() {
     harness: string;
     data: TtlMissMetrics;
   }>();
+  const [highlightedSpendDates, setHighlightedSpendDates] = useState<string[]>();
   const screenshotRef = useRef<HTMLDivElement>(null);
   const pendingScrollYRef = useRef<number | undefined>(undefined);
   const refreshScrollYRef = useRef<number | undefined>(
@@ -408,7 +409,10 @@ export function NewPage() {
                   />
                 }
               >
-                <SpendComposition data={data.spendComposition} />
+                <SpendComposition
+                  data={data.spendComposition}
+                  highlightedDates={highlightedSpendDates}
+                />
               </Suspense>
             )
             : (
@@ -446,6 +450,7 @@ export function NewPage() {
                 >
                   <SessionDiagnostics
                     data={workRhythmData.sessionDiagnostics}
+                    onHighlightDates={setHighlightedSpendDates}
                   />
                 </Suspense>
               )

--- a/src/client/new/SessionDiagnostics.tsx
+++ b/src/client/new/SessionDiagnostics.tsx
@@ -129,7 +129,11 @@ function SessionDot({
   cy,
   payload,
   onOpen,
-}: SessionDotGeometryProps & { onOpen: (session: ChartPoint) => void }) {
+  onHoverChange,
+}: SessionDotGeometryProps & {
+  onOpen: (session: ChartPoint) => void;
+  onHoverChange: (session: ChartPoint, hovering: boolean) => void;
+}) {
   if (cx === undefined || cy === undefined || !payload) return <g />;
   const canOpen = payload.harness !== undefined;
   const open = () => {
@@ -144,6 +148,10 @@ function SessionDot({
       tabIndex={canOpen ? 0 : undefined}
       aria-label={canOpen ? `Open ${payload.title}` : undefined}
       onClick={open}
+      onMouseEnter={() => onHoverChange(payload, true)}
+      onMouseLeave={() => onHoverChange(payload, false)}
+      onFocus={() => onHoverChange(payload, true)}
+      onBlur={() => onHoverChange(payload, false)}
       onKeyDown={(event) => {
         if (event.key === "Enter" || event.key === " ") {
           event.preventDefault();
@@ -183,7 +191,13 @@ function SessionDot({
   );
 }
 
-export function SessionDiagnostics({ data }: { data: SessionDiagnosticsData }) {
+export function SessionDiagnostics({
+  data,
+  onHighlightDates,
+}: {
+  data: SessionDiagnosticsData;
+  onHighlightDates?: (dates: string[] | undefined) => void;
+}) {
   const navigate = useNavigate();
   const [metric, setMetric] = useState<Metric>("spend");
   const sessions = data.sessions;
@@ -217,6 +231,10 @@ export function SessionDiagnostics({ data }: { data: SessionDiagnosticsData }) {
   });
   const metricLabel = metric === "spend" ? "Spend" : "Processed input";
 
+  function setHover(session: ChartPoint, hovering: boolean) {
+    onHighlightDates?.(hovering ? session.dates : undefined);
+  }
+
   function openSession(session: ChartPoint) {
     if (!session.harness) return;
     saveOverviewReturnScroll();
@@ -235,7 +253,11 @@ export function SessionDiagnostics({ data }: { data: SessionDiagnosticsData }) {
 
   const scatterDotProps = {
     "shape": (geometry: SessionDotGeometryProps) => (
-      <SessionDot {...geometry} onOpen={openSession} />
+      <SessionDot
+        {...geometry}
+        onOpen={openSession}
+        onHoverChange={setHover}
+      />
     ),
   };
 

--- a/src/client/new/SpendComposition.tsx
+++ b/src/client/new/SpendComposition.tsx
@@ -3,6 +3,8 @@ import {
   Bar,
   CartesianGrid,
   ComposedChart,
+  ReferenceArea,
+  ReferenceLine,
   ResponsiveContainer,
   Tooltip,
   XAxis,
@@ -22,8 +24,10 @@ import "./SpendComposition.css";
 type Metric = "spend" | "tokens";
 type CompositionDay = SpendCompositionData["days"][number];
 type ChartRow = {
+  index: number;
   date: string;
   source: CompositionDay;
+  total: number;
   [key: string]: string | number | CompositionDay;
 };
 
@@ -238,9 +242,10 @@ function CompositionTooltip({ active, payload, data, metric }: {
 }
 
 function CompositionChart(
-  { data, metric }: {
+  { data, metric, highlightedDates }: {
     data: SpendCompositionData;
     metric: Metric;
+    highlightedDates?: string[];
   },
 ) {
   const series = useMemo(() => [
@@ -254,7 +259,7 @@ function CompositionChart(
       : []),
   ], [data]);
   const rows = useMemo(() =>
-    data.days.map((day) => {
+    data.days.map((day, index) => {
       const values: Record<string, number> = {};
       data.models.forEach((model, index) => {
         const value = day.models.find((item) => item.model === model.model);
@@ -267,8 +272,14 @@ function CompositionChart(
           ? day.otherSpend
           : day.otherProcessedInput;
       }
-      return { date: day.date, source: day, ...values };
+      const total = Object.values(values).reduce((sum, value) => sum + value, 0);
+      return { index, date: day.date, source: day, total, ...values };
     }), [data, metric]);
+  const highlightedRows = (highlightedDates ?? [])
+    .flatMap((date) => rows.find((row) => row.date === date) ?? [])
+    .toSorted((a, b) => a.index - b.index);
+  const maxTotal = Math.max(0, ...rows.map((row) => row.total));
+  const highlightCeiling = maxTotal === 0 ? 1 : maxTotal * 1.06;
 
   return (
     <div
@@ -292,9 +303,14 @@ function CompositionChart(
             strokeDasharray="3 5"
           />
           <XAxis
-            dataKey="date"
+            dataKey="index"
+            type="number"
+            domain={[-0.5, Math.max(0.5, rows.length - 0.5)]}
+            ticks={rows.map((row) => row.index)}
             tickFormatter={(value) =>
-              shortDate.format(parseDate(String(value)))}
+              shortDate.format(
+                parseDate(rows[Math.round(Number(value))]?.date ?? ""),
+              )}
             minTickGap={42}
             axisLine={false}
             tickLine={false}
@@ -307,6 +323,7 @@ function CompositionChart(
           <YAxis
             yAxisId="volume"
             width={48}
+            domain={[0, () => highlightCeiling]}
             tickFormatter={(value) =>
               metric === "spend"
                 ? `$${compact.format(Number(value))}`
@@ -344,13 +361,42 @@ function CompositionChart(
               isAnimationActive={false}
             />
           ))}
+          {highlightedRows.length > 0 && (
+            <ReferenceArea
+              yAxisId="volume"
+              x1={highlightedRows[0].index - 0.5}
+              x2={highlightedRows[highlightedRows.length - 1].index + 0.5}
+              y1={0}
+              y2={highlightCeiling}
+              fill="#0f7169"
+              fillOpacity={0.08}
+              stroke="none"
+              ifOverflow="visible"
+            />
+          )}
+          {highlightedRows.map((row) => (
+            <ReferenceLine
+              key={row.date}
+              yAxisId="volume"
+              segment={[
+                { x: row.index, y: highlightCeiling },
+                { x: row.index, y: row.total },
+              ]}
+              stroke="#0f7169"
+              strokeDasharray="4 4"
+              ifOverflow="visible"
+            />
+          ))}
         </ComposedChart>
       </ResponsiveContainer>
     </div>
   );
 }
 
-export function SpendComposition({ data }: { data: SpendCompositionData }) {
+export function SpendComposition({ data, highlightedDates }: {
+  data: SpendCompositionData;
+  highlightedDates?: string[];
+}) {
   const [metric, setMetric] = useState<Metric>("spend");
   const empty = data.models.length === 0;
 
@@ -404,7 +450,11 @@ export function SpendComposition({ data }: { data: SpendCompositionData }) {
               </div>
             </header>
             <div className="composition-trend">
-              <CompositionChart data={data} metric={metric} />
+              <CompositionChart
+                data={data}
+                metric={metric}
+                highlightedDates={highlightedDates}
+              />
             </div>
           </div>
         )}

--- a/src/server/activityOverview.test.ts
+++ b/src/server/activityOverview.test.ts
@@ -85,6 +85,7 @@ Deno.test("activity overview returns period totals and daily drill-down data", (
   strictEqual(result.summary.topDecileSpendShare, 5 / 9);
   deepStrictEqual(workRhythm.sessionDiagnostics.sessions, [{
     id: "2",
+    dates: ["2026-07-02"],
     title: "Session 2",
     primaryModel: null,
     estimatedActiveMinutes: 0,
@@ -96,6 +97,7 @@ Deno.test("activity overview returns period totals and daily drill-down data", (
     userTurns: 1,
   }, {
     id: "1",
+    dates: ["2026-07-01", "2026-07-02"],
     title: "Session 1",
     primaryModel: null,
     estimatedActiveMinutes: 0,

--- a/src/server/activityOverview.ts
+++ b/src/server/activityOverview.ts
@@ -226,6 +226,7 @@ function sessionDiagnostics(
     const session:
       WorkRhythmOverviewResponse["sessionDiagnostics"]["sessions"][number] = {
         id: root.sessionID ?? String(root.rootSessionID),
+        dates: days.map((day) => day.date),
         title: root.title ?? `Session ${root.rootSessionID}`,
         primaryModel,
         estimatedActiveMinutes: intervals.reduce(

--- a/src/shared/sessionSchemas.ts
+++ b/src/shared/sessionSchemas.ts
@@ -576,6 +576,7 @@ export const spendCompositionSchema = z.object({
 export const sessionDiagnosticsSchema = z.object({
   sessions: z.array(z.object({
     id: z.string(),
+    dates: z.array(z.string()).min(1),
     title: z.string(),
     harness: harnessSchema.optional(),
     primaryModel: z.string().nullable(),


### PR DESCRIPTION
- Context: Unique sessions are referenced multiple times in different charts (scatterplot, rhythm, recent sessions, etc) but do not have any indication that a given session in one place is the same session on one of the others. 

- Changes: Added session activity dates to diagnostics data and passed scatter hover dates into the spend composition chart.

- Outcome: Hovering a scatter point marks the matching spend-chart day or date range while leaving table and timeline views unchanged.